### PR TITLE
fix dropshipping route with transit

### DIFF
--- a/stock_route_transit/data/stock_location.xml
+++ b/stock_route_transit/data/stock_location.xml
@@ -23,5 +23,15 @@
       <field name="picking_type_id" ref="stock_dropshipping.picking_type_dropship"/>
     </record>
 
+   <record id="push_rule_dropshipping_transit" model='stock.location.path'>
+     <field name="name">Transit → Customer</field>
+     <field name="location_from_id" ref='transit_outgoing'/>
+     <field name="location_dest_id" ref="stock.stock_location_customers"/>
+     <field name="picking_type_id"
+            ref="stock_dropshipping.picking_type_dropship"/>
+     <field name='auto'>auto</field>
+     <field name="route_id" ref="stock_dropshipping.route_drop_shipping"/>
+   </record>
+
   </data>
 </openerp>


### PR DESCRIPTION
we need a push rule to ensure that dropshipping PO going through the outgoing
transit location do arrive at the customer location
