### PR TITLE
7.0 ADD stock_picking_back2binvoiced

### DIFF
--- a/stock_picking_back2binvoiced/README.rst
+++ b/stock_picking_back2binvoiced/README.rst
@@ -1,0 +1,32 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Stock Picking Back2Invoiced
+===========================
+
+If an invoice is created from a picking, when you delete it, the picking
+will be back to '2binvoiced' state. So you will be able to generate a 
+new invoice.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Florian da Costa <florian.dacosta@akretion.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/stock_picking_back2binvoiced/__init__.py
+++ b/stock_picking_back2binvoiced/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#  licence AGPL version 3 or later
+#  see licence in __openerp__.py or http://www.gnu.org/licenses/agpl-3.0.txt
+#  Copyright (C) 2015 Akretion (http://www.akretion.com).
+#  @author Florian da Costa <florian.dacosta@akretion.com>
+#
+##############################################################################
+
+from . import invoice

--- a/stock_picking_back2binvoiced/__openerp__.py
+++ b/stock_picking_back2binvoiced/__openerp__.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) All Rights Reserved 2015 Akretion
+#    @author Florian da Costa <florian.dacosta@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+
+{
+    'name': 'Stock Picking Back2Invoiced',
+    'version': '0.1',
+    'author': "Akretion,Odoo Community Association (OCA)",
+    'category': 'Warehouse Management',
+    'depends': [
+        'stock_picking_invoice_link',
+    ],
+    'summary': 'Put the picking back to 2binvoiced state',
+    'website': 'http://www.akretion.com/',
+    'description': """
+Stock Picking Back2Invoiced
+===========================
+If an invoice is created from a picking, when you delete it, the picking
+will be back to '2binvoiced' state. So you will be able to generate a
+new invoice.
+
+Contributors
+------------
+* Florian da Costa <florian.dacosta@akretion.com>
+
+""",
+    'license': 'AGPL-3',
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+}

--- a/stock_picking_back2binvoiced/invoice.py
+++ b/stock_picking_back2binvoiced/invoice.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#############################################################################
+#
+#  licence AGPL version 3 or later
+#  see licence in __openerp__.py or http://www.gnu.org/licenses/agpl-3.0.txt
+#  Copyright (C) 2015 Akretion (http://www.akretion.com).
+#  @author Florian da Costa <florian.dacosta@akretion.com>
+#
+#############################################################################
+
+from openerp.osv import orm
+
+
+class AccountInvoice(orm.Model):
+    _inherit = "account.invoice"
+
+    def unlink(self, cr, uid, ids, context=None):
+        picking_ids = []
+        invoices = self.read(cr, uid, ids, ['picking_ids'], context=context)
+        for inv in invoices:
+            if inv['picking_ids']:
+                picking_ids += inv['picking_ids']
+        res = super(AccountInvoice, self).unlink(
+            cr, uid, ids, context=context)
+        self.pool['stock.picking'].write(
+            cr, uid, picking_ids, {'invoice_state': '2binvoiced'})
+        return res


### PR DESCRIPTION
Add a very small module which change the invoice state of pickings when an invoice is deleted.
It depends of stock_picking_invoice_link.

I think it could be directly inside the module stock_picking_invoice_link, but I don't know it all users would want this feature.
But I can make another PR to put it inside the existing module instead of creating a new one.
