### PR TITLE
[IMP] Fix typo in link to Github repository

### DIFF
--- a/stock_no_negative/README.rst
+++ b/stock_no_negative/README.rst
@@ -42,10 +42,10 @@ Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/
-stock-logictics-workflow/issues>`_.
+stock-logistics-workflow/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
-stock-logictics-workflow/issues/new?body=module:%20
+stock-logistics-workflow/issues/new?body=module:%20
 stock_no_negative%0Aversion:%20
 8.0.1.0.10A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 


### PR DESCRIPTION
Link to repository has an typo in stock_no_negative/README.rst 
