### PR TITLE
Add workflow trigger on picking after assigning move

### DIFF
--- a/picking_dispatch/picking_dispatch.py
+++ b/picking_dispatch/picking_dispatch.py
@@ -205,6 +205,9 @@ class PickingDispatch(Model):
             ('state', 'in', ('confirmed', 'waiting')),
         ], context=context)
 
+        # In order to avoid calling _product_reserve on each stock move,
+        # a groupyby is first done to try to reserve products for all the
+        # moves (grouped by product and location) present in the dispatches.
         cr.execute("""
             SELECT
                 product_id,
@@ -219,8 +222,7 @@ class PickingDispatch(Model):
         groups = cr.fetchall()
 
         for product_id, location_id, quantity in groups:
-            # Try to reserve all moves with the same product and location
-            # together
+            # Reserve quantity for "grouped" moves
             res = location_obj._product_reserve(
                 cr,
                 uid,
@@ -232,10 +234,11 @@ class PickingDispatch(Model):
             )
 
             if res and len(res) == 1:
+                # The reservation worked: mark moves as assigned...
                 move_obj.write(cr, uid, move_ids, {'state': 'assigned',
                                                    'location_id': res[0][1]},
                                context=context)
-                # trigger workflow on related pickings
+                # ... and trigger workflow on the moves' related pickings
                 cr.execute("""
                     SELECT DISTINCT picking_id
                     FROM stock_move
@@ -245,7 +248,7 @@ class PickingDispatch(Model):
                 for pick_id in pick_ids:
                     wf_service.trg_write(uid, 'stock.picking', pick_id, cr)
             else:
-                # We could not reserve all the moves together, or the
+                # We could not reserve all the moves all at once, or the
                 # reservation is split among many sublocations.
                 # If that's the case, fall back to reserving one move at a time
                 move_obj.action_assign(cr, uid, move_ids, context=context)

--- a/picking_dispatch/tests/test_dispatch.py
+++ b/picking_dispatch/tests/test_dispatch.py
@@ -67,6 +67,7 @@ class TestPickingDispatch(TransactionCase):
         self.dispatch.check_assign_all()
         for move in self.picking.move_lines:
             self.assertEqual(move.state, 'assigned')
+        self.assertEqual(self.picking.state, 'assigned')
 
     def test_cancel(self):
         self.dispatch.action_cancel()


### PR DESCRIPTION
This PR is to add a needed `wkf_trigger` on picking after the mass assign on stock moves; it was called before in https://github.com/OCA/OCB/blob/7.0/addons/stock/stock.py#L2229 , but that is not the case anymore.
