### PR TITLE
8.0 product_unique_serial and stock_no_negative modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,29 @@
+language: python
+
 sudo: false
-cache: pip
+cache:
+  apt: true
+  directories:
+    - $HOME/.pip-cache/
 
 addons:
   apt:
     packages:
-      - expect-dev  # provides unbuffer utility
-      - python-lxml # because pip installation is slow
-
-language: python
+      - expect-dev
+      - python-lxml
+      - python-simplejson
+      - python-yaml
 
 python:
   - "2.7"
 
 env:
   global:
-    - VERSION="8.0" TESTS="0" LINT_CHECK="0"
+  - LINT_CHECK=0 TESTS="0" VERSION="8.0" ODOO_REPO="vauxoo/odoo"
+
   matrix:
-    - LINT_CHECK="1"
-    - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="picking_dispatch,stock_split_picking"
-    - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="picking_dispatch,stock_split_picking"
-    - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="picking_dispatch"
-    - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="picking_dispatch"
-    - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="stock_split_picking"
-    - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="stock_split_picking"
+  - LINT_CHECK=1
+  - TESTS="1"
 
 virtualenv:
   system_site_packages: true
@@ -31,12 +32,13 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git $HOME/maintainer-quality-tools
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
   - travis_install_nightly
+  - pip install coveralls flake8
   - git clone https://github.com/OCA/product-attribute -b ${VERSION} $HOME/product-attribute
   - git clone https://github.com/OCA/webkit-tools -b ${VERSION} $HOME/webkit-tools
   - git clone https://github.com/OCA/stock-logistics-warehouse -b ${VERSION} $HOME/stock-logistics-warehouse
 
 script:
-  - travis_run_tests
+  - travis_wait travis_run_tests
 
 after_success:
-  coveralls
+  - travis_after_tests_success

--- a/product_unique_serial/README.rst
+++ b/product_unique_serial/README.rst
@@ -1,0 +1,90 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+============================
+Product Unique Serial Number
+============================
+
+Allow to control product serial lot number with a unique relation, adding a restriction
+to avoid stock moves with quantity different than 1, only if **Unique Lot** option (explained later)
+is enabled
+
+Installation
+============
+
+To install this module, just selected from available modules.
+
+Configuration
+=============
+
+To configure serial uniqueness feature, do the following
+
+* Go to Warehouse > Products > Products
+
+* Choose the product you need to acomplish unique serial
+
+* Get into Inventory tab in the form view and enable at least one of the
+  lots available options for serial lot tracking, and then **Unique Lot** option
+  will appear to enable it
+
+Usage
+=====
+When doing a warehouse transfer, there are two posibilities for serial lot number treatment :
+
+#. Incoming transfer: Serial numbers will not appear unless it have not already a
+   stock move related and letting to the user create a new one from scratch
+
+#. Outgoing / Internal transfer: Dont show unused serial lots leaving to the user
+   to select only those one that have associated moves
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/154/8.0
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+Known issues / Roadmap
+======================
+
+* When computing last location for a lot based on quants, it fails, this is not
+  fully tested
+* Look how to append domain strings
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/
+stock-logistics-workflow/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+stock-logistics-workflow/issues/new?body=module:%20
+product_unique_serial%0Aversion:%20
+8.0.1.0.1%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Moisés Lopez <moylop260@vauxoo.com>
+* Osval Reyes <osval@vauxoo.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/product_unique_serial/__init__.py
+++ b/product_unique_serial/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models
+from . import wizards

