### PR TITLE
[IMP] 'stock_picking_mass_assign' add possibility to force availability and to deliver many pickings;

### DIFF
--- a/stock_picking_mass_assign/__openerp__.py
+++ b/stock_picking_mass_assign/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 {'name': 'Delivery Orders Mass Assign',
- 'version': '0.1',
+ 'version': '0.2',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'category': 'Warehouse Management',
@@ -32,8 +32,11 @@ Delivery Orders Mass Assign
 
 Facilities to check the availability of delivery orders:
 
-* A wizard which allows to check availability on multiple delivery
-  orders at a time.
+* A wizard which allows on multiple delivery orders at a time to:
+    * check availability of Delivery Orders;
+    * force availability of Delivery Orders;
+    * process Pickings (deliver);
+
 * A scheduled action to check availability of all the delivery orders.
   It is not active by default.
 

--- a/stock_picking_mass_assign/__openerp__.py
+++ b/stock_picking_mass_assign/__openerp__.py
@@ -21,7 +21,7 @@
 
 {'name': 'Delivery Orders Mass Assign',
  'version': '0.2',
- 'author': "Camptocamp,Odoo Community Association (OCA)",
+ 'author': "Camptocamp,GRAP,Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'category': 'Warehouse Management',
  'depends': ['stock',

--- a/stock_picking_mass_assign/i18n/de.po
+++ b/stock_picking_mass_assign/i18n/de.po
@@ -1,20 +1,24 @@
 # Translation of OpenERP Server.
 # This file contains the translation of the following modules:
-# 	* stock_picking_mass_assign
+#	* stock_picking_mass_assign
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-07-17 09:00+0000\n"
-"PO-Revision-Date: 2015-02-01 13:42+0100\n"
-"Last-Translator: Rudolf Schnapka <rs@techno-flex.de>\n"
+"POT-Creation-Date: 2015-04-06 11:29+0000\n"
+"PO-Revision-Date: 2015-04-06 11:29+0000\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
-"X-Generator: Poedit 1.5.4\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_picking_mass_assign
+#: view:stock.picking.check.assign.all:0
+msgid "Apply"
+msgstr "Apply"
 
 #. module: stock_picking_mass_assign
 #: view:stock.picking.check.assign.all:0
@@ -23,7 +27,7 @@ msgstr "Abbrechen"
 
 #. module: stock_picking_mass_assign
 #: model:ir.actions.act_window,name:stock_picking_mass_assign.action_check_assign_all
-#: view:stock.picking.check.assign.all:0
+#: field:stock.picking.check.assign.all,check_availability:0
 msgid "Check Availability"
 msgstr "Verfügbarkeit prüfen"
 
@@ -33,16 +37,14 @@ msgid "Check the availability of the selected delivery orders"
 msgstr "Verfügbarkeit für ausgewählte Lieferaufträge prüfen"
 
 #. module: stock_picking_mass_assign
-#: code:_description:0
-#: model:ir.model,name:stock_picking_mass_assign.model_stock_picking
-#, python-format
-msgid "Picking List"
-msgstr "Kommissionierschein"
+#: field:stock.picking.check.assign.all,create_invoice:0
+msgid "Create Invoices/Refunds"
+msgstr "Erstelle Rechnung / Gutschrift"
 
 #. module: stock_picking_mass_assign
-#: view:stock.picking.check.assign.all:0
-msgid "or"
-msgstr "oder"
+#: field:stock.picking.check.assign.all,process_picking:0
+msgid "Deliver"
+msgstr "Ausliefern"
 
 #. module: stock_picking_mass_assign
 #: code:_description:0
@@ -50,3 +52,62 @@ msgstr "oder"
 #, python-format
 msgid "Delivery Orders Check Availability"
 msgstr "Verfügbarkeitsprüfung zur Lieferung"
+
+#. module: stock_picking_mass_assign
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:62
+#, python-format
+msgid "Error"
+msgstr "Error"
+
+#. module: stock_picking_mass_assign
+#: field:stock.picking.check.assign.all,force_availability:0
+msgid "Force Availability"
+msgstr "Erzwinge Verfügbarkeit"
+
+#. module: stock_picking_mass_assign
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:63
+#, python-format
+msgid "No selected delivery orders"
+msgstr "No selected delivery orders"
+
+#. module: stock_picking_mass_assign
+#: code:_description:0
+#: model:ir.model,name:stock_picking_mass_assign.model_stock_picking
+#, python-format
+msgid "Picking List"
+msgstr "Kommissionierschein"
+
+#. module: stock_picking_mass_assign
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:115
+#, python-format
+msgid "Stock Invoice Onshipping"
+msgstr "Stock Invoice Onshipping"
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,check_availability:0
+msgid "check this box if you want to check the availability of the selected Delivery Orders."
+msgstr "check this box if you want to check the availability of the selected Delivery Orders."
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,create_invoice:0
+msgid "check this box if you want to create Invoices or Refunds for all the selected Delivery Orders."
+msgstr "check this box if you want to create Invoices or Refunds for all the selected Delivery Orders."
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,process_picking:0
+msgid "check this box if you want to deliver all the selected Delivery Orders.\n"
+" You'll not have the possibility to realize a partial delivery.\n"
+" If you want to do that, please do it manually on the Delivery Order form."
+msgstr "check this box if you want to deliver all the selected Delivery Orders.\n"
+" You'll not have the possibility to realize a partial delivery.\n"
+" If you want to do that, please do it manually on the Delivery Order form."
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,force_availability:0
+msgid "check this box if you want to force the availability of the selected Delivery Orders."
+msgstr "check this box if you want to force the availability of the selected Delivery Orders."
+
+#. module: stock_picking_mass_assign
+#: view:stock.picking.check.assign.all:0
+msgid "or"
+msgstr "oder"

--- a/stock_picking_mass_assign/i18n/de.po
+++ b/stock_picking_mass_assign/i18n/de.po
@@ -18,7 +18,7 @@ msgstr ""
 #. module: stock_picking_mass_assign
 #: view:stock.picking.check.assign.all:0
 msgid "Apply"
-msgstr "Apply"
+msgstr ""
 
 #. module: stock_picking_mass_assign
 #: view:stock.picking.check.assign.all:0
@@ -57,7 +57,7 @@ msgstr "Verfügbarkeitsprüfung zur Lieferung"
 #: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:62
 #, python-format
 msgid "Error"
-msgstr "Error"
+msgstr ""
 
 #. module: stock_picking_mass_assign
 #: field:stock.picking.check.assign.all,force_availability:0
@@ -68,7 +68,7 @@ msgstr "Erzwinge Verfügbarkeit"
 #: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:63
 #, python-format
 msgid "No selected delivery orders"
-msgstr "No selected delivery orders"
+msgstr ""
 
 #. module: stock_picking_mass_assign
 #: code:_description:0
@@ -81,31 +81,29 @@ msgstr "Kommissionierschein"
 #: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:115
 #, python-format
 msgid "Stock Invoice Onshipping"
-msgstr "Stock Invoice Onshipping"
+msgstr ""
 
 #. module: stock_picking_mass_assign
 #: help:stock.picking.check.assign.all,check_availability:0
 msgid "check this box if you want to check the availability of the selected Delivery Orders."
-msgstr "check this box if you want to check the availability of the selected Delivery Orders."
+msgstr ""
 
 #. module: stock_picking_mass_assign
 #: help:stock.picking.check.assign.all,create_invoice:0
 msgid "check this box if you want to create Invoices or Refunds for all the selected Delivery Orders."
-msgstr "check this box if you want to create Invoices or Refunds for all the selected Delivery Orders."
+msgstr ""
 
 #. module: stock_picking_mass_assign
 #: help:stock.picking.check.assign.all,process_picking:0
 msgid "check this box if you want to deliver all the selected Delivery Orders.\n"
 " You'll not have the possibility to realize a partial delivery.\n"
 " If you want to do that, please do it manually on the Delivery Order form."
-msgstr "check this box if you want to deliver all the selected Delivery Orders.\n"
-" You'll not have the possibility to realize a partial delivery.\n"
-" If you want to do that, please do it manually on the Delivery Order form."
+msgstr ""
 
 #. module: stock_picking_mass_assign
 #: help:stock.picking.check.assign.all,force_availability:0
 msgid "check this box if you want to force the availability of the selected Delivery Orders."
-msgstr "check this box if you want to force the availability of the selected Delivery Orders."
+msgstr ""
 
 #. module: stock_picking_mass_assign
 #: view:stock.picking.check.assign.all:0

--- a/stock_picking_mass_assign/i18n/fr.po
+++ b/stock_picking_mass_assign/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-04-06 11:21+0000\n"
-"PO-Revision-Date: 2015-04-06 11:21+0000\n"
+"POT-Creation-Date: 2015-04-14 15:51+0000\n"
+"PO-Revision-Date: 2015-04-14 15:51+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -42,6 +42,7 @@ msgid "Create Invoices/Refunds"
 msgstr "Créer factures/avoirs"
 
 #. module: stock_picking_mass_assign
+#: model:ir.actions.act_window,name:stock_picking_mass_assign.action_deliver_all
 #: field:stock.picking.check.assign.all,process_picking:0
 msgid "Deliver"
 msgstr "Livraison"
@@ -55,17 +56,20 @@ msgstr "Vérification de la disponibilité des bons de livraisons"
 
 #. module: stock_picking_mass_assign
 #: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:62
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:75
 #, python-format
 msgid "Error"
 msgstr "Erreur"
 
 #. module: stock_picking_mass_assign
+#: model:ir.actions.act_window,name:stock_picking_mass_assign.action_force_availability_all
 #: field:stock.picking.check.assign.all,force_availability:0
 msgid "Force Availability"
 msgstr "Forcer la disponibilité"
 
 #. module: stock_picking_mass_assign
 #: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:63
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:76
 #, python-format
 msgid "No selected delivery orders"
 msgstr "Aucun bon de livraison sélectionnés"
@@ -79,6 +83,7 @@ msgstr "Opération de manutention"
 
 #. module: stock_picking_mass_assign
 #: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:115
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:128
 #, python-format
 msgid "Stock Invoice Onshipping"
 msgstr "Créer les factures brouillons"

--- a/stock_picking_mass_assign/i18n/fr.po
+++ b/stock_picking_mass_assign/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-07-17 09:00+0000\n"
-"PO-Revision-Date: 2014-07-17 09:00+0000\n"
+"POT-Creation-Date: 2015-04-06 11:21+0000\n"
+"PO-Revision-Date: 2015-04-06 11:21+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,12 +17,17 @@ msgstr ""
 
 #. module: stock_picking_mass_assign
 #: view:stock.picking.check.assign.all:0
+msgid "Apply"
+msgstr "Appliquer"
+
+#. module: stock_picking_mass_assign
+#: view:stock.picking.check.assign.all:0
 msgid "Cancel"
 msgstr "Annuler"
 
 #. module: stock_picking_mass_assign
 #: model:ir.actions.act_window,name:stock_picking_mass_assign.action_check_assign_all
-#: view:stock.picking.check.assign.all:0
+#: field:stock.picking.check.assign.all,check_availability:0
 msgid "Check Availability"
 msgstr "Vérifier la disponibilité"
 
@@ -32,16 +37,14 @@ msgid "Check the availability of the selected delivery orders"
 msgstr "Vérifier la disponibilité des bons de livraisons sélectionnés"
 
 #. module: stock_picking_mass_assign
-#: code:_description:0
-#: model:ir.model,name:stock_picking_mass_assign.model_stock_picking
-#, python-format
-msgid "Picking List"
-msgstr "Opération de manutention"
+#: field:stock.picking.check.assign.all,create_invoice:0
+msgid "Create Invoices/Refunds"
+msgstr "Créer factures/avoirs"
 
 #. module: stock_picking_mass_assign
-#: view:stock.picking.check.assign.all:0
-msgid "or"
-msgstr "ou"
+#: field:stock.picking.check.assign.all,process_picking:0
+msgid "Deliver"
+msgstr "Livraison"
 
 #. module: stock_picking_mass_assign
 #: code:_description:0
@@ -49,4 +52,63 @@ msgstr "ou"
 #, python-format
 msgid "Delivery Orders Check Availability"
 msgstr "Vérification de la disponibilité des bons de livraisons"
+
+#. module: stock_picking_mass_assign
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:62
+#, python-format
+msgid "Error"
+msgstr "Erreur"
+
+#. module: stock_picking_mass_assign
+#: field:stock.picking.check.assign.all,force_availability:0
+msgid "Force Availability"
+msgstr "Forcer la disponibilité"
+
+#. module: stock_picking_mass_assign
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:63
+#, python-format
+msgid "No selected delivery orders"
+msgstr "Aucun bon de livraison sélectionnés"
+
+#. module: stock_picking_mass_assign
+#: code:_description:0
+#: model:ir.model,name:stock_picking_mass_assign.model_stock_picking
+#, python-format
+msgid "Picking List"
+msgstr "Opération de manutention"
+
+#. module: stock_picking_mass_assign
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:115
+#, python-format
+msgid "Stock Invoice Onshipping"
+msgstr "Créer les factures brouillons"
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,check_availability:0
+msgid "check this box if you want to check the availability of the selected Delivery Orders."
+msgstr "cochez cette case si vous souhaitez vérifier la disponibilité des bons de livraisons sélectionnés."
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,create_invoice:0
+msgid "check this box if you want to create Invoices or Refunds for all the selected Delivery Orders."
+msgstr "cochez cette case si vous souhaitez créer des factures ou des avoirs pour les bons de livraisons sélectionnés."
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,process_picking:0
+msgid "check this box if you want to deliver all the selected Delivery Orders.\n"
+" You'll not have the possibility to realize a partial delivery.\n"
+" If you want to do that, please do it manually on the Delivery Order form."
+msgstr "cochez cette case si vous souhaitez réaliser la livraison pour tous les bons de livraisons sélectionnés.\n"
+" Vous n'aurez pas la possibilité de réaliser une livraison partielle.\n"
+" Si vous souhaitez le faire, veuillez le réaliser manuellement sur le formulaire du bon de livraison."
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,force_availability:0
+msgid "check this box if you want to force the availability of the selected Delivery Orders."
+msgstr "cochez cette case si vous souhaitez forcer la disponibilité des bons de livraisons sélectionnés."
+
+#. module: stock_picking_mass_assign
+#: view:stock.picking.check.assign.all:0
+msgid "or"
+msgstr "ou"
 

--- a/stock_picking_mass_assign/i18n/stock_picking_mass_assign.pot
+++ b/stock_picking_mass_assign/i18n/stock_picking_mass_assign.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-07-17 09:00+0000\n"
-"PO-Revision-Date: 2014-07-17 09:00+0000\n"
+"POT-Creation-Date: 2015-04-06 11:28+0000\n"
+"PO-Revision-Date: 2015-04-06 11:28+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,18 +17,57 @@ msgstr ""
 
 #. module: stock_picking_mass_assign
 #: view:stock.picking.check.assign.all:0
+msgid "Apply"
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: view:stock.picking.check.assign.all:0
 msgid "Cancel"
 msgstr ""
 
 #. module: stock_picking_mass_assign
 #: model:ir.actions.act_window,name:stock_picking_mass_assign.action_check_assign_all
-#: view:stock.picking.check.assign.all:0
+#: field:stock.picking.check.assign.all,check_availability:0
 msgid "Check Availability"
 msgstr ""
 
 #. module: stock_picking_mass_assign
 #: view:stock.picking.check.assign.all:0
 msgid "Check the availability of the selected delivery orders"
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: field:stock.picking.check.assign.all,create_invoice:0
+msgid "Create Invoices/Refunds"
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: field:stock.picking.check.assign.all,process_picking:0
+msgid "Deliver"
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: code:_description:0
+#: model:ir.model,name:stock_picking_mass_assign.model_stock_picking_check_assign_all
+#, python-format
+msgid "Delivery Orders Check Availability"
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:62
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: field:stock.picking.check.assign.all,force_availability:0
+msgid "Force Availability"
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:63
+#, python-format
+msgid "No selected delivery orders"
 msgstr ""
 
 #. module: stock_picking_mass_assign
@@ -39,14 +78,35 @@ msgid "Picking List"
 msgstr ""
 
 #. module: stock_picking_mass_assign
-#: view:stock.picking.check.assign.all:0
-msgid "or"
+#: code:addons/stock_picking_mass_assign/wizard/check_assign_all.py:115
+#, python-format
+msgid "Stock Invoice Onshipping"
 msgstr ""
 
 #. module: stock_picking_mass_assign
-#: code:_description:0
-#: model:ir.model,name:stock_picking_mass_assign.model_stock_picking_check_assign_all
-#, python-format
-msgid "Delivery Orders Check Availability"
+#: help:stock.picking.check.assign.all,check_availability:0
+msgid "check this box if you want to check the availability of the selected Delivery Orders."
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,create_invoice:0
+msgid "check this box if you want to create Invoices or Refunds for all the selected Delivery Orders."
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,process_picking:0
+msgid "check this box if you want to deliver all the selected Delivery Orders.\n"
+" You'll not have the possibility to realize a partial delivery.\n"
+" If you want to do that, please do it manually on the Delivery Order form."
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: help:stock.picking.check.assign.all,force_availability:0
+msgid "check this box if you want to force the availability of the selected Delivery Orders."
+msgstr ""
+
+#. module: stock_picking_mass_assign
+#: view:stock.picking.check.assign.all:0
+msgid "or"
 msgstr ""
 

--- a/stock_picking_mass_assign/wizard/check_assign_all.py
+++ b/stock_picking_mass_assign/wizard/check_assign_all.py
@@ -3,7 +3,8 @@
 #
 #    Author: Guewen Baconnier
 #    Copyright 2014 Camptocamp SA
-#
+#    @author Sylvain LE GAL (https://twitter.com/legalsylvain)
+
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
 #    published by the Free Software Foundation, either version 3 of the
@@ -46,8 +47,18 @@ class check_assign_all(orm.TransientModel):
             """ Orders."""),
     }
 
+    def _default_force_availability(self, cr, uid, context=None):
+        context = context or {}
+        return context.get('force_availability', False)
+
+    def _default_process_picking(self, cr, uid, context=None):
+        context = context or {}
+        return context.get('process_picking', False)
+
     _defaults = {
         'check_availability': True,
+        'force_availability': _default_force_availability,
+        'process_picking': _default_process_picking,
     }
 
     def check(self, cr, uid, ids, context=None):
@@ -121,5 +132,4 @@ class check_assign_all(orm.TransientModel):
                 'context': ctx,
             }
         else:
