### PR TITLE
Add new module stock_transfer_split_multi

### DIFF
--- a/stock_transfer_split_multi/README.rst
+++ b/stock_transfer_split_multi/README.rst
@@ -1,0 +1,10 @@
+Stock Transfer Split Multi
+==========================
+
+This module adds a button *Split multiple units* on the lines of the
+Transfer wizard of the pickings next to the native *Split* button. When
+you click on this button, it will ask you to enter the quantity
+to extract from this line and it will create a new line.
+
+This module has been written by Alexis de Lattre from Akretion
+<alexis.delattre@akretion.com>.

--- a/stock_transfer_split_multi/README.rst
+++ b/stock_transfer_split_multi/README.rst
@@ -1,10 +1,31 @@
 Stock Transfer Split Multi
 ==========================
 
+Usage
+=====
+
 This module adds a button *Split multiple units* on the lines of the
 Transfer wizard of the pickings next to the native *Split* button. When
 you click on this button, it will ask you to enter the quantity
 to extract from this line and it will create a new line.
 
-This module has been written by Alexis de Lattre from Akretion
-<alexis.delattre@akretion.com>.
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/stock_transfer_split_multi/__init__.py
+++ b/stock_transfer_split_multi/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Transfer Split Multi module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import wizard

--- a/stock_transfer_split_multi/__openerp__.py
+++ b/stock_transfer_split_multi/__openerp__.py
@@ -1,0 +1,46 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Transfer Split Multi module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com).
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Stock Transfer Split Multi',
+    'version': '1.0',
+    'category': 'Warehouse Management',
+    'license': 'AGPL-3',
+    'summary': "In the stock transfer wizard, you can split by multiple units",
+    'description': """
+This module adds a button *Split multiple units* on the lines of the
+Transfer wizard of the pickings next to the native *Split* button. When
+you click on this button, it will ask you to enter the quantity
+to extract from this line and it will create a new line.
+
+This module has been written by Alexis de Lattre from Akretion
+<alexis.delattre@akretion.com>.
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['stock'],
+    'data': [
+        'wizard/stock_transfer_split_multi.xml',
+        'wizard/stock_transfer_details.xml',
+        ],
+    'installable': True,
+}

--- a/stock_transfer_split_multi/__openerp__.py
+++ b/stock_transfer_split_multi/__openerp__.py
@@ -26,15 +26,6 @@
     'category': 'Warehouse Management',
     'license': 'AGPL-3',
     'summary': "In the stock transfer wizard, you can split by multiple units",
-    'description': """
-This module adds a button *Split multiple units* on the lines of the
-Transfer wizard of the pickings next to the native *Split* button. When
-you click on this button, it will ask you to enter the quantity
-to extract from this line and it will create a new line.
-
-This module has been written by Alexis de Lattre from Akretion
-<alexis.delattre@akretion.com>.
-    """,
     'author': 'Akretion',
     'website': 'http://www.akretion.com',
     'depends': ['stock'],

--- a/stock_transfer_split_multi/i18n/fr.po
+++ b/stock_transfer_split_multi/i18n/fr.po
@@ -1,0 +1,78 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_transfer_split_multi
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-01-07 20:32+0000\n"
+"PO-Revision-Date: 2015-01-07 20:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_transfer_split_multi
+#: view:stock.transfer.split.multi:stock_transfer_split_multi.stock_transfer_split_multi_form
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,create_uid:0
+msgid "Created by"
+msgstr "Created by"
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,create_date:0
+msgid "Created on"
+msgstr "Created on"
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,write_uid:0
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,write_date:0
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,split_qty:0
+msgid "Quantity to Extract"
+msgstr "Quantité à extraire"
+
+#. module: stock_transfer_split_multi
+#: model:ir.actions.act_window,name:stock_transfer_split_multi.stock_transfer_split_multi_action
+msgid "Split Configurable Quantity"
+msgstr "Split Configurable Quantity"
+
+#. module: stock_transfer_split_multi
+#: view:stock.transfer.split.multi:stock_transfer_split_multi.stock_transfer_split_multi_form
+msgid "Split Line"
+msgstr "Scinder la ligne"
+
+#. module: stock_transfer_split_multi
+#: view:stock.transfer_details:stock_transfer_split_multi.view_stock_enter_transfer_details
+msgid "Split Multi"
+msgstr "Scinder en quantité configurable"
+
+#. module: stock_transfer_split_multi
+#: model:ir.model,name:stock_transfer_split_multi.model_stock_transfer_split_multi
+msgid "Split by multi units on stock transfer wizard"
+msgstr "Split by multi units on stock transfer wizard"
+
+#. module: stock_transfer_split_multi
+#: code:addons/stock_transfer_split_multi/wizard/stock_transfer_split_multi.py:47
+#, python-format
+msgid "The Quantity to extract (%s) cannot be superior or equal to the quantity of the line (%s)"
+msgstr "La quantité à extraire (%s) ne peut pas être supérieure ou égale à la quantité de la ligne (%s)"
+

--- a/stock_transfer_split_multi/i18n/stock_transfer_split_multi.pot
+++ b/stock_transfer_split_multi/i18n/stock_transfer_split_multi.pot
@@ -1,0 +1,78 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_transfer_split_multi
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-01-07 20:32+0000\n"
+"PO-Revision-Date: 2015-01-07 20:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_transfer_split_multi
+#: view:stock.transfer.split.multi:stock_transfer_split_multi.stock_transfer_split_multi_form
+msgid "Cancel"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,id:0
+msgid "ID"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: field:stock.transfer.split.multi,split_qty:0
+msgid "Quantity to Extract"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: model:ir.actions.act_window,name:stock_transfer_split_multi.stock_transfer_split_multi_action
+msgid "Split Configurable Quantity"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: view:stock.transfer.split.multi:stock_transfer_split_multi.stock_transfer_split_multi_form
+msgid "Split Line"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: view:stock.transfer_details:stock_transfer_split_multi.view_stock_enter_transfer_details
+msgid "Split Multi"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: model:ir.model,name:stock_transfer_split_multi.model_stock_transfer_split_multi
+msgid "Split by multi units on stock transfer wizard"
+msgstr ""
+
+#. module: stock_transfer_split_multi
+#: code:addons/stock_transfer_split_multi/wizard/stock_transfer_split_multi.py:47
+#, python-format
+msgid "The Quantity to extract (%s) cannot be superior or equal to the quantity of the line (%s)"
+msgstr ""
+

--- a/stock_transfer_split_multi/wizard/__init__.py
+++ b/stock_transfer_split_multi/wizard/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Transfer Split Multi module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import stock_transfer_split_multi

--- a/stock_transfer_split_multi/wizard/stock_transfer_details.xml
+++ b/stock_transfer_split_multi/wizard/stock_transfer_details.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data>
+
+
+<record id="view_stock_enter_transfer_details" model="ir.ui.view">
+    <field name="name">stock_transfer_split_multi.split_multi</field>
+    <field name="model">stock.transfer_details</field>
+    <field name="inherit_id" ref="stock.view_stock_enter_transfer_details" />
+    <field name="arch" type="xml">
+        <button name="split_quantities" type="object" position="after">
+            <button name="%(stock_transfer_split_multi_action)d" type="action"
+                string="Split Multi" icon="STOCK_CUT"/>
+        </button>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/stock_transfer_split_multi/wizard/stock_transfer_split_multi.py
+++ b/stock_transfer_split_multi/wizard/stock_transfer_split_multi.py
@@ -1,0 +1,54 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Transfer Split Multi module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api, _
+import openerp.addons.decimal_precision as dp
+from openerp.exceptions import Warning
+
+
+class StockTransferSplitMulti(models.TransientModel):
+    _name = "stock.transfer.split.multi"
+    _description = "Split by multi units on stock transfer wizard"
+
+    split_qty = fields.Float(
+        string="Quantity to Extract",
+        digits=dp.get_precision('Product Unit of Measure'), required=True)
+
+    @api.multi
+    def split_multi_quantities(self):
+        self.ensure_one()
+        assert self.env.context.get('active_model') == \
+            'stock.transfer_details_items', 'Wrong underlying model'
+        trf_line = self.env['stock.transfer_details_items'].browse(
+            self.env.context['active_id'])
+        split_qty = self[0].split_qty
+        if split_qty > 0:
+            if split_qty >= trf_line.quantity:
+                raise Warning(
+                    _("The Quantity to extract (%s) cannot be superior or equal to "
+                        "the quantity of the line (%s)")
+                    % (split_qty, trf_line.quantity))
+            new_line = trf_line.copy()
+            new_line.write({'quantity': split_qty, 'packop_id': False})
+            trf_line.quantity -= split_qty
+        action = trf_line.transfer_id.wizard_view()
+        return action

--- a/stock_transfer_split_multi/wizard/stock_transfer_split_multi.py
+++ b/stock_transfer_split_multi/wizard/stock_transfer_split_multi.py
@@ -52,3 +52,14 @@ class StockTransferSplitMulti(models.TransientModel):
             trf_line.quantity -= split_qty
         action = trf_line.transfer_id.wizard_view()
         return action
+
+    @api.multi
+    def cancel(self):
+        """We have to re-call the wizard when the user clicks on Cancel"""
+        self.ensure_one()
+        assert self.env.context.get('active_model') == \
+            'stock.transfer_details_items', 'Wrong underlying model'
+        trf_line = self.env['stock.transfer_details_items'].browse(
+            self.env.context['active_id'])
+        action = trf_line.transfer_id.wizard_view()
+        return action

--- a/stock_transfer_split_multi/wizard/stock_transfer_split_multi.py
+++ b/stock_transfer_split_multi/wizard/stock_transfer_split_multi.py
@@ -44,8 +44,8 @@ class StockTransferSplitMulti(models.TransientModel):
         if split_qty > 0:
             if split_qty >= trf_line.quantity:
                 raise Warning(
-                    _("The Quantity to extract (%s) cannot be superior or equal to "
-                        "the quantity of the line (%s)")
+                    _("The Quantity to extract (%s) cannot be superior or "
+                        "equal to the quantity of the line (%s)")
                     % (split_qty, trf_line.quantity))
             new_line = trf_line.copy()
             new_line.write({'quantity': split_qty, 'packop_id': False})

--- a/stock_transfer_split_multi/wizard/stock_transfer_split_multi.xml
+++ b/stock_transfer_split_multi/wizard/stock_transfer_split_multi.xml
@@ -21,7 +21,8 @@
             <footer>
                 <button name="split_multi_quantities" type="object"
                     string="Split Line" class="oe_highlight"/>
-                <button special="cancel" string="Cancel" class="oe_link"/>
+                <button name="cancel" type="object"
+                    string="Cancel" class="oe_link"/>
             </footer>
         </form>
     </field>

--- a/stock_transfer_split_multi/wizard/stock_transfer_split_multi.xml
+++ b/stock_transfer_split_multi/wizard/stock_transfer_split_multi.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data>
+
+
+<record id="stock_transfer_split_multi_form" model="ir.ui.view">
+    <field name="name">stock_transfer_split_multi.wizard_form</field>
+    <field name="model">stock.transfer.split.multi</field>
+    <field name="arch" type="xml">
+        <form string="Split Line">
+            <group name="main">
+                <field name="split_qty"/>
+            </group>
+            <footer>
+                <button name="split_multi_quantities" type="object"
+                    string="Split Line" class="oe_highlight"/>
+                <button special="cancel" string="Cancel" class="oe_link"/>
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record id="stock_transfer_split_multi_action" model="ir.actions.act_window">
+    <field name="name">Split Configurable Quantity</field>
+    <field name="res_model">stock.transfer.split.multi</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
Extract from the module description:

This module adds a button _Split multiple units_ on the lines of the Transfer wizard of the pickings next to the native _Split_ button. When
you click on this button, it will ask you to enter the quantity to extract from this line and it will create a new line.

This is a small and useful module, developed to support real-life needs of real-life users :)
