### PR TITLE
[FIX] stock_dropshipping_dual_invoice: Don't detect MTO orders as dual invoiceable

### DIFF
--- a/stock_dropshipping_dual_invoice/wizard/stock_invoice_onshipping.py
+++ b/stock_dropshipping_dual_invoice/wizard/stock_invoice_onshipping.py
@@ -48,9 +48,13 @@ class StockInvoiceOnshipping(models.TransientModel):
                 self.env.context['active_id'])
             so = picking.sale_id
             moves = picking.move_lines.filtered('purchase_line_id')[:1]
-            return (so.order_policy == 'picking' and
+            if (so.order_policy == 'picking' and
                     moves.purchase_line_id.order_id.invoice_method ==
-                    'picking')
+                    'picking'):
+                # We still need to investigate if this an MTO or drop-shipping
+                p_type = picking.picking_type_id
+                return (p_type.default_location_src_id.usage == 'supplier' and
+                        p_type.default_location_dest_id.usage == 'customer')
         return False
 
     @api.depends('journal_type', 'need_two_invoices')

--- a/stock_dropshipping_dual_invoice/wizard/stock_invoice_onshipping.py
+++ b/stock_dropshipping_dual_invoice/wizard/stock_invoice_onshipping.py
@@ -51,7 +51,9 @@ class StockInvoiceOnshipping(models.TransientModel):
             if (so.order_policy == 'picking' and
                     moves.purchase_line_id.order_id.invoice_method ==
                     'picking'):
-                # We still need to investigate if this an MTO or drop-shipping
+                # MTO pickings are also associated to both a sales and purchase
+                # order line, so we still need to investigate if this an MTO
+                # or drop-shipping
                 p_type = picking.picking_type_id
                 return (p_type.default_location_src_id.usage == 'supplier' and
                         p_type.default_location_dest_id.usage == 'customer')


### PR DESCRIPTION
MTO orders passes the same checks as drop-shipping orders, so we need to add one more to avoid dual invoicing in these cases.

@lepistone, please check.
