### PR TITLE
Add stock_route_sales_team

### DIFF
--- a/stock_route_sales_team/README.rst
+++ b/stock_route_sales_team/README.rst
@@ -1,9 +1,9 @@
 Stock Route Sales Teams
 =======================
 
-Allow to configure a Route according to a sales team.
+Allows to configure a Route according to a sales team.
 
- * An option on the Routes define if the route can be used on sales
+ * An option on the Routes defines if the route can be used on sales
    teams or not
  * A new option on a sales team allows to choose the Route to use
    for their sales (the procurements will use this route, except if
@@ -14,8 +14,8 @@ Configuration
 
 The configurations available for this module are:
 
- * In `Warehouse > Configuration > Routes`, you can select the routes available
-   for the sales teams
+ * In `Warehouse > Configuration > Routes`, you can select which routes are
+   available for the sales teams
  * In `Sales > Sales Teams`, you can optionally choose a route that will be
    used for a team
 
@@ -23,7 +23,7 @@ Usage
 =====
 
 As soon as a sales order is created and its sales team has a route, the
-stock will use this route.
+procurements will use this route.
 
 Known issues / Roadmap
 ======================

--- a/stock_route_sales_team/README.rst
+++ b/stock_route_sales_team/README.rst
@@ -1,10 +1,50 @@
 Stock Route Sales Teams
 =======================
 
-Allow to configure a Route for a sales team.
+Allow to configure a Route according to a sales team.
 
  * An option on the Routes define if the route can be used on sales
    teams or not
  * A new option on a sales team allows to choose the Route to use
    for their sales (the procurements will use this route, except if
    another one has been set on the lines)
+
+Configuration
+=============
+
+The configurations available for this module are:
+
+ * In `Warehouse > Configuration > Routes`, you can select the routes available
+   for the sales teams
+ * In `Sales > Sales Teams`, you can optionally choose a route that will be
+   used for a team
+
+Usage
+=====
+
+As soon as a sales order is created and its sales team has a route, the
+stock will use this route.
+
+Known issues / Roadmap
+======================
+
+Credits
+=======
+
+Contributors
+------------
+
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/stock_route_sales_team/README.rst
+++ b/stock_route_sales_team/README.rst
@@ -1,0 +1,10 @@
+Stock Route Sales Teams
+=======================
+
+Allow to configure a Route for a sales team.
+
+ * An option on the Routes define if the route can be used on sales
+   teams or not
+ * A new option on a sales team allows to choose the Route to use
+   for their sales (the procurements will use this route, except if
+   another one has been set on the lines)

--- a/stock_route_sales_team/__init__.py
+++ b/stock_route_sales_team/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import model

--- a/stock_route_sales_team/__openerp__.py
+++ b/stock_route_sales_team/__openerp__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014-2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{'name': 'Stock Route Sales Teams',
+ 'version': '1.0',
+ 'author': 'Camptocamp',
+ 'maintainer': 'Camptocamp',
+ 'license': 'AGPL-3',
+ 'category': 'Specific',
+ 'depends': ['sale_stock',
+             ],
+ 'website': 'http://www.camptocamp.com',
+ 'data': ['view/crm_case_section_view.xml',
+          'view/stock_location_route_view.xml',
+          ],
+ 'test': [],
+ 'installable': True,
+ 'auto_install': False,
+ }

--- a/stock_route_sales_team/__openerp__.py
+++ b/stock_route_sales_team/__openerp__.py
@@ -20,8 +20,8 @@
 ##############################################################################
 
 {'name': 'Stock Route Sales Teams',
- 'version': '1.0',
- 'author': 'Camptocamp',
+ 'version': '8.0.1.0.0',
+ 'author': 'Camptocamp, Odoo Community Association (OCA)',
  'maintainer': 'Camptocamp',
  'license': 'AGPL-3',
  'category': 'Specific',

--- a/stock_route_sales_team/model/__init__.py
+++ b/stock_route_sales_team/model/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import crm_case_section
+from . import sale_order
+from . import stock_location_route

--- a/stock_route_sales_team/model/crm_case_section.py
+++ b/stock_route_sales_team/model/crm_case_section.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014-2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class CrmCaseSection(models.Model):
+    _inherit = 'crm.case.section'
+
+    route_id = fields.Many2one('stock.location.route',
+                               string='Route',
+                               domain=[('section_selectable', '=', True)])

--- a/stock_route_sales_team/model/sale_order.py
+++ b/stock_route_sales_team/model/sale_order.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014-2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _prepare_order_line_procurement(self, cr, uid, order, line,
+                                        group_id=False, context=None):
+        _super = super(SaleOrder, self)
+        vals = _super._prepare_order_line_procurement(cr, uid, order, line,
+                                                      group_id=group_id,
+                                                      context=context)
+        if order.section_id.route_id and not vals.get('route_ids'):
+            route = order.section_id.route_id
+            routes = [(4, route.id)]
+            vals['route_ids'] = routes
+        return vals

--- a/stock_route_sales_team/model/stock_location_route.py
+++ b/stock_route_sales_team/model/stock_location_route.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014-2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class StockLocationRoute(models.Model):
+    _inherit = 'stock.location.route'
+
+    section_selectable = fields.Boolean('Applicable in Sales Teams')

--- a/stock_route_sales_team/tests/__init__.py
+++ b/stock_route_sales_team/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_sale_team_route

--- a/stock_route_sales_team/tests/test_sale_team_route.py
+++ b/stock_route_sales_team/tests/test_sale_team_route.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests import common
+
+
+class TestSaleTeamRoute(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleTeamRoute, self).setUp()
+        self.sale_order_model = self.env['sale.order']
+        self.sale_line_model = self.env['sale.order.line']
+        self.product = self.env.ref('product.product_product_7')
+        self.partner = self.env.ref('base.res_partner_1')
+        self.sales_team = self.env.ref('sales_team.crm_case_section_1')
+        self.route = self.env['stock.location.route'].create({
+            'name': 'Test Route',
+            'section_selectable': True,
+        })
+        self.line_route = self.env['stock.location.route'].create({
+            'name': 'Line Test Route',
+        })
+
+    def test_sales_team_route(self):
+        self.sales_team.route_id = self.route
+        order = self.sale_order_model.create({
+            'partner_id': self.partner.id,
+            'section_id': self.sales_team.id,
+        })
+        line = self.sale_line_model.create({
+            'order_id': order.id,
+            'product_id': self.product.id,
+            'product_uom_qty': 1,
+        })
+        order.action_button_confirm()
+        procurement = line.procurement_ids
+        self.assertEquals(procurement.route_ids, self.route)
+
+    def test_sales_team_route_line_has_priority(self):
+        self.sales_team.route_id = self.route
+        order = self.sale_order_model.create({
+            'partner_id': self.partner.id,
+            'section_id': self.sales_team.id,
+        })
+        line = self.sale_line_model.create({
+            'order_id': order.id,
+            'product_id': self.product.id,
+            'product_uom_qty': 1,
+            'route_id': self.line_route.id,
+        })
+        order.action_button_confirm()
+        procurement = line.procurement_ids
+        self.assertEquals(procurement.route_ids, self.line_route)

--- a/stock_route_sales_team/view/crm_case_section_view.xml
+++ b/stock_route_sales_team/view/crm_case_section_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="0">
+
+    <record id="crm_case_section_view_form" model="ir.ui.view">
+      <field name="name">crm.case.section.form</field>
+      <field name="model">crm.case.section</field>
+      <field name="inherit_id" ref="sales_team.crm_case_section_view_form"/>
+      <field name="arch" type="xml">
+        <group name="left" position="inside">
+          <field name="route_id" groups="sale_stock.group_route_so_lines"/>
+        </group>
+      </field>
+    </record>
+
+  </data>
+</openerp>

--- a/stock_route_sales_team/view/stock_location_route_view.xml
+++ b/stock_route_sales_team/view/stock_location_route_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="0">
+    <record id="stock_location_route_form_view" model="ir.ui.view">
+      <field name="name">stock.location.route.form</field>
+      <field name="model">stock.location.route</field>
+      <field name="inherit_id" ref="sale_stock.stock_location_route_form_view_inherit"/>
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='sale_selectable']" position="after">
+            <field name="section_selectable" string="Sales Teams"/>
+        </xpath>
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
Allow to configure a Route for a sales team.
- An option on the Routes define if the route can be used on sales
  teams or not
- A new option on a sales team allows to choose the Route to use
  for their sales (the procurements will use this route, except if
  another one has been set on the lines)