--- a/product_unique_serial/__openerp__.py
+++ b/product_unique_serial/__openerp__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Product Serial Unique Number",
+    'version': '8.0.1.0.1',
+    'author': "Vauxoo,Odoo Community Association (OCA)",
+    'website': "http://www.vauxoo.com",
+    'category': 'stock',
+    'license': 'AGPL-3',
+    'depends': [
+        'stock_no_negative'
+    ],
+    'data': [
+        "views/product_template.xml",
+        "views/stock_production_lot.xml",
+    ],
+    'demo': [
+        "demo/product_product.xml",
+        "demo/stock_production_lot.xml",
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/product_unique_serial/demo/product_product.xml
+++ b/product_unique_serial/demo/product_product.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+        <!-- Products -->
+        <record id="product_demo_1" model="product.product">
+            <field name="name">Huawei Ascend</field>
+            <field name="track_all" eval="True"/>
+            <field name="check_no_negative" eval="False"/>
+            <field name="categ_id" ref="product.product_category_all"/>
+            <field name="lot_unique_ok" eval="True"/>
+            <field name="standard_price">75.50</field>
+            <field name="list_price">82.25</field>
+        </record>
+        <record id="product_demo_2" model="product.product">
+            <field name="name">Nokia 2630</field>
+            <field name="track_all" eval="True"/>
+            <field name="check_no_negative" eval="True"/>
+            <field name="categ_id" ref="product.product_category_all"/>
+            <field name="lot_unique_ok" eval="True"/>
+            <field name="standard_price">35.50</field>
+            <field name="list_price">42.28</field>
+        </record>
+    </data>
+</openerp>

--- a/product_unique_serial/demo/stock_production_lot.xml
+++ b/product_unique_serial/demo/stock_production_lot.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+        <!-- Sales Orders -->
+        <record id="serial_number_demo_1" model="stock.production.lot">
+            <field name="name">86137801852514</field>
+            <field name="product_id" ref="product_demo_1"/>
+        </record>
+
+        <record id="serial_number_demo_2" model="stock.production.lot">
+            <field name="name">86137801852515</field>
+            <field name="product_id" ref="product_demo_1"/>
+        </record>
+
+        <record id="serial_number_demo_3" model="stock.production.lot">
+            <field name="name">86137801852516</field>
+            <field name="product_id" ref="product_demo_1"/>
+        </record>
+    </data>
+</openerp>

--- a/product_unique_serial/i18n/es.po
+++ b/product_unique_serial/i18n/es.po
@@ -1,0 +1,76 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_unique_serial
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-06 22:51+0000\n"
+"PO-Revision-Date: 2015-10-06 22:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_unique_serial
+#: help:product.template,lot_unique_ok:0
+msgid "Forces set qty=1 to specify a Unique Serial Number for all moves"
+msgstr "Forza a especificar la cantidad de 1 para todos los movimiento en los numeros de lote"
+
+#. module: product_unique_serial
+#: model:product.template,name:product_unique_serial.product_demo_1_product_template
+msgid "Huawei Ascend"
+msgstr "Huawei Ascend"
+
+#. module: product_unique_serial
+#: field:stock.production.lot,last_location_id:0
+msgid "Last location"
+msgstr "Ultima ubicación"
+
+#. module: product_unique_serial
+#: model:ir.model,name:product_unique_serial.model_stock_production_lot
+msgid "Lot/Serial"
+msgstr "Lote/No. de Serial"
+
+#. module: product_unique_serial
+#: model:product.template,name:product_unique_serial.product_demo_2_product_template
+msgid "Nokia 2630"
+msgstr "Nokia 2630"
+
+#. module: product_unique_serial
+#: model:ir.model,name:product_unique_serial.model_stock_transfer_details
+msgid "Picking wizard"
+msgstr "Asistente de albarán"
+
+#. module: product_unique_serial
+#: code:addons/product_unique_serial/models/stock_move.py:73
+#, python-format
+msgid "Product '%s' has active 'unique lot'\n"
+"but with this move you will have a quantity of '%s' in lot '%s'"
+msgstr "El Producto '%s' tiene activa la restricción 'Lote Único'
+pero con este movimiento tendrá una cantidad de '%s' en el lote '%s'"
+
+#. module: product_unique_serial
+#: code:addons/product_unique_serial/models/stock_move.py:50
+#, python-format
+msgid "Product '%s' has active 'unique lot' but has qty > 1"
+msgstr "El producto '%s' tiene activo 'Lote Único' pero tiene cantidad mayor a 1"
+
+#. module: product_unique_serial
+#: model:ir.model,name:product_unique_serial.model_product_template
+msgid "Product Template"
+msgstr "Plantilla de Producto"
+
+#. module: product_unique_serial
+#: model:ir.model,name:product_unique_serial.model_stock_move
+msgid "Stock Move"
+msgstr "Movimiento de Inventario"
+
+#. module: product_unique_serial
+#: field:product.template,lot_unique_ok:0
+msgid "Unique lot"
+msgstr "Lote Único"
+

--- a/product_unique_serial/i18n/product_unique_serial.pot
+++ b/product_unique_serial/i18n/product_unique_serial.pot
@@ -1,0 +1,75 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_unique_serial
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-06 22:51+0000\n"
+"PO-Revision-Date: 2015-10-06 22:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_unique_serial
+#: help:product.template,lot_unique_ok:0
+msgid "Forces set qty=1 to specify a Unique Serial Number for all moves"
+msgstr ""
+
+#. module: product_unique_serial
+#: model:product.template,name:product_unique_serial.product_demo_1_product_template
+msgid "Huawei Ascend"
+msgstr ""
+
+#. module: product_unique_serial
+#: field:stock.production.lot,last_location_id:0
+msgid "Last location"
+msgstr ""
+
+#. module: product_unique_serial
+#: model:ir.model,name:product_unique_serial.model_stock_production_lot
+msgid "Lot/Serial"
+msgstr ""
+
+#. module: product_unique_serial
+#: model:product.template,name:product_unique_serial.product_demo_2_product_template
+msgid "Nokia 2630"
+msgstr ""
+
+#. module: product_unique_serial
+#: model:ir.model,name:product_unique_serial.model_stock_transfer_details
+msgid "Picking wizard"
+msgstr ""
+
+#. module: product_unique_serial
+#: code:addons/product_unique_serial/models/stock_move.py:73
+#, python-format
+msgid "Product '%s' has active 'unique lot'\n"
+"but with this move you will have a quantity of '%s' in lot '%s'"
+msgstr ""
+
+#. module: product_unique_serial
+#: code:addons/product_unique_serial/models/stock_move.py:50
+#, python-format
+msgid "Product '%s' has active 'unique lot' but has qty > 1"
+msgstr ""
+
+#. module: product_unique_serial
+#: model:ir.model,name:product_unique_serial.model_product_template
+msgid "Product Template"
+msgstr ""
+
+#. module: product_unique_serial
+#: model:ir.model,name:product_unique_serial.model_stock_move
+msgid "Stock Move"
+msgstr ""
+
+#. module: product_unique_serial
+#: field:product.template,lot_unique_ok:0
+msgid "Unique lot"
+msgstr ""
+

--- a/product_unique_serial/models/__init__.py
+++ b/product_unique_serial/models/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import product_template
+from . import stock_move
+from . import stock_production_lot

--- a/product_unique_serial/models/product_template.py
+++ b/product_unique_serial/models/product_template.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    lot_unique_ok = fields.Boolean('Unique lot',
+                                   help='Forces set qty=1 '
+                                        'to specify a Unique '
+                                        'Serial Number for '
+                                        'all moves')

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import _, exceptions, models
+
+
+class StockMove(models.Model):
+
+    """
+    Stock Move
+    """
+    _inherit = 'stock.move'
+
+    def check_after_action_done(self, cr, uid, operation_or_move,
+                                lot_id=None, context=None):
+        super(StockMove, self).check_after_action_done(
+            cr, uid, operation_or_move, lot_id, context=context)
+        return self.check_unicity_qty_available(cr, uid, operation_or_move,
+                                                lot_id, context=context)
+
+    def check_unicity_move_qty(self, cr, uid, ids, context=None):
+        """
+        Check move quantity to verify that has qty = 1
+        if 'lot unique' is ok on product
+        """
+        if not isinstance(ids, list):
+            ids = [ids]
+        for move in self.browse(cr, uid, ids, context=context):
+            if move.product_id.lot_unique_ok:
+                for move_operation in \
+                        move.linked_move_operation_ids:
+                    if abs(move_operation.qty) > 1:
+                        raise exceptions.ValidationError(_(
+                            "Product '%s' has active"
+                            " 'unique lot' "
+                            "but has qty > 1"
+                        ) % (move.product_id.name))
+
+    def check_unicity_qty_available(self, cr, uid, operation_or_move,
+                                    lot_id,
+                                    context=None):
+        """
+        Check quantity on hand to verify that has qty = 1
+        if 'lot unique' is ok on product
+        """
+        if operation_or_move.product_id.lot_unique_ok and lot_id:
+            ctx = context.copy()
+            ctx.update({'lot_id': lot_id})
+            product_ctx = self.pool.get('product.product').browse(
+                cr, uid, [operation_or_move.product_id.id],
+                context=ctx)[0]
+            qty = product_ctx.qty_available
+            if not 0 <= qty <= 1:
+                lot = self.pool.get('stock.production.lot').browse(
+                    cr, uid, [lot_id])[0]
+                raise exceptions.ValidationError(_(
+                    "Product '%s' has active "
+                    "'unique lot'\n"
+                    "but with this move "
+                    "you will have a quantity of "
+                    "'%s' in lot '%s'"
+                ) % (operation_or_move.product_id.name, qty, lot.name))
+        return True
+
+    def check_tracking(self, cr, uid, move, lot_id, context=None):
+        res = super(StockMove, self).check_tracking(
+            cr, uid, move, lot_id, context=context)
+        self.check_unicity_move_qty(cr, uid, [move.id], context=context)
+        return res

--- a/product_unique_serial/models/stock_production_lot.py
+++ b/product_unique_serial/models/stock_production_lot.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import api, fields, models
+
+
+class StockProductionLot(models.Model):
+
+    """
+    Adds information about lot last location using quants data
+    and avoid creation of duplicated serial numbers
+    """
+    _inherit = 'stock.production.lot'
+
+    last_location_id = fields.Many2one(
+        'stock.location',
+        string="Last location",
+        compute='_get_last_location_id',
+        store=True)
+    ref = fields.Char('Internal Reference',
+                      help="Internal reference number"
+                           " in this case it"
+                           " is same of manufacturer's"
+                           " serial number",
+                      related="name", store=True, readonly=True)
+
+    @api.multi
+    @api.depends('quant_ids')
+    def _get_last_location_id(self):
+        for prodlot_id in self:
+            last_quant_data = self.env['stock.quant'].search_read(
+                [('id', 'in', prodlot_id.quant_ids.ids)],
+                ['location_id'],
+                order='in_date DESC, id DESC',
+                limit=1)
+
+            prodlot_id.last_location_id = last_quant_data and \
+                last_quant_data[0]['location_id'][0] or False

--- a/product_unique_serial/tests/__init__.py
+++ b/product_unique_serial/tests/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import test_for_unicity

--- a/product_unique_serial/tests/test_for_unicity.py
+++ b/product_unique_serial/tests/test_for_unicity.py
@@ -21,7 +21,7 @@
 
 from copy import deepcopy
 
-from openerp.exceptions import except_orm
+from openerp.exceptions import ValidationError
 from openerp.tests.common import TransactionCase
 from openerp.tools import mute_logger
 from psycopg2 import IntegrityError
@@ -168,10 +168,7 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_1,
             self.env.ref('product_unique_serial.serial_number_demo_1'))