-            # close the wizard
-            return {'type': 'ir.actions.act_window_close'}
+            return True

--- a/stock_picking_mass_assign/wizard/check_assign_all.py
+++ b/stock_picking_mass_assign/wizard/check_assign_all.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 
-from openerp.osv import orm
+from openerp.osv import orm, fields
 from openerp.tools.translate import _
 
 
@@ -27,22 +27,99 @@ class check_assign_all(orm.TransientModel):
     _name = 'stock.picking.check.assign.all'
     _description = 'Delivery Orders Check Availability'
 
-    def check(self, cr, uid, ids, context=None):
-        if context is None:
-            context = {}
+    _columns = {
+        'check_availability': fields.boolean(
+            'Check Availability', help="""check this box if you want to"""
+            """ check the availability of the selected Delivery Orders."""),
+        'force_availability': fields.boolean(
+            'Force Availability', help="""check this box if you want to"""
+            """ force the availability of the selected Delivery Orders."""),
+        'process_picking': fields.boolean(
+            'Deliver', help="""check this box if you want to"""
+            """ deliver all the selected Delivery Orders.\n You'll not have"""
+            """ the possibility to realize a partial delivery.\n If you want"""
+            """ to do that, please do it manually on the Delivery Order"""
+            """ form."""),
+        'create_invoice': fields.boolean(
+            'Create Invoices/Refunds', help="""check this box if you want to"""
+            """ create Invoices or Refunds for all the selected Delivery"""
+            """ Orders."""),
+    }
 
