### PR TITLE
[ADD] procurement_jit_assign_move

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE=procurement_jit_assign_move
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE=procurement_jit_assign_move
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE=procurement_jit_assign_move
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE=procurement_jit_assign_move
 
 virtualenv:
   system_site_packages: true

--- a/procurement_jit_assign_move/README.rst
+++ b/procurement_jit_assign_move/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================================
+Procurement JIT: assign stock moves
+===================================
+
+This module extends the functionality of procurement_jit to assign moves for
+make to stock procurements.
+
+This compensates the change of behavior reported in
+https://github.com/odoo/odoo/issues/7773 which is specific to 8.0 (we get back
+the feature of 7.0, and 9.0 switched back to this behavior.
+
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/154/8.0
+
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/stock-logistics-workflow/issues/new?body=module:%20procurement_jit_assign_move%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Alexandre Fayolle <alexandre.fayolle@camptocam.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/procurement_jit_assign_move/__init__.py
+++ b/procurement_jit_assign_move/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/procurement_jit_assign_move/__openerp__.py
+++ b/procurement_jit_assign_move/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# © 2015 Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Procurement Jit assign stock moves",
+    "summary": "Change the behavior of procurement_jit to assign stock moves",
+    "version": "8.0.1.0.0",
+    "category": "Base",
+    "website": "https://odoo-community.org/",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "procurement_jit_stock",
+    ],
+}

--- a/procurement_jit_assign_move/models/__init__.py
+++ b/procurement_jit_assign_move/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import stock_move

--- a/procurement_jit_assign_move/models/stock_move.py
+++ b/procurement_jit_assign_move/models/stock_move.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2015 Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    @api.multi
+    def action_confirm(self):
+        res = super(StockMove, self).action_confirm()
+        make_to_stock_moves = self.filtered(
+            lambda x: x.procure_method == 'make_to_stock'
+        )
+        make_to_stock_moves.action_assign()
+        return res

--- a/procurement_jit_assign_move/tests/__init__.py
+++ b/procurement_jit_assign_move/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_procurement

--- a/procurement_jit_assign_move/tests/test_procurement.py
+++ b/procurement_jit_assign_move/tests/test_procurement.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# © 2015 Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from openerp import fields
+
+
+class ProcurementTest(TransactionCase):
+
+    def test_procurement_jit_again(self):
+        values = {'company_id': self.env.ref('base.main_company').id,
+                  'date_planned': fields.Datetime.now(),
+                  'name': 'SOME/TEST/0001',
+                  'product_id': self.env.ref('product.product_product_16').id,
+                  'product_qty': 4,
+                  'product_uom': self.env.ref('product.product_uom_unit').id,
+                  'product_uos_qty': 0,
+                  }
+        proc = self.env['procurement.order'].create(values)
+        self.assertEqual(proc.state, 'exception')


### PR DESCRIPTION
This module changes the behavior of procurement_jit in 8.0 to avoid having
manually check availability on all the stock pickings.

See https://github.com/odoo/odoo/issues/7773 for details