-        with self.assertRaisesRegexp(
-                except_orm,
-                r"you will have a quantity of '2.0' "
-                r"in lot '86137801852514'"):
+        with self.assertRaises(ValidationError):
             self.transfer_picking(
                 picking_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -229,10 +226,7 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_out_1,
             self.env.ref('product_unique_serial.serial_number_demo_1'))
-        with self.assertRaisesRegexp(
-                except_orm,
-                r"you will have a quantity of '-1.0' "
-                r"in lot '86137801852514'"):
+        with self.assertRaises(ValidationError):
             self.transfer_picking(
                 picking_out_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -263,7 +257,7 @@ class TestUnicity(TransactionCase):
             stock_move_datas, picking_data_1,
             self.env.ref('stock.picking_type_in'))
         # Executing the wizard for pickings transfering
-        with self.assertRaisesRegexp(except_orm, r'but has qty > 1'):
+        with self.assertRaises(ValidationError):
             self.transfer_picking(
                 picking_1,
                 [self.env.ref('product_unique_serial.serial_number_demo_2')])
@@ -300,12 +294,13 @@ class TestUnicity(TransactionCase):
             self.env.ref('stock.picking_type_in'))
         # Executing the wizard for pickings transfering: this should be correct
         # 'cause is the ideal case
-        self.transfer_picking(
-            picking_in,
-            [self.env.ref('product_unique_serial.serial_number_demo_1'),
-             self.env.ref('product_unique_serial.serial_number_demo_2'),
-             self.env.ref('product_unique_serial.serial_number_demo_3')]
-        )
+        with self.assertRaises(ValidationError):
+            self.transfer_picking(
+                picking_in,
+                [self.env.ref('product_unique_serial.serial_number_demo_1'),
+                 self.env.ref('product_unique_serial.serial_number_demo_2'),
+                 self.env.ref('product_unique_serial.serial_number_demo_3')]
+            )
 
     def test_5_1product_1serialnumber_2p_internal(self):
         """
@@ -364,9 +359,7 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_internal_1,
             [self.env.ref('product_unique_serial.serial_number_demo_1')])
-        with self.assertRaisesRegexp(
-                except_orm,
-                r"Product 'Nokia 2630' has active 'check no negative'"):
+        with self.assertRaises(ValidationError):
             self.transfer_picking(
                 picking_internal_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -383,6 +376,5 @@ class TestUnicity(TransactionCase):
             'product_id': product_id.id
         }
         self.stock_production_lot_obj.create(lot_data)
-        with self.assertRaisesRegexp(
-                IntegrityError, r'"stock_production_lot_name_ref_uniq"'):
+        with self.assertRaises(IntegrityError):
             self.stock_production_lot_obj.create(lot_data)

--- a/product_unique_serial/tests/test_for_unicity.py
+++ b/product_unique_serial/tests/test_for_unicity.py
@@ -1,0 +1,388 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Sergio Tostado, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from copy import deepcopy
+
+from openerp.exceptions import except_orm
+from openerp.tests.common import TransactionCase
+from openerp.tools import mute_logger
+from psycopg2 import IntegrityError
+
+
+class TestUnicity(TransactionCase):
+
+    """
+    This test will prove the next cases to procure the
+    module unicity:
+    - Test 1: Can't be created two Serial Numbers with the same name
+    """
+
+    def setUp(self):
+        super(TestUnicity, self).setUp()
+        self.stock_production_lot_obj = self.env['stock.production.lot']
+        self.stock_picking_type_obj = self.env['stock.picking.type']
+        self.stock_picking_obj = self.env['stock.picking']
+        self.product_obj = self.env['product.product']
+        self.stock_move_obj = self.env['stock.move']
+        self.product_uom_obj = self.env['product.uom']
+        self.stock_location_obj = self.env['stock.location']
+
+    def create_stock_picking(self, moves_data, picking_data, picking_type):
+        """ Returns the stock.picking object, with his respective created
+            created stock.move lines """
+        # Require deepcopy for clone dict into list items
+        moves_data_copy = deepcopy(moves_data)
+        picking_data_copy = picking_data.copy()
+        stock_move_ids = []
+        default_product_data = None
+        for move_n in moves_data_copy:
+            # Getting the qty for the stock.move
+            qty = move_n.get('qty')
+            del move_n['qty']
+            # Getting default data through product_id onchange
+            if 'source_loc' in move_n.keys()\
+                    and 'destination_loc' in move_n.keys():
+                default_product_data = self.stock_move_obj.onchange_product_id(
+                    prod_id=move_n.get('product_id'),
+                    loc_id=move_n.get('source_loc'),
+                    loc_dest_id=move_n.get('destination_loc'))
+                del move_n['source_loc']
+                del move_n['destination_loc']
+            else:
+                default_product_data = self.stock_move_obj.onchange_product_id(
+                    move_n.get('product_id'))
+            move_n.update(default_product_data.get('value'))
+            # Getting default data through product_uom_qty onchange
+            default_qty_data = self.stock_move_obj.onchange_quantity(
+                move_n.get('product_id'),
+                qty,
+                default_product_data.get('product_uom'),
+                default_product_data.get('product_uos'))
+            default_qty_data['value'].update({'product_uom_qty': qty})
+            move_n.update(default_qty_data.get('value'))
+            # Getting the new stock.move id
+            move_created = self.stock_move_obj.with_context(
+                default_picking_type_id=picking_type.id).create(move_n)
+            stock_move_ids.append(move_created.id)
+        # Creating picking
+        picking_data_copy.update({
+            'move_lines': [(6, 0, stock_move_ids)],
+            # TODO: Uncomment when fix current context bug
+            # 'move_lines': [(0, 0, moves_data_copy)],
+            # and remove move_created line
+            'picking_type_id': picking_type.id})
+        return self.stock_picking_obj.create(picking_data_copy)
+
+    def transfer_picking(self, picking_instance, serial_number=None):
+        """ Creates a wizard to transfer the picking given like parameter """
+        # Marking the picking as Todo
+        picking_instance.action_confirm()
+        if picking_instance.state == 'confirmed':
+            # Checking availability
+            picking_instance.action_assign()
+        if picking_instance.state == 'assigned':
+            # Transfering picking
+            transfer_details = picking_instance.do_enter_transfer_details()
+            wizard_for_transfer = self.env[transfer_details.get('res_model')].\
+                browse(transfer_details.get('res_id'))
+            if serial_number:
+                if len(serial_number) == 1:
+                    for transfer_item in wizard_for_transfer.item_ids:
+                        transfer_item.lot_id = serial_number[0].id
+                else:
+                    # Case for the A, B & C serial numbers: That are 3 like
+                    # value for the quantity field in the wizard, so we should
+                    # split this record 2 times.
+                    # Splitting the record and executing the transfer
+                    wizard_split = wizard_for_transfer.item_ids[0].\
+                        split_quantities()
+                    wizard_for_transfer = self.env['stock.transfer_details'].\
+                        browse(wizard_split.get('res_id'))
+                    wizard_split = wizard_for_transfer.item_ids[0].\
+                        split_quantities()
+                    wizard_for_transfer = self.env['stock.transfer_details'].\
+                        browse(wizard_split.get('res_id'))
+                    index = 0
+                    for transfer_item in wizard_for_transfer.item_ids:
+                        transfer_item.lot_id = serial_number[index].id
+                        index += 1
+            # Executing the picking transfering
+            wizard_for_transfer.do_detailed_transfer()
+
+    def test_1_1product_1serialnumber_2p_in(self):
+        """
+        Test 1. Creating 2 pickings with 1 product for the same serial number,
+        in the receipts scope, with the next form:
+        - Picking 1
+        =============================================
+        || Product ||  Quantity  ||  Serial Number ||
+        =============================================
+        ||    A    ||      1     ||      001       ||
+        =============================================
+        - Picking 2
+        =============================================
+        || Product ||  Quantity  ||  Serial Number ||
+        =============================================
+        ||    A    ||      1     ||      001       ||
+        =============================================
+        Warehouse: Your Company
+        """
+        # Creating move line for picking
+        product = self.env.ref('product_unique_serial.product_demo_1')
+        stock_move_datas = [{
+            'product_id': product.id,
+            'qty': 1.0
+        }]
+        # Creating the pickings
+        picking_data_1 = {
+            'name': 'Test Picking IN 1',
+        }
+        picking_data_2 = {
+            'name': 'Test Picking IN 2',
+        }
+        picking_1 = self.create_stock_picking(
+            stock_move_datas, picking_data_1,
+            self.env.ref('stock.picking_type_in'))
+        picking_2 = self.create_stock_picking(
+            stock_move_datas, picking_data_2,
+            self.env.ref('stock.picking_type_in'))
+        # Executing the wizard for pickings transfering
+        self.transfer_picking(
+            picking_1,
+            self.env.ref('product_unique_serial.serial_number_demo_1'))
+        with self.assertRaisesRegexp(
+                except_orm,
+                r"you will have a quantity of '2.0' "
+                r"in lot '86137801852514'"):
+            self.transfer_picking(
+                picking_2,
+                [self.env.ref('product_unique_serial.serial_number_demo_1')])
+
+    def test_2_1product_1serialnumber_2p_out(self):
+        """
+        Test 2. Creating 2 pickings with 1 product for the same serial number,
+        in the delivery orders scope, with the next form:
+        - Picking 1
+        =============================================
+        || Product ||  Quantity  ||  Serial Number ||
+        =============================================
+        ||    A    ||      1     ||      001       ||
+        =============================================
+        - Picking 2
+        =============================================
+        || Product ||  Quantity  ||  Serial Number ||
+        =============================================
+        ||    A    ||      1     ||      001       ||
+        =============================================
+        NOTE: To can operate this case, we need an IN PICKING
+        Warehouse: Your Company
+        """
+        # Creating move line for picking
+        product = self.env.ref('product_unique_serial.product_demo_1')
+        stock_move_datas = [{
+            'product_id': product.id,
+            'qty': 1.0
+        }]
+        # Creating the pickings
+        picking_data_in = {
+            'name': 'Test Picking IN 1',
+        }
+        picking_data_out_1 = {
+            'name': 'Test Picking OUT 1',
+        }
+        picking_data_out_2 = {
+            'name': 'Test Picking OUT 2',
+        }
+        # IN PROCESS
+        picking_in = self.create_stock_picking(
+            stock_move_datas, picking_data_in,
+            self.env.ref('stock.picking_type_in'))
+        self.transfer_picking(
+            picking_in,
+            self.env.ref('product_unique_serial.serial_number_demo_1'))
+        # OUT PROCESS
+        picking_out_1 = self.create_stock_picking(
+            stock_move_datas, picking_data_out_1,
+            self.env.ref('stock.picking_type_out'))
+        picking_out_2 = self.create_stock_picking(
+            stock_move_datas, picking_data_out_2,
+            self.env.ref('stock.picking_type_out'))
+        # Executing the wizard for pickings transfering
+        self.transfer_picking(
+            picking_out_1,
+            self.env.ref('product_unique_serial.serial_number_demo_1'))
+        with self.assertRaisesRegexp(
+                except_orm,
+                r"you will have a quantity of '-1.0' "
+                r"in lot '86137801852514'"):
+            self.transfer_picking(
+                picking_out_2,
+                [self.env.ref('product_unique_serial.serial_number_demo_1')])
+
+    def test_3_1product_qtyno1_1serialnumber_1p_in(self):
+        """
+        Test 3. Creating a picking with 1 product for the same serial number,
+        in the delivery orders scope, with the next form:
+        - Picking 1
+        =============================================
+        || Product ||  Quantity  ||  Serial Number ||
+        =============================================
+        ||    A    ||     >1     ||      001       ||
+        =============================================
+        Warehouse: Your Company
+        """
+        # Creating move line for picking
+        product = self.env.ref('product_unique_serial.product_demo_1')
+        stock_move_datas = [{
+            'product_id': product.id,
+            'qty': 2.0
+        }]
+        # Creating the pickings
+        picking_data_1 = {
+            'name': 'Test Picking IN 1',
+        }
+        picking_1 = self.create_stock_picking(
+            stock_move_datas, picking_data_1,
+            self.env.ref('stock.picking_type_in'))
+        # Executing the wizard for pickings transfering
+        with self.assertRaisesRegexp(except_orm, r'but has qty > 1'):
+            self.transfer_picking(
+                picking_1,
+                [self.env.ref('product_unique_serial.serial_number_demo_2')])
+
+    def test_4_1product_qty3_3serialnumber_1p_in(self):
+        """
+        Test 4. Creating a picking with 1 product for three serial numbers,
+        in the receipts scope, with the next form:
+        - Picking 1
+        =============================================
+        || Product ||  Quantity  ||  Serial Number ||
+        =============================================
+        ||    A    ||      1     ||      001       ||
+        =============================================
+        ||    A    ||      1     ||      002       ||
+        =============================================
+        ||    A    ||      1     ||      003       ||
+        =============================================
+        Warehouse: Your Company
+        """
+        # Creating move line for picking
+        product = self.env.ref('product_unique_serial.product_demo_1')
+        stock_move_datas = [
+            {'product_id': product.id, 'qty': 1.0},
+            {'product_id': product.id, 'qty': 1.0},
+            {'product_id': product.id, 'qty': 1.0}
+        ]
+        # Creating the picking
+        picking_data_in = {
+            'name': 'Test Picking IN 1',
+        }
+        picking_in = self.create_stock_picking(
+            stock_move_datas, picking_data_in,
+            self.env.ref('stock.picking_type_in'))
+        # Executing the wizard for pickings transfering: this should be correct
+        # 'cause is the ideal case
+        self.transfer_picking(
+            picking_in,
+            [self.env.ref('product_unique_serial.serial_number_demo_1'),
+             self.env.ref('product_unique_serial.serial_number_demo_2'),
+             self.env.ref('product_unique_serial.serial_number_demo_3')]
+        )
+
+    def test_5_1product_1serialnumber_2p_internal(self):
+        """
+        Test 5. Creating 2 pickings with 1 product for the same serial number,
+        in the internal scope, with the next form:
+        - Picking 1
+        =============================================
+        || Product ||  Quantity  ||  Serial Number ||
+        =============================================
+        ||    A    ||      1     ||      001       ||
+        =============================================
+        - Picking 2
+        =============================================
+        || Product ||  Quantity  ||  Serial Number ||
+        =============================================
+        ||    A    ||      1     ||      001       ||
+        =============================================
+        NOTE: To can operate this case, we need an IN PICKING
+        Warehouse: Your Company
+        """
+        product = self.env.ref('product_unique_serial.product_demo_2')
+        stock_move_in_datas = [
+            {'product_id': product.id,
+             'qty': 1.0,
+             'source_loc': self.env.ref('stock.stock_location_suppliers').id,
+             'destination_loc': self.env.ref(
+                 'stock.stock_location_components').id}]
+        stock_move_internal_datas = [
+            {'product_id': product.id,
+             'qty': 1.0,
+             'source_loc': self.env.ref('stock.stock_location_components').id,
+             'destination_loc': self.env.ref('stock.stock_location_14').id}]
+        picking_data_in = {
+            'name': 'Test Picking IN 1',
+        }
+        picking_data_internal_1 = {
+            'name': 'Test Picking INTERNAL 1',
+        }
+        picking_data_internal_2 = {
+            'name': 'Test Picking INTERNAL 2',
+        }
+        # IN PROCESS
+        picking_in = self.create_stock_picking(
+            stock_move_in_datas, picking_data_in,
+            self.env.ref('stock.picking_type_in'))
+        self.transfer_picking(
+            picking_in,
+            [self.env.ref('product_unique_serial.serial_number_demo_1')])
+        # INTERNAL PROCESS
+        picking_internal_1 = self.create_stock_picking(
+            stock_move_internal_datas, picking_data_internal_1,
+            self.env.ref('stock.picking_type_internal'))
+        picking_internal_2 = self.create_stock_picking(
+            stock_move_internal_datas, picking_data_internal_2,
+            self.env.ref('stock.picking_type_internal'))
+        self.transfer_picking(
+            picking_internal_1,
+            [self.env.ref('product_unique_serial.serial_number_demo_1')])
+        with self.assertRaisesRegexp(
+                except_orm,
+                r"Product 'Nokia 2630' has active 'check no negative'"):
+            self.transfer_picking(
+                picking_internal_2,
+                [self.env.ref('product_unique_serial.serial_number_demo_1')])
+
+    @mute_logger('openerp.sql_db')
+    def test_6_1serialnumber_1product_2records(self):
+        """
+        Test 7. Creating 2 identical serial numbers
+        """
+        product_id = self.env.ref('product_unique_serial.product_demo_1')
+        lot_data = {
+            'name': '86137801852520',
+            'ref': '86137801852520',
+            'product_id': product_id.id
+        }
+        self.stock_production_lot_obj.create(lot_data)
+        with self.assertRaisesRegexp(
+                IntegrityError, r'"stock_production_lot_name_ref_uniq"'):
+            self.stock_production_lot_obj.create(lot_data)

--- a/product_unique_serial/views/product_template.xml
+++ b/product_unique_serial/views/product_template.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_product_unique_serial_form" model="ir.ui.view">
+            <field name="name">view.product.unique.serial.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="stock.view_template_property_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='track_outgoing']" position="after">
+                    <field name="lot_unique_ok" groups="stock.group_production_lot"
+                        attrs="{'invisible': [
+                            ('track_all', '=', False),
+                            ('track_incoming', '=', False),
+                            ('track_outgoing', '=', False),
+                        ]}"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/product_unique_serial/views/stock_production_lot.xml
+++ b/product_unique_serial/views/stock_production_lot.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_production_lot_form_inh_pus" model="ir.ui.view">
+            <field name="name">stock.production.lot.form.inh.pus</field>
+            <field name="model">stock.production.lot</field>
+            <field name="inherit_id" ref="stock.view_production_lot_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='product_id']" position="after">
+                    <field name="last_location_id"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/product_unique_serial/wizards/__init__.py
+++ b/product_unique_serial/wizards/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Sergio Tostado, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import stock_transfer_details

--- a/product_unique_serial/wizards/stock_transfer_details.py
+++ b/product_unique_serial/wizards/stock_transfer_details.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Moisés Lopez, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from lxml import etree
+
+from openerp import api, models
+
+
+def domain_str_append(old_domain_str, subdomain_str):
+    return old_domain_str.replace(
+        "]",
+        ", " + subdomain_str + "]")
+
+
+class StockTransferDetails(models.TransientModel):
+    _inherit = 'stock.transfer_details'
+
+    @api.model
+    def fields_view_get(self, view_id=None, view_type='form',
+                        toolbar=False, submenu=False):
+        """
+        Allow create serial only with incoming picking
+        Set option "no_create = True"
+        when picking type is different to incoming.
+        """
+        res = super(StockTransferDetails, self).fields_view_get(
+            view_id=view_id, view_type=view_type,
+            toolbar=toolbar, submenu=submenu)
+        context = self._context
+        if 'item_ids' in res['fields']:
+            arch = res['fields']['item_ids'][
+                'views']['tree']['arch']
+            doc = etree.XML(arch)
+            if context.get('active_model') == 'stock.picking' \
+               and context.get('active_id'):
+                picking = self.env['stock.picking'].\
+                    browse(context['active_id'])
+                for node in doc.xpath("//field[@name='lot_id']"):
+                    if picking.picking_type_id.code != 'incoming':
+                        node.set('options', "{'no_create': True}")
+                        # Don't show unused serial.
+                        # allow to select a serial with moves.
+                        # TODO: Disable this option when
+                        #       fields.function last_location_id
+                        #       was fix it
+                        sub_domain = "('quant_ids', '!=', [])"
+                        # Set domain to show only serial number
+                        # that exists in source location
+                        # TODO: Enable when fields.function
+                        #       last_location_id was fix it
+                        # sub_domain = "('last_location_id', '=', " + \
+                        #     "sourceloc_id)"
+                    else:
+                        # Don't show old serial number
+                        # just allow to create new one or
+                        # allow to select a serial without moves
+                        sub_domain = "('quant_ids', '=', [])"
+                    new_domain = domain_str_append(
+                        node.get('domain'), sub_domain)
+                    node.set('domain', new_domain)
+                res['fields']['item_ids']['views'][
+                    'tree']['arch'] = etree.tostring(doc)
+        return res

--- a/product_unique_serial/wizards/stock_transfer_details.py
+++ b/product_unique_serial/wizards/stock_transfer_details.py
@@ -23,14 +23,11 @@ from lxml import etree
 from openerp import api, models
 
 
-def domain_str_append(old_domain_str, subdomain_str):
-    return old_domain_str.replace(
-        "]",
-        ", " + subdomain_str + "]")
-
-
 class StockTransferDetails(models.TransientModel):
     _inherit = 'stock.transfer_details'
+
+    def domain_str_append(self, old_domain_str, subdomain_str):
+        return old_domain_str.replace("]", ", " + subdomain_str + "]")
 
     @api.model
     def fields_view_get(self, view_id=None, view_type='form',
@@ -72,7 +69,7 @@ class StockTransferDetails(models.TransientModel):
                         # just allow to create new one or
                         # allow to select a serial without moves
                         sub_domain = "('quant_ids', '=', [])"
-                    new_domain = domain_str_append(
+                    new_domain = self.domain_str_append(
                         node.get('domain'), sub_domain)
                     node.set('domain', new_domain)
                 res['fields']['item_ids']['views'][

--- a/stock_no_negative/README.rst
+++ b/stock_no_negative/README.rst
@@ -1,0 +1,75 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Stock Check No Negative
+=======================
+
+This module extends warehouse functionalities to not reach below zero in product available quantities
+
+Installation
+============
+
+Just select it from available modules to install it, there is no need to extra installations
+
+Configuration
+=============
+
+This module brings product configurations per products as the following,
+
+* Go to Products > Products, in the Inventory tab is now allowed to select an option
+  called "**Check no negative**" to activate this module main functionality
+
+Usage
+=====
+
+* Before doing a transfer this will check availability for every single product (with the option mentioned before marked) within the transfer
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/154/8.0
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+Known issues / Roadmap
+======================
+
+* TODO in method check_before_action_done: stock_move use product_uom
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/
+stock-logictics-workflow/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+stock-logictics-workflow/issues/new?body=module:%20
+stock_no_negative%0Aversion:%20
+8.0.1.0.10A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Moises Lopez <moylop260@vauxoo.com>
+* Osval Reyes <osval@vauxoo.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/stock_no_negative/__init__.py
+++ b/stock_no_negative/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Luis Torres, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from . import models

--- a/stock_no_negative/__openerp__.py
+++ b/stock_no_negative/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Luis Torres, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Stock Check No Negative",
+    "version": "8.0.1.0.1",
+    "author": "Vauxoo,Odoo Community Association (OCA)",
+    "category": "Generic Modules",
+    "website": "http://www.vauxoo.com",
+    "license": "AGPL-3",
+    "depends": [
+        "stock"
+    ],
+    "data": [
+        "views/product_template.xml"
+    ],
+    "installable": True,
+    "auto_install": False
+}

--- a/stock_no_negative/models/__init__.py
+++ b/stock_no_negative/models/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Luis Torres, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import product_template
+from . import stock_move

--- a/stock_no_negative/models/product_template.py
+++ b/stock_no_negative/models/product_template.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Luis Torres, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    check_no_negative = fields.Boolean(
+        'Check no negative',
+        help='If this field is True can not move this'
+             ' product in negative quantity available in'
+             ' the internal location source')

--- a/stock_no_negative/models/stock_move.py
+++ b/stock_no_negative/models/stock_move.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author: Luis Torres, Osval Reyes
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import _, exceptions, models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def get_operations_as_action_done(self, cr, uid, ids,
+                                      context=None):
+        """Get stock.pack.operation from stock move
+        Copied from 'action_done' original method
+
+        I don't know if use directly move.linked_move_operation_ids
+        or move.pack_operation_ids is a good idea.
+        But I prefer use native extract data.
+        Move don't exists 'lot_id', then this is necessary to get it
+        """
+
+        # Search operations that are linked to the moves
+        operations = set()
+        for move in self.browse(cr, uid, ids, context=context):
+            for link in move.linked_move_operation_ids:
+                operations.add(link.operation_id)
+
+        # Sort operations according to entire packages first,
+        # then package + lot, package only, lot only
+        operations = list(operations)
+        # This part not is necessary
+        # operations.sort(key=lambda x: (
+        #    (x.package_id and not x.product_id) and -4 or 0) \
+        #    + (x.package_id and -2 or 0) + (x.lot_id and -1 or 0))
+        return operations
+
+    def check_after_action_done(self, cr, uid, operation_or_move,
+                                lot_id=None, context=None):
+        """
+        Method to check operation or move plus lot_id
+        easiest inherit cases after action done
+        """
+        return True
+
+    def check_before_action_done(self, cr, uid, operation_or_move,
+                                 lot_id=None, context=None):
+        """
+        Method to check operation or move plus lot_id
+        easiest inherit cases before action done
+        """
+        self.check_before_done_no_negative(
+            cr, uid, operation_or_move.product_id.id,
+            operation_or_move.product_uom_id.id,
+            operation_or_move.product_qty,
+            operation_or_move.location_id.id,
+            lot_id=lot_id,
+            context=context)
+        return True
+
+    def action_done(self, cr, uid, ids, context=None):
+        """
+        Method to enable check operation or move
+
+        We need this check after of process move to get
+        real quantity after of this moves and we need this check
+        before of process move to validate with no real quantity
+        """
+        # operations before done
+        operations_before_done = self.get_operations_as_action_done(
+            cr, uid, ids, context=context)
+
+        for operation in operations_before_done:
+            lot_id = operation.lot_id.id if operation.lot_id else False
+
+            self.check_before_action_done(
+                cr, uid, operation, lot_id, context=context)
+
+        res = super(StockMove, self).action_done(
+            cr, uid, ids, context=context)
+
+        # operations after done
+        operations_after_done = self.get_operations_as_action_done(
+            cr, uid, ids, context=context)
+
+        for operation in operations_after_done:
+            lot_id = operation.lot_id.id if operation.lot_id else False
+
+            self.check_after_action_done(
+                cr, uid, operation, lot_id, context=context)
+        return res
+
+    def check_before_done_no_negative(
+            self, cr, uid,
+            product_id, product_uom, product_qty,
+            location_id, lot_id=None,
+            context=None):
+        """
+        Check quantity no negative from a location.
+        if product has active check_no_negative and
+        location is internal
+        Use lot_id if exists to get quantity available
+        @param self: The object pointer.
+        @param cr: A database cursor
+        @param uid: ID of the user currently logged in
+        @param product_id: integer with product.product to check
+        @param location_id: integer with stock.location to check
+        @param lot_id: optional integer with
+                       stock.production.lot to check
+        @param context: A standard dictionary
+        @return: True if quantity available >= 0
+                 triggers an exception if quantity available <0
+        """
+        product_pool = self.pool.get('product.product')
+        location_pool = self.pool.get('stock.location')
+        lot_pool = self.pool.get('stock.production.lot')
+        product_uom_obj = self.pool.get('product.uom')
+        product_data = product_pool.read(
+            cr, uid,
+            [product_id], ['name', 'check_no_negative', 'uom_id'],
+            context=context)[0]
+        if product_data['check_no_negative']:
+            location_data = location_pool.read(
+                cr, uid, [location_id],
+                ['complete_name', 'usage'],
+                context=context)[0]
+            if location_data['usage'] == 'internal':
+                ctx = context.copy()
+                ctx.update({
+                    'lot_id': lot_id,
+                    'location': location_id,
+                    'compute_child': True,
+                })
+                qty_available_before_done = product_pool.read(
+                    cr, uid,
+                    [product_id], ['qty_available'],
+                    context=ctx)[0]['qty_available']
+                default_uom_id = product_data['uom_id'][0]
+                qty_computed = product_uom_obj._compute_qty(
+                    cr, uid, product_uom, product_qty, default_uom_id)
+                qty_available_after_done = \
+                    qty_available_before_done - qty_computed
+                if qty_available_after_done < 0:
+                    lot_msg_str = ""
+                    if lot_id:
+                        lot_data = lot_pool.read(
+                            cr, uid,
+                            [lot_id], ['name'],
+                            context=context)[0]
+                        lot_msg_str = _(
+                            " with the lot/serial '%s' "
+                        ) % lot_data['name']
+                    raise exceptions.ValidationError(_(
+                        "Product '%s' has active "
+                        "'check no negative' \n"
+                        "but with this move "
+                        "you will have a quantity of "
+                        "'%s' \n%sin location \n'%s'"
+                    ) % (product_data['name'],
+                         qty_available_after_done,
+                         lot_msg_str,
+                         location_data['complete_name'],))
+        return True

--- a/stock_no_negative/views/product_template.xml
+++ b/stock_no_negative/views/product_template.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_product_no_negative_form" model="ir.ui.view">
+            <field name="name">view.product.no.negative.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="stock.view_template_property_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='virtual_available']" position="after">
+                    <field name='check_no_negative'/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
This two modules were added by @moylop260 to control product serial lot number with a unique relation, adding a restriction to avoid stock moves with quantity different than 1, as the module describes and discussed in this old PR https://github.com/OCA/stock-logistics-workflow/pull/64. This is an up-to-date modules, adapted to api 8.0 waiting for merge in the pull request pointed before 
@pedrobaeza @gurneyalex @nhomar 
