### PR TITLE
fix: no name attribute on field definitions

### DIFF
--- a/stock_picking_package_preparation/model/stock_picking_package_preparation.py
+++ b/stock_picking_package_preparation/model/stock_picking_package_preparation.py
@@ -118,7 +118,7 @@ class StockPickingPackagePreparation(models.Model):
         relation='stock_quant_pack_prepare_rel',
         column1='stock_picking_package_preparation_id',
         column2='stock_quant_id',
-        name='All Content',
+        string='All Content',
     )
 
     @api.one


### PR DESCRIPTION
Sometimes, this seems to cause frontent crashes when creating
preparations. No idea why other times it seems to work fine.

ping @guewen @fclementic2c
