### PR TITLE
[IMP] stock_dropshipping_dual_invoice: Allow to invoice more than one dropshipping pickings + returning view

### DIFF
--- a/stock_dropshipping_dual_invoice/README.rst
+++ b/stock_dropshipping_dual_invoice/README.rst
@@ -34,11 +34,9 @@ Usage
 Known issues
 ------------
 
-When the wizard creates a supplier invoice and a customer invoice, it does not
-show them, and instead the wizard is simply closed, going back to the picking.
-This is because we cannot easily show a customer and a supplier invoice
-together in a tree view, because one of them would not get the correct form
-view.
+* When the wizard creates a supplier invoice and a customer invoice, the
+  returned view doesn't allow to show invoices in form view, because the form
+  wouldn't be correctly displayed.
 
 
 Bug Tracker

--- a/stock_dropshipping_dual_invoice/__openerp__.py
+++ b/stock_dropshipping_dual_invoice/__openerp__.py
@@ -18,7 +18,9 @@
  'summary':
  'Create both Supplier and Customer Invoices from a Dropshipping Delivery',
  'version': '0.1',
- 'author': "Camptocamp,Odoo Community Association (OCA)",
+ 'author': "Camptocamp, "
+           "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+           "Odoo Community Association (OCA)",
  'category': 'Warehouse',
  'license': 'AGPL-3',
  'depends': ['stock_account',

--- a/stock_dropshipping_dual_invoice/wizard/stock_invoice_onshipping_view.xml
+++ b/stock_dropshipping_dual_invoice/wizard/stock_invoice_onshipping_view.xml
@@ -7,7 +7,10 @@
       <field name="model">stock.invoice.onshipping</field>
       <field name="inherit_id" ref="stock_account.view_stock_invoice_onshipping"/>
       <field name="arch" type="xml">
-        <field name="journal_type" position="replace">
+        <field name="journal_type" position="attributes">
+          <attribute name="invisible">1</attribute>
+        </field>
+        <field name="journal_type" position="after">
           <field name="wizard_title" />
         </field>
         <field name="journal_id" position="after">


### PR DESCRIPTION
This PR contains 2 improvements:
- Allow to invoice more than one dropshipping pickings, making previously a grouping by customer that allows to call with the context correctly.
- Return a list view only with the created invoices (with no possibility to go to form view, so the data is correct).

cc @lepistone 