+    _defaults = {
+        'check_availability': True,
+    }
+
+    def check(self, cr, uid, ids, context=None):
+        context = context or {}
+        picking_obj = self.pool['stock.picking']
+        process_wizard_obj = self.pool['stock.partial.picking']
         picking_ids = context.get('active_ids')
+        wizard_id = ids[0]
+
         if not picking_ids:
             raise orm.except_orm(
                 _('Error'),
                 _('No selected delivery orders'))
 
-        picking_obj = self.pool['stock.picking']
+        wizard = self.browse(cr, uid, wizard_id, context=context)
+
+        # Get confirmed pickings
         domain = [('type', '=', 'out'),
                   ('state', '=', 'confirmed'),
                   ('id', 'in', picking_ids)]
-        picking_ids = picking_obj.search(cr, uid, domain,
-                                         order='min_date',
-                                         context=context)
-        picking_obj.check_assign_all(cr, uid, picking_ids, context=context)
-        return {'type': 'ir.actions.act_window_close'}
+        confirmed_picking_ids = picking_obj.search(
+                cr, uid, domain, order='min_date', context=context)
+
+        # Assign all picking if asked
+        if wizard.check_availability and confirmed_picking_ids:
+            picking_obj.check_assign_all(
+                cr, uid, confirmed_picking_ids, context=context)
+
+        # Force availability if asked
+        if wizard.force_availability and confirmed_picking_ids:
+            picking_obj.force_assign(cr, uid, confirmed_picking_ids)
+
+        # Get all pickings ready to deliver
+        domain = [('type', '=', 'out'),
+                  ('state', '=', 'assigned'),
+                  ('id', 'in', picking_ids)]
+        assigned_picking_ids = picking_obj.search(
+                cr, uid, domain, order='min_date', context=context)
+
+        # Process all pickings if asked
+        if wizard.process_picking and assigned_picking_ids:
+            for picking in picking_obj.browse(
+                    cr, uid, assigned_picking_ids, context=context):
+                ctx = context.copy()
+                ctx['active_ids'] = [picking.id]
+                process_wizard_id = process_wizard_obj.create(
+                     cr, uid, {}, context=ctx)
+                process_wizard_obj.do_partial(
+                    cr, uid, [process_wizard_id], context=context)
+
+        # Get all pickings ready to invoice
+        domain = [('type', '=', 'out'),
+                  ('invoice_state', '=', '2binvoiced'),
+                  ('id', 'in', picking_ids)]
+        to_invoice_picking_ids = picking_obj.search(
+                cr, uid, domain, order='min_date', context=context)
+
+        # Invoice all pickings if asked
+        if wizard.create_invoice and to_invoice_picking_ids:
+            # return the regular wizard to invoice many pickings
+            ctx = context.copy()
+            ctx['active_ids'] = to_invoice_picking_ids
+            ctx['active_model'] = 'stock.picking.out'
+            return {
+                'name': _('Stock Invoice Onshipping'),
+                'view_type': 'form',
+                'view_mode': 'form',
+                'res_model': 'stock.invoice.onshipping',
+                'type': 'ir.actions.act_window',
+                'target': 'new',
+                'context': ctx,
+            }
+        else:
+            # close the wizard
+            return {'type': 'ir.actions.act_window_close'}

