### PR TITLE
move transport_information from OCA/vertical-ngo

### DIFF
--- a/transport_information/README.rst
+++ b/transport_information/README.rst
@@ -1,6 +1,6 @@
 Transport Information
 =====================
-This simple module is en extraction of objects related to transportation of
+This simple module is an extraction of objects related to transportation of
 goods that are needed in some modules of the verticalization for NGOs, like
 logistic_requisition.
 

--- a/transport_information/README.rst
+++ b/transport_information/README.rst
@@ -1,10 +1,40 @@
 Transport Information
 =====================
-This simple module is an extraction of objects related to transportation of
-goods that are needed in some modules of the verticalization for NGOs, like
-logistic_requisition.
+This simple module is an extraction of objects related to transportation of goods that are needed
+in **Shipment Management** (`stock_shipment_management`) and some modules of the verticalization
+for NGOs, like **Logistics Requisition** (`logistic_requisition`).
 
 Objects introduced here include:
 
 - Transport Mode
 - Transport Vehicle
+
+Usage
+=====
+
+This module is required by **Shipment Management** and **Logistics Requisition**.
+It has no usage on itself but adding new objects.
+
+Known issues / Roadmap
+======================
+
+Credits
+=======
+
+Contributors
+------------
+
+* Leonardo Pistone <leonardo.pistone@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/transport_information/README.rst
+++ b/transport_information/README.rst
@@ -1,0 +1,10 @@
+Transport Information
+=====================
+This simple module is en extraction of objects related to transportation of
+goods that are needed in some modules of the verticalization for NGOs, like
+logistic_requisition.
+
+Objects introduced here include:
+
+- Transport Mode
+- Transport Vehicle

--- a/transport_information/__init__.py
+++ b/transport_information/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import model

--- a/transport_information/__openerp__.py
+++ b/transport_information/__openerp__.py
@@ -26,10 +26,6 @@
  "category": "Purchase Management",
  "license": "AGPL-3",
  'complexity': "easy",
