### PR TITLE
Add multi-company rule for picking dispatches

### DIFF
--- a/picking_dispatch/__openerp__.py
+++ b/picking_dispatch/__openerp__.py
@@ -39,6 +39,7 @@
                 'wizard/dispatch_assign_picker_view.xml',
                 'report.xml',
                 'security/ir.model.access.csv',
+                'security/security.xml',
                 # 'picking_dispatch_workflow.xml',
                 ],
  'demo_xml': [],

--- a/picking_dispatch/__openerp__.py
+++ b/picking_dispatch/__openerp__.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 {'name': 'Picking dispatch',
- 'version': '1.2.2',
+ 'version': '1.2.3',
  'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
  'category': 'Products',

--- a/picking_dispatch/picking_dispatch.py
+++ b/picking_dispatch/picking_dispatch.py
@@ -98,13 +98,22 @@ class PickingDispatch(Model):
         'related_picking_ids': fields.function(
             _get_related_picking, method=True, type='one2many',
             relation='stock.picking', string='Related Dispatch Picking'),
+        'company_id': fields.many2one('res.company', 'Company',
+                                      required=True),
     }
+
+    def _default_company(self, cr, uid, context=None):
+        company_obj = self.pool.get('res.company')
+        return company_obj._company_default_get(cr, uid,
+                                                'picking.dispatch',
+                                                context=context)
 
     _defaults = {
         'name': lambda obj, cr, uid, ctxt: obj.pool.get('ir.sequence').get(
             cr, uid, 'picking.dispatch'),
         'date': fields.date.context_today,
-        'state': 'draft'
+        'state': 'draft',
+        'company_id': _default_company,
     }
 
     def _check_picker_assigned(self, cr, uid, ids, context=None):

--- a/picking_dispatch/security/security.xml
+++ b/picking_dispatch/security/security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <record model="ir.rule" id="picking_dispatch_rule">
+            <field name="name">picking_dispatch multi-company</field>
+            <field name="model_id" ref="model_picking_dispatch"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Since stock pickings possess multi-company rules, and are displayed in dispatches, you can get access errors if dispatches not in the user's company are displayed.