--- a/stock_picking_mass_assign/wizard/check_assign_all.py
+++ b/stock_picking_mass_assign/wizard/check_assign_all.py
@@ -69,7 +69,7 @@ class check_assign_all(orm.TransientModel):
                   ('state', '=', 'confirmed'),
                   ('id', 'in', picking_ids)]
         confirmed_picking_ids = picking_obj.search(
-                cr, uid, domain, order='min_date', context=context)
+            cr, uid, domain, order='min_date', context=context)
 
         # Assign all picking if asked
         if wizard.check_availability and confirmed_picking_ids:
@@ -85,7 +85,7 @@ class check_assign_all(orm.TransientModel):
                   ('state', '=', 'assigned'),
                   ('id', 'in', picking_ids)]
         assigned_picking_ids = picking_obj.search(
-                cr, uid, domain, order='min_date', context=context)
+            cr, uid, domain, order='min_date', context=context)
 
         # Process all pickings if asked
         if wizard.process_picking and assigned_picking_ids:
@@ -94,7 +94,7 @@ class check_assign_all(orm.TransientModel):
                 ctx = context.copy()
                 ctx['active_ids'] = [picking.id]
                 process_wizard_id = process_wizard_obj.create(
-                     cr, uid, {}, context=ctx)
+                    cr, uid, {}, context=ctx)
                 process_wizard_obj.do_partial(
                     cr, uid, [process_wizard_id], context=context)
 