- "description": """
-Transport Information
-=====================
-""",
  "depends": ["purchase",
              ],
  "data": ["view/transport_mode.xml",

--- a/transport_information/__openerp__.py
+++ b/transport_information/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#    Author: Leonardo Pistone
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{"name": "Transport Information",
+ "summary": "Transport Information",
+ "version": "0.1",
+ "author": "Camptocamp",
+ "category": "Purchase Management",
+ "license": "AGPL-3",
+ 'complexity': "easy",
+ "description": """
+Transport Information
+=====================
+""",
+ "depends": ["purchase",
+             ],
+ "data": ["view/transport_mode.xml",
+          "view/transport_vehicle.xml",
+          "security/ir.model.access.csv",
+          ],
+ "installable": True,
+ }

--- a/transport_information/i18n/transport_information.pot
+++ b/transport_information/i18n/transport_information.pot
@@ -1,0 +1,77 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* transport_information
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-24 09:38+0000\n"
+"PO-Revision-Date: 2014-10-24 09:38+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: transport_information
+#: field:transport.mode,create_uid:0
+#: field:transport.vehicle,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: transport_information
+#: field:transport.mode,create_date:0
+#: field:transport.vehicle,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: transport_information
+#: field:transport.mode,id:0
+#: field:transport.vehicle,id:0
+msgid "ID"
+msgstr ""
+
+#. module: transport_information
+#: field:transport.mode,write_uid:0
+#: field:transport.vehicle,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: transport_information
+#: field:transport.mode,write_date:0
+#: field:transport.vehicle,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: transport_information
+#: field:transport.mode,name:0
+#: field:transport.vehicle,name:0
+msgid "Name"
+msgstr ""
+
+#. module: transport_information
+#: view:transport.mode:transport_information.view_transport_mode_form
+msgid "Transport Mode"
+msgstr ""
+
+#. module: transport_information
+#: model:ir.actions.act_window,name:transport_information.action_transport_mode
+#: model:ir.ui.menu,name:transport_information.menu_transport_mode
+#: view:transport.mode:transport_information.view_transport_mode_tree
+msgid "Transport Modes"
+msgstr ""
+
+#. module: transport_information
+#: view:transport.vehicle:transport_information.view_transport_vehicle_tree
+msgid "Transport Vehicles"
+msgstr ""
+
+#. module: transport_information
+#: model:ir.actions.act_window,name:transport_information.action_transport_vehicle
+#: model:ir.ui.menu,name:transport_information.menu_transport_vehicle
+#: view:transport.vehicle:transport_information.view_transport_vehicle_form
+msgid "Vehicles"
+msgstr ""
+

--- a/transport_information/model/__init__.py
+++ b/transport_information/model/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+import transport_mode
+import transport_vehicle

--- a/transport_information/model/__init__.py
+++ b/transport_information/model/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-import transport_mode
-import transport_vehicle
+from . import transport_mode
+from . import transport_vehicle

--- a/transport_information/model/transport_mode.py
+++ b/transport_information/model/transport_mode.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#    Author: Leonardo Pistone
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, fields
+
+
+class TransportMode(models.Model):
+    _name = "transport.mode"
+
+    name = fields.Char('Name', required=True)

--- a/transport_information/model/transport_mode.py
+++ b/transport_information/model/transport_mode.py
@@ -24,4 +24,4 @@ from openerp import models, fields
 class TransportMode(models.Model):
     _name = "transport.mode"
 
-    name = fields.Char('Name', required=True)
+    name = fields.Char('Name', required=True, translate=True)

--- a/transport_information/model/transport_vehicle.py
+++ b/transport_information/model/transport_vehicle.py
@@ -24,4 +24,4 @@ from openerp import models, fields
 class TransportVehicle(models.Model):
     _name = "transport.vehicle"
 
-    name = fields.Char('Name', required=True)
+    name = fields.Char('Name', required=True, translate=True)

--- a/transport_information/model/transport_vehicle.py
+++ b/transport_information/model/transport_vehicle.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#    Author: Leonardo Pistone
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, fields
+
+
+class TransportVehicle(models.Model):
+    _name = "transport.vehicle"
+
+    name = fields.Char('Name', required=True)

--- a/transport_information/security/ir.model.access.csv
+++ b/transport_information/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_transport_mode,access_transport_mode,model_transport_mode,,1,1,1,1
+access_transport_vehicle,access_transport_vehicle,model_transport_vehicle,,1,1,1,1

--- a/transport_information/security/ir.model.access.csv
+++ b/transport_information/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_transport_mode,access_transport_mode,model_transport_mode,,1,1,1,1
-access_transport_vehicle,access_transport_vehicle,model_transport_vehicle,,1,1,1,1
+access_transport_mode_all,access_transport_mode_all,model_transport_mode,,1,0,0,0
+access_transport_mode_manager,access_transport_mode_manager,model_transport_mode,purchase.group_purchase_manager,1,1,1,1
+access_transport_vehicle_all,access_transport_vehicle_all,model_transport_vehicle,,1,0,0,0
+access_transport_vehicle_manager,access_transport_vehicle_manager,model_transport_vehicle,purchase.group_purchase_manager,1,1,1,1

--- a/transport_information/view/transport_mode.xml
+++ b/transport_information/view/transport_mode.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="view_transport_mode_form">
+      <field name="name">view_transport_mode_form</field>
+      <field name="model">transport.mode</field>
+      <field name="arch" type="xml">
+        <form>
+          <group string="Transport Mode">
+            <field name="name"/>
+          </group>
+        </form>
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_transport_mode_tree">
+      <field name="name">view_transport_mode_tree</field>
+      <field name="model">transport.mode</field>
+      <field name="arch" type="xml">
+        <tree string="Transport Modes">
+          <field name="name"/>
+        </tree>
+      </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="action_transport_mode">
+      <field name="name">Transport Modes</field>
+      <field name="res_model">transport.mode</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem
+      name="Transport Modes"
+      parent="purchase.menu_purchase_config_purchase"
+      action="action_transport_mode"
+      id="menu_transport_mode"/>
+
+  </data>
+</openerp>

--- a/transport_information/view/transport_vehicle.xml
+++ b/transport_information/view/transport_vehicle.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="view_transport_vehicle_form">
+      <field name="name">view_transport_vehicle_form</field>
+      <field name="model">transport.vehicle</field>
+      <field name="arch" type="xml">
+        <form>
+          <group string="Vehicles">
+            <field name="name"/>
+          </group>
+        </form>
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_transport_vehicle_tree">
+      <field name="name">view_transport_vehicle_tree</field>
+      <field name="model">transport.vehicle</field>
+      <field name="arch" type="xml">
+        <tree string="Transport Vehicles">
+          <field name="name"/>
+        </tree>
+      </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="action_transport_vehicle">
+      <field name="name">Vehicles</field>
+      <field name="res_model">transport.vehicle</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem
+      name="Vehicles"
+      parent="purchase.menu_purchase_config_purchase"
+      action="action_transport_vehicle"
+      id="menu_transport_vehicle"/>
+
+  </data>
+</openerp>
+


### PR DESCRIPTION
In order to be able to use this module for logistics purpose in a new module stock_shipment_management I move this module here to break dependency on OCA/vertical-ngo

Removed from vertical-ngo at: https://github.com/OCA/vertical-ngo/pull/113
