### PR TITLE
separate the picking_dispatch tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
   global:
     - VERSION="8.0" TESTS="0" LINT_CHECK="0"
   matrix:
-  - LINT_CHECK="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="picking_dispatch"
-  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="picking_dispatch"
-  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="picking_dispatch"
-  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="picking_dispatch"
+    - LINT_CHECK="1"
+    - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="picking_dispatch"
+    - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="picking_dispatch"
+    - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="picking_dispatch"
+    - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="picking_dispatch"
 
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,14 @@ python:
   - "2.7"
 
 env:
-  - VERSION="8.0" LINT_CHECK="1"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0" EXCLUDE="picking_dispatch"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB"  LINT_CHECK="0" EXCLUDE="picking_dispatch"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0" INCLUDE="picking_dispatch"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB"  LINT_CHECK="0" INCLUDE="picking_dispatch"
+  global:
+    - VERSION="8.0" TESTS="0" LINT_CHECK="0"
+  matrix:
+  - LINT_CHECK="1"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="picking_dispatch"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="picking_dispatch"
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="picking_dispatch"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="picking_dispatch"
 
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ python:
 
 env:
   - VERSION="8.0" LINT_CHECK="1"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB"  LINT_CHECK="0"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0" EXCLUDE="picking_dispatch"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB"  LINT_CHECK="0" EXCLUDE="picking_dispatch"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0" INCLUDE="picking_dispatch"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB"  LINT_CHECK="0" INCLUDE="picking_dispatch"
 
 virtualenv:
   system_site_packages: true

--- a/stock_dropshipping_dual_invoice/model/__init__.py
+++ b/stock_dropshipping_dual_invoice/model/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import move
 from . import picking
+from . import purchase_order

--- a/stock_dropshipping_dual_invoice/model/purchase_order.py
+++ b/stock_dropshipping_dual_invoice/model/purchase_order.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+#    Author: Yannick Vaucher
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from openerp import models, api
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    @api.multi
+    def wkf_confirm_order(self):
+        po = self.with_context(no_invoice_policy_check=True)
+        super(PurchaseOrder, po).wkf_confirm_order()

--- a/stock_dropshipping_dual_invoice/wizard/stock_invoice_onshipping.py
+++ b/stock_dropshipping_dual_invoice/wizard/stock_invoice_onshipping.py
@@ -64,6 +64,7 @@ class StockInvoiceOnshipping(models.TransientModel):
             first_invoice_ids = pick.with_context(
                 partner_to_invoice_id=pick.partner_id.id,
                 date_inv=self.invoice_date,
+                inv_type='in_invoice',
             ).action_invoice_create(
                 journal_id=self.journal_id.id,
                 group=self.group,
@@ -75,6 +76,7 @@ class StockInvoiceOnshipping(models.TransientModel):
                     move.invoice_state = '2binvoiced'
             second_invoice_ids = pick.with_context(
                 date_inv=self.invoice_date,
+                inv_type='out_invoice',
             ).action_invoice_create(
                 journal_id=self.second_journal_id.id,
                 group=self.group,


### PR DESCRIPTION
picking dispatch adds a dependency on delivery
and the presence of this module breaks the tests of stock_ownership_by_move
(but the module works fine with delivery installed)
