### PR TITLE
[IMP] select only moves with internal source location (avoid to select dropshipping moves)

### DIFF
--- a/picking_dispatch_wave/dispatch_wave.py
+++ b/picking_dispatch_wave/dispatch_wave.py
@@ -36,7 +36,8 @@ class StockPickingDispatchWave(orm.TransientModel):
         move_ids = move_obj.search(cr, uid,
                                    [('dispatch_id', '=', False),
                                     ('state', '=', 'assigned'),
-                                    ('type', '=', 'out')],
+                                    ('type', '=', 'out'),
+                                    ('location_id.usage', '=', 'internal')],
                                    order='date_expected DESC',
                                    context=context)
         for move in move_obj.browse(cr, uid, move_ids, context=context):


### PR DESCRIPTION
It makes sense to grab only moves coming from an internal source location, for example it avoids to select dropshipping moves.
