### PR TITLE
[IMP] from a wave, a dispatch can be directly assigned

### DIFF
--- a/picking_dispatch_wave/__openerp__.py
+++ b/picking_dispatch_wave/__openerp__.py
@@ -23,7 +23,7 @@
 {
     "name": "Picking Dispatch Wave",
     "version": "0.1",
-    "depends": ['picking_dispatch', 'sale_stock'],
+    "depends": ['picking_dispatch'],
     "author": "Camptocamp",
     'license': 'AGPL-3',
     "description": """Allows to set a picking dispatch

--- a/picking_dispatch_wave/dispatch_wave.py
+++ b/picking_dispatch_wave/dispatch_wave.py
@@ -101,6 +101,9 @@ class StockPickingDispatchWave(orm.TransientModel):
                 self.pool['stock.move'].write(cr, uid, move_ids,
                                               {'dispatch_id': dispatch_id},
                                               context=context)
+                # picking dispatch can be directly assigned
+                dispatch_obj.action_assign(cr, uid, [dispatch_id],
+                                           context=context)
                 context['active_id'] = dispatch_id
                 return {
                     'domain': str([('id', '=', dispatch_id)]),

--- a/picking_dispatch_wave/test/test_dispatch_wave.yml
+++ b/picking_dispatch_wave/test/test_dispatch_wave.yml
@@ -2,32 +2,18 @@
   In order to test stock picking wave
   I have to ensure when a picking dispatch wave is set, a picking dispatch is well created.
 -
-  I create a product
+  I create a picking OUT
 -
-  !record {model: product.product, id: prod_wave}:
-    name: product_wave
-    procure_method: make_to_stock
-    supply_method: buy
--
-  I create a SO
--
-  !record {model: sale.order, id: so_wave}:
+  !record {model: stock.picking.out, id: picking_wave}:
     partner_id: base.res_partner_2
-    order_policy: 'manual'
-    picking_policy: 'direct'
-    order_line:
-      - product_id: prod_wave
-        product_uom_qty: 3
+    move_lines:
+      - product_id: product.product_product_24
+        product_qty: 3
 -
-  Then I confirm the order
--
-  !workflow {model: sale.order, action: order_confirm, ref: so_wave}
--
-  Then (for test needs) I force the picking as ready to deliver
+  Then I confirm the picking
 -
   !python {model: stock.picking}: |
-    picking = self.search(cr, uid, [('sale_id', '=', ref("so_wave"))])
-    self.force_assign(cr, uid, picking)
+    self.action_assign(cr, uid, [ref("picking_wave")])
 -
   Then I ask a picking dispatch wave with 1 unit.
 -

--- a/picking_dispatch_wave/test/test_dispatch_wave.yml
+++ b/picking_dispatch_wave/test/test_dispatch_wave.yml
@@ -40,8 +40,8 @@
   !python {model: stock.picking.dispatch.wave}:
     self.action_create_picking_dispatch(cr, uid, [ref("wiz_wave")], context=context)
 -
-  Then I check if the picking dispatch is created
+  Then I check if the picking dispatch is assigned to the right picker
 -
   !python {model: picking.dispatch}: |
-    dispatchs = self.search(cr, uid, [('state','=','draft'),('picker_id','=',ref("base.user_demo"))])
-    assert len(dispatchs) == 1, "The dispatch is ready"
+    dispatchs = self.search(cr, uid, [('state','=','assigned'),('picker_id','=',ref("base.user_demo"))])
+    assert len(dispatchs) == 1, "The dispatch is assigned to the right picker"


### PR DESCRIPTION
When the user asks a wave of x pickings in the wizard, it assigns the wave to himself or another user (then the action to assign the wave to someone is already done), then we can directly consider the dispatch as assigned.