@@ -103,7 +103,7 @@ class check_assign_all(orm.TransientModel):
                   ('invoice_state', '=', '2binvoiced'),
                   ('id', 'in', picking_ids)]
         to_invoice_picking_ids = picking_obj.search(
-                cr, uid, domain, order='min_date', context=context)
+            cr, uid, domain, order='min_date', context=context)
 
         # Invoice all pickings if asked
         if wizard.create_invoice and to_invoice_picking_ids:

--- a/stock_picking_mass_assign/wizard/check_assign_all_view.xml
+++ b/stock_picking_mass_assign/wizard/check_assign_all_view.xml
@@ -6,8 +6,14 @@
       <field name="model">stock.picking.check.assign.all</field>
       <field name="arch" type="xml">
         <form string="Check the availability of the selected delivery orders" version="7.0">
+              <group>
+                  <field name="check_availability"/>
+                  <field name="force_availability"/>
+                  <field name="process_picking"/>
+                  <field name="create_invoice"/>
+              </group>
           <footer>
-            <button name="check" string="Check Availability" type="object" class="oe_highlight"/>
+            <button name="check" string="Apply" type="object" class="oe_highlight"/>
             or
             <button string="Cancel" class="oe_link" special="cancel"/>
           </footer>

--- a/stock_picking_mass_assign/wizard/check_assign_all_view.xml
+++ b/stock_picking_mass_assign/wizard/check_assign_all_view.xml
@@ -21,12 +21,12 @@
       </field>
     </record>
 
