### PR TITLE
Corrections on stock_picking_update_date:

### DIFF
--- a/stock_picking_update_date/model/stock_picking.py
+++ b/stock_picking_update_date/model/stock_picking.py
@@ -81,7 +81,7 @@ class StockPicking(orm.Model):
             "this field will update all the lines in the picking.",
             store={
                 'stock.move': (
-                    _move_trigger, ['date_expected'], 10
+                    _move_trigger, ['date_expected'], 40
                 )
             }),
     }
@@ -115,7 +115,7 @@ class StockPickingIn(orm.Model):
             help="Scheduled time for the shipment to be processed",
             store={
                 'stock.move': (
-                    _move_trigger, ['date_expected'], 10
+                    _move_trigger, ['date_expected'], 40
                 )
             }),
     }
@@ -145,7 +145,7 @@ class StockPickingOut(orm.Model):
             help="Scheduled time for the shipment to be processed",
             store={
                 'stock.move': (
-                    _move_trigger, ['date_expected'], 10
+                    _move_trigger, ['date_expected'], 40
                 )
             }),
     }

--- a/stock_picking_update_date/test/test_picking_in.yml
+++ b/stock_picking_update_date/test/test_picking_in.yml
@@ -35,3 +35,8 @@
 -
   !assert {model: stock.move, id: picking_2_line_2}:
     - date_expected == '2013-10-07 00:00:00'
+-
+  I check that the expected date of the picking has changed
+-
+  !assert {model: stock.picking.in, id: picking_2}:
+    - date_expected == '2013-10-07 00:00:00'

--- a/stock_picking_update_date/test/test_picking_internal.yml
+++ b/stock_picking_update_date/test/test_picking_internal.yml
@@ -35,3 +35,8 @@
 -
   !assert {model: stock.move, id: picking_1_line_2}:
     - date_expected == '2013-10-07 00:00:00'
+-
+  I check that the expected date of the picking has changed
+-
+  !assert {model: stock.picking, id: picking_1}:
+    - date_expected == '2013-10-07 00:00:00'

--- a/stock_picking_update_date/test/test_picking_out.yml
+++ b/stock_picking_update_date/test/test_picking_out.yml
@@ -35,3 +35,8 @@
 -
   !assert {model: stock.move, id: picking_3_line_2}:
     - date_expected == '2013-10-07 00:00:00'
+-
+  I check that the expected date of the picking has changed
+-
+  !assert {model: stock.picking.out, id: picking_3}:
+    - date_expected == '2013-10-07 00:00:00'

--- a/stock_picking_update_date/view/picking.xml
+++ b/stock_picking_update_date/view/picking.xml
@@ -14,7 +14,7 @@
 
     <record model="ir.ui.view" id="picking_in_form">
       <field name="inherit_id" ref="stock.view_picking_in_form"/>
-      <field name="model">stock.picking</field>
+      <field name="model">stock.picking.in</field>
       <field name="arch" type="xml">
         <field name="min_date" position="replace">
           <field name="date_expected"/>
@@ -24,7 +24,7 @@
 
     <record model="ir.ui.view" id="picking_out_form">
       <field name="inherit_id" ref="stock.view_picking_out_form"/>
-      <field name="model">stock.picking</field>
+      <field name="model">stock.picking.out</field>
       <field name="arch" type="xml">
         <field name="min_date" position="replace">
           <field name="date_expected"/>


### PR DESCRIPTION
- The views were not loaded because the declared models were not using the
  out/in suffixes
- The date_expected field was updated to the last min_date value instead
  of the new one due to the ordering of the function fields
