### PR TITLE
transit and shipment collaboration

### DIFF
--- a/stock_route_transit/__openerp__.py
+++ b/stock_route_transit/__openerp__.py
@@ -23,7 +23,7 @@
 {
     "name": "Stock Routes Transit",
     # description is in README.rst
-    "version": "0.1",
+    "version": "0.2",
     "depends": ["stock_dropshipping"],
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/stock_route_transit/view/stock_warehouse.xml
+++ b/stock_route_transit/view/stock_warehouse.xml
@@ -15,5 +15,15 @@
         </field>
       </field>
     </record>
+    <record model='ir.ui.view' id='view_picking_type_form'>
+      <field name='model'>stock.picking.type</field>
+      <field name='name'>Picking Types</field>
+      <field name='inherit_id' ref='stock.view_picking_type_form'/>
+      <field name='arch' type='xml'>
+        <field name='name' position='after'>
+          <field name='active'/>
+        </field>
+      </field>
+    </record>
   </data>
 </openerp>

--- a/stock_shipment_management/view/stock_move.xml
+++ b/stock_shipment_management/view/stock_move.xml
@@ -78,7 +78,7 @@
         <field name="view_type">form</field>
         <field name="view_id" ref="view_move_transit_pipline_tree"/>
         <field name="search_view_id" ref="view_move_transit_pipeline_search"/>
-        <field name="domain" eval="[('location_dest_id', '=', ref('stock_route_transit.transit_outgoing'))]"/>
+        <field name="domain" eval="[('location_dest_id.usage', '=', 'transit')]"/>
         <field name="context">{'search_default_ship_to_plan': 1}</field>
         <field name="help" type="html">
           <p>
@@ -94,7 +94,7 @@
         <field name="view_type">form</field>
         <field name="view_id" ref="view_move_transit_pipline_tree"/>
         <field name="search_view_id" ref="view_move_transit_pipeline_search"/>
-        <field name="domain" eval="[('location_dest_id', '=', ref('stock_route_transit.transit_outgoing'))]"/>
+        <field name="domain" eval="[('location_dest_id.usage', '=', 'transit')]"/>
         <field name="context">{'search_default_ship_in_transit': 1}</field>
         <field name="help" type="html">
           <p>

--- a/stock_shipment_management/wizard/create_shipment.py
+++ b/stock_shipment_management/wizard/create_shipment.py
@@ -131,10 +131,8 @@ class ShipmentPlanCreator(models.TransientModel):
         mvs_wrong_state = residual.filtered(
             lambda rec: rec.state not in ('confirmed', 'waiting', 'assigned'))
         residual -= mvs_wrong_state
-        loc_ref = 'stock_route_transit.transit_outgoing'
-        transit_location = self.env.ref(loc_ref)
         mvs_not_transit = residual.filtered(
-            lambda rec: rec.location_dest_id != transit_location)
+            lambda rec: rec.location_dest_id.usage != 'transit')
         residual -= mvs_not_transit
         mvs_no_dest = residual.filtered(
             lambda rec: not rec.move_dest_id)


### PR DESCRIPTION
- reinit the transit picking types when changing the config of a warehouse (resetting possible editions made by the user which would break the config)
- fix the location of the Buy pull route
- shipment: fix transit location detection by using the `usage` field of the location