+<!-- Check Availability Action -->
     <record id="action_check_assign_all" model="ir.actions.act_window">
       <field name="name">Check Availability</field>
       <field name="res_model">stock.picking.check.assign.all</field>
       <field name="view_type">form</field>
       <field name="view_mode">form</field>
-      <field name="view_id" ref="view_check_assign_all"/>
       <field name="target">new</field>
     </record>
 
@@ -35,6 +35,44 @@
       <field name="name">Check Availability</field>
       <field name="key2">client_action_multi</field>
       <field name="value" eval="'ir.actions.act_window,' + str(ref('action_check_assign_all'))"/>
+      <field name="key">action</field>
+      <field name="model">stock.picking.out</field>
+    </record>
+
+<!-- Force Availability Action -->
+    <record id="action_force_availability_all" model="ir.actions.act_window">
+      <field name="name">Force Availability</field>
+      <field name="res_model">stock.picking.check.assign.all</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="target">new</field>
+      <field name="context">{'force_availability': 1}</field>
+    </record>
+
+    <record id="action_force_availability_all_values" model="ir.values">
+      <field name="model_id" ref="stock.model_stock_picking_out" />
+      <field name="name">Force Availability</field>
+      <field name="key2">client_action_multi</field>
+      <field name="value" eval="'ir.actions.act_window,' + str(ref('action_force_availability_all'))"/>
+      <field name="key">action</field>
+      <field name="model">stock.picking.out</field>
+    </record>
+
+<!-- Deliver Action -->
+    <record id="action_deliver_all" model="ir.actions.act_window">
+      <field name="name">Deliver</field>
+      <field name="res_model">stock.picking.check.assign.all</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="target">new</field>
+      <field name="context">{'force_availability': 1, 'process_picking': 1,}</field>
+    </record>
+
+    <record id="action_deliver_all_values" model="ir.values">
+      <field name="model_id" ref="stock.model_stock_picking_out" />
+      <field name="name">Deliver</field>
+      <field name="key2">client_action_multi</field>
+      <field name="value" eval="'ir.actions.act_window,' + str(ref('action_deliver_all'))"/>
       <field name="key">action</field>
       <field name="model">stock.picking.out</field>
     </record>


### PR DESCRIPTION
Hi all,
I was searching for a tool to check availability of many pickings. I found 'stock_picking_mass_assign' and I improved it to give the possibility to : 
- mass force availability;
- mass deliver;
- directly display after the invoices wizard;

I let by default the same behaviour. I just added options (by checkbox), unchecked by default.

Thanks for your review.
CC : @guewen 
