### PR TITLE
[ADD] stock_traceability_internal: mandatory prodlot on internal moves

### DIFF
--- a/stock_traceability_internal/__init__.py
+++ b/stock_traceability_internal/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from . import product
+from . import stock

--- a/stock_traceability_internal/__openerp__.py
+++ b/stock_traceability_internal/__openerp__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+{
+    "name": "Enforce internal traceability",
+    "version": "1.0",
+    "depends": ["stock"],
+    "author": u"Numérigraphe",
+    "category": "Warehouse Management",
+    "description": """
+Enforce Serial Number traceability in Internal Moves
+====================================================
+This module makes adds a checkbox on the product form to indicate that internal
+traceability is required for the produce.
+When the box is check, the Serial Number will be mandatory for all Internal
+Moves.""",
+    "data": [
+        "product_view.xml",
+    ],
+}

--- a/stock_traceability_internal/i18n/fr.po
+++ b/stock_traceability_internal/i18n/fr.po
@@ -1,0 +1,32 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* stock_traceability_internal
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-07 12:57+0000\n"
+"PO-Revision-Date: 2014-08-07 12:57+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stocktraceability_internal
+#: field:product.product,track_internal:0
+msgid "Track Lots internally"
+msgstr "Suivre les lots en interne"
+
+#. module: stock_traceability_internal
+#: help:product.product,track_internal:0
+msgid "Forces to specify a Serial Number for all internal moves containing this product."
+msgstr "Oblige à indiquer un numéro de série pour tous les mouvements internes contenant cet article."
+
+#. module: stock_traceability_internal
+#: constraint:stock.move:0
+msgid "You must assign a serial number for this product."
+msgstr "Vous devez attribuer un numéro de série à cet article."
+

--- a/stock_traceability_internal/i18n/stock_traceability_internal.pot
+++ b/stock_traceability_internal/i18n/stock_traceability_internal.pot
@@ -1,0 +1,32 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* stock_traceability_internal
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-07 12:57+0000\n"
+"PO-Revision-Date: 2014-08-07 12:57+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stocktraceability_internal
+#: field:product.product,track_outgoing:0
+msgid "Track Lots internally"
+msgstr ""
+
+#. module: stock_traceability_internal
+#: help:product.product,track_outgoing:0
+msgid "Forces to specify a Serial Number for all internal moves containing this product."
+msgstr ""
+
+#. module: stock_traceability_internal
+#: constraint:stock.move:0
+msgid "You must assign a serial number for this product."
+msgstr ""
+

--- a/stock_traceability_internal/product.py
+++ b/stock_traceability_internal/product.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    This module is copyright (C) 2013 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from openerp.osv import orm, fields
+
+
+class ProductProduct(orm.Model):
+    _inherit = 'product.product'
+
+    _columns = {
+        'track_internal': fields.boolean(
+            'Track Lots internally',
+            help="Forces to specify a Serial Number for all internal moves "
+                 "containing this product."),
+    }

--- a/stock_traceability_internal/product_view.xml
+++ b/stock_traceability_internal/product_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_product_track_internal"
+            model="ir.ui.view">
+            <field name="name">Track lots on internal moves</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="stock.view_normal_procurement_locations_form"/>
+            <field name="arch" type="xml">
+                <group name="lot" position="inside">
+                    <field name="track_internal"/>
+                </group>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/stock_traceability_internal/stock.py
+++ b/stock_traceability_internal/stock.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    This module is copyright (C) 2013 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from openerp.osv import orm
+
+
+class StockMove(orm.Model):
+    _inherit = 'stock.move'
+
+    def _check_internal_tracking(self, cr, uid, ids, context=None):
+        """Checks if production lot is assigned to stock move or not.
+        @return: True or False
+        """
+        for move in self.browse(cr, uid, ids, context=context):
+            if (not move.prodlot_id
+                    and move.state == 'done'
+                    and move.product_id.track_internal
+                    and (
+                        move.location_id.usage == 'internal'
+                        or move.location_dest_id.usage == 'internal')
+                    # We still let users correct wrong moves with inventories
+                    and move.location_id.usage != 'inventory'
+                    and move.location_dest_id.usage != 'inventory'
+                    # We don't block pseudo-moves
+                    and move.product_qty != 0.0):
+                return False
+        return True
+
+    _constraints = [
+        (_check_internal_tracking,
+            'You must assign a serial number for this product.',
+            ['prodlot_id']),
+    ]


### PR DESCRIPTION
Fixes #5 by giving a basic implementation
