### PR TITLE
[FIX] stock_split_picking: Fixed "split" when spliting move lines in stock.picking

### DIFF
--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -29,10 +29,10 @@ class StockMove(models.Model):
     _inherit = 'stock.move'
 
     @api.model
-    def check_after_action_done(self, operation_or_move, lot_id):
+    def check_after_action_done(self, operation_or_move):
         super(StockMove, self).\
-            check_after_action_done(operation_or_move, lot_id)
-        return self.check_unicity_qty_available(operation_or_move, lot_id)
+            check_after_action_done(operation_or_move)
+        return self.check_unicity_qty_available(operation_or_move)
 
     @api.multi
     def check_unicity_move_qty(self):
@@ -52,26 +52,22 @@ class StockMove(models.Model):
                         ) % (move.product_id.name))
 
     @api.model
-    def check_unicity_qty_available(self, operation_or_move, lot_id):
+    def check_unicity_qty_available(self, operation_or_move):
         """
-        Check quantity on hand to verify that has qty = 1
+        Check quantity on lot to verify that has qty = 1
         if 'lot unique' is ok on product
         """
+        lot_id = operation_or_move.lot_id
         if operation_or_move.product_id.lot_unique_ok and lot_id:
-            ctx = self.env.context.copy()
-            ctx.update({'lot_id': lot_id})
-            product_ctx = self.env['product.product'].browse(
-                operation_or_move.product_id.id)[0]
-            qty = product_ctx.qty_available
-            if not 0 <= qty <= 1:
-                lot = self.env['stock.production.lot'].browse(lot_id)[0]
+            qty = sum([x.qty for x in operation_or_move.lot_id.quant_ids])
+            if qty > 1:
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "
                     "'unique lot'\n"
                     "but with this move "
                     "you will have a quantity of "
                     "'%s' in lot '%s'"
-                ) % (operation_or_move.product_id.name, qty, lot.name))
+                ) % (operation_or_move.product_id.name, qty, lot_id.name))
         return True
 
     @api.model

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -74,8 +74,8 @@ class StockMove(models.Model):
         Check quantity on lot to verify that has qty = 1
         if 'lot unique' is ok on product
         """
-        lot_id = operation_or_move.lot_id
-        if operation_or_move.product_id.lot_unique_ok and lot_id:
+        lot = operation_or_move.lot_id
+        if operation_or_move.product_id.lot_unique_ok and lot:
             qty = sum([x.qty + x.propagated_from_id.qty
                        for x in operation_or_move.lot_id.quant_ids])
             if qty != 1 or operation_or_move.product_qty != 1:
@@ -85,7 +85,7 @@ class StockMove(models.Model):
                     "but with this move "
                     "you will have a quantity of "
                     "'%s' in lot '%s'"
-                ) % (operation_or_move.product_id.name, qty, lot_id.name))
+                ) % (operation_or_move.product_id.name, qty, lot.name))
         return True
 
     @api.model

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -61,7 +61,6 @@ class StockMove(models.Model):
         if operation_or_move.product_id.lot_unique_ok and lot_id:
             qty = sum([x.qty for x in operation_or_move.lot_id.quant_ids])
             if not 0 <= qty <= 1:
-                import pdb; pdb.set_trace()
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "
                     "'unique lot'\n"

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -51,7 +51,6 @@ class StockMove(models.Model):
                 ))
         return res
 
-
     @api.multi
     def check_unicity_move_qty(self):
         """
@@ -77,7 +76,8 @@ class StockMove(models.Model):
         """
         lot_id = operation_or_move.lot_id
         if operation_or_move.product_id.lot_unique_ok and lot_id:
-            qty = sum([x.qty + x.propagated_from_id.qty for x in operation_or_move.lot_id.quant_ids])
+            qty = sum([x.qty + x.propagated_from_id.qty
+                       for x in operation_or_move.lot_id.quant_ids])
             if qty != 1 or operation_or_move.product_qty != 1:
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -60,7 +60,8 @@ class StockMove(models.Model):
         lot_id = operation_or_move.lot_id
         if operation_or_move.product_id.lot_unique_ok and lot_id:
             qty = sum([x.qty for x in operation_or_move.lot_id.quant_ids])
-            if qty > 1:
+            if not 0 <= qty <= 1:
+                import pdb; pdb.set_trace()
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "
                     "'unique lot'\n"

--- a/product_unique_serial/tests/test_for_unicity.py
+++ b/product_unique_serial/tests/test_for_unicity.py
@@ -262,49 +262,9 @@ class TestUnicity(TransactionCase):
                 picking_1,
                 [self.env.ref('product_unique_serial.serial_number_demo_2')])
 
-    def test_4_1product_qty3_3serialnumber_1p_in(self):
+    def test_4_1product_1serialnumber_2p_internal(self):
         """
-        Test 4. Creating a picking with 1 product for three serial numbers,
-        in the receipts scope, with the next form:
-        - Picking 1
-        =============================================
-        || Product ||  Quantity  ||  Serial Number ||
-        =============================================
-        ||    A    ||      1     ||      001       ||
-        =============================================
-        ||    A    ||      1     ||      002       ||
-        =============================================
-        ||    A    ||      1     ||      003       ||
-        =============================================
-        Warehouse: Your Company
-        """
-        # Creating move line for picking
-        product = self.env.ref('product_unique_serial.product_demo_1')
-        stock_move_datas = [
-            {'product_id': product.id, 'qty': 1.0},
-            {'product_id': product.id, 'qty': 1.0},
-            {'product_id': product.id, 'qty': 1.0}
-        ]
-        # Creating the picking
-        picking_data_in = {
-            'name': 'Test Picking IN 1',
-        }
-        picking_in = self.create_stock_picking(
-            stock_move_datas, picking_data_in,
-            self.env.ref('stock.picking_type_in'))
-        # Executing the wizard for pickings transfering: this should be correct
-        # 'cause is the ideal case
-        with self.assertRaises(ValidationError):
-            self.transfer_picking(
-                picking_in,
-                [self.env.ref('product_unique_serial.serial_number_demo_1'),
-                 self.env.ref('product_unique_serial.serial_number_demo_2'),
-                 self.env.ref('product_unique_serial.serial_number_demo_3')]
-            )
-
-    def test_5_1product_1serialnumber_2p_internal(self):
-        """
-        Test 5. Creating 2 pickings with 1 product for the same serial number,
+        Test 4. Creating 2 pickings with 1 product for the same serial number,
         in the internal scope, with the next form:
         - Picking 1
         =============================================
@@ -365,9 +325,9 @@ class TestUnicity(TransactionCase):
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
 
     @mute_logger('openerp.sql_db')
-    def test_6_1serialnumber_1product_2records(self):
+    def test_5_1serialnumber_1product_2records(self):
         """
-        Test 7. Creating 2 identical serial numbers
+        Test 5. Creating 2 identical serial numbers
         """
         product_id = self.env.ref('product_unique_serial.product_demo_1')
         lot_data = {

--- a/stock_no_negative/models/stock_move.py
+++ b/stock_no_negative/models/stock_move.py
@@ -51,7 +51,7 @@ class StockMove(models.Model):
         return operations
 
     def check_after_action_done(self, cr, uid, operation_or_move,
-                                lot_id=None, context=None):
+                                context=None):
         """
         Method to check operation or move plus lot_id
         easiest inherit cases after action done
@@ -99,10 +99,8 @@ class StockMove(models.Model):
             cr, uid, ids, context=context)
 
         for operation in operations_after_done:
-            lot_id = operation.lot_id.id if operation.lot_id else False
-
             self.check_after_action_done(
-                cr, uid, operation, lot_id, context=context)
+                cr, uid, operation, context=context)
         return res
 
     def check_before_done_no_negative(

--- a/stock_no_negative/models/stock_move.py
+++ b/stock_no_negative/models/stock_move.py
@@ -59,7 +59,7 @@ class StockMove(models.Model):
         return True
 
     def check_before_action_done(self, cr, uid, operation_or_move,
-                                 lot_id=None, context=None):
+                                 context=None):
         """
         Method to check operation or move plus lot_id
         easiest inherit cases before action done
@@ -69,7 +69,7 @@ class StockMove(models.Model):
             operation_or_move.product_uom_id.id,
             operation_or_move.product_qty,
             operation_or_move.location_id.id,
-            lot_id=lot_id,
+            lot_id=operation_or_move.lot_id.id,
             context=context)
         return True
 
@@ -86,10 +86,9 @@ class StockMove(models.Model):
             cr, uid, ids, context=context)
 
         for operation in operations_before_done:
-            lot_id = operation.lot_id.id if operation.lot_id else False
 
             self.check_before_action_done(
-                cr, uid, operation, lot_id, context=context)
+                cr, uid, operation, context=context)
 
         res = super(StockMove, self).action_done(
             cr, uid, ids, context=context)

--- a/stock_split_picking/__openerp__.py
+++ b/stock_split_picking/__openerp__.py
@@ -31,7 +31,8 @@
  'data': ['view/stock_partial_picking.xml'],
  'demo': [],
  'test': ['test/test_picking_split.yml',
-          'test/test_assigned_picking_split.yml'],
+          'test/test_assigned_picking_split.yml',
+          'test/test_picking_split_two_move_lines.yml'],
  'installable': True,
  'auto_install': False,
  }

--- a/stock_split_picking/model/stock.py
+++ b/stock_split_picking/model/stock.py
@@ -64,8 +64,6 @@ class StockMove(models.Model):
         moves = move + new_move
         if move.reserved_availability > move.product_qty:
             moves.do_unreserve()
-        if move.picking_id:
-            move.picking_id.pack_operation_ids.unlink()
         if move_assigned:
             moves.action_assign()
         else:

--- a/stock_split_picking/test/test_picking_split_two_move_lines.yml
+++ b/stock_split_picking/test/test_picking_split_two_move_lines.yml
@@ -1,0 +1,111 @@
+-
+  In order to test stock picking out spliting with two move lines
+  I have to ensure when I split out picking, related backorder is not in state done
+-
+  I create two products for my tests
+-
+  !record {model: product.product, id: product_gameboy_color}:
+    categ_id: product.product_category_1
+    name: GameBoyColor
+    type: product
+    uom_id: product.product_uom_unit
+    uom_po_id: product.product_uom_unit
+    property_stock_inventory: stock.location_inventory
+    property_stock_procurement: stock.location_procurement
+    property_stock_production: stock.location_production
+-
+  !record {model: product.product, id: product_gameboy_advance}:
+    categ_id: product.product_category_1
+    name: GameBoyAdvance
+    type: product
+    uom_id: product.product_uom_unit
+    uom_po_id: product.product_uom_unit
+    property_stock_inventory: stock.location_inventory
+    property_stock_procurement: stock.location_procurement
+    property_stock_production: stock.location_production
+-
+  I add some stock for the products
+-
+ !python {model: stock.change.product.qty}: |
+    data = {'product_id': ref('product_gameboy_color'),
+            'new_quantity': 130,
+            'location_id': ref('stock.stock_location_stock'),
+            }
+    id = self.create(cr, uid, data, context=context)
+    self.change_product_qty(cr, uid, [id], context=context)
+-
+ !python {model: stock.change.product.qty}: |
+    data = {'product_id': ref('product_gameboy_advance'),
+            'new_quantity': 130,
+            'location_id': ref('stock.stock_location_stock'),
+            }
+    id = self.create(cr, uid, data, context=context)
+    self.change_product_qty(cr, uid, [id], context=context)
+-
+  I create a manual stock picking out with two move lines
+-
+ !record {model: stock.picking, id: outgoing_shipment_gameboys}:
+    picking_type_id: stock.picking_type_out
+    origin: 'outgoing shipment main_warehouse'
+    partner_id: base.res_partner_6
+    move_lines:
+      - product_id: product_gameboy_color
+        product_uom: product.product_uom_unit
+        product_uom_qty: 130.0
+        product_uos_qty: 130.0
+        picking_type_id: stock.picking_type_out
+        location_id: stock.stock_location_stock
+        location_dest_id: stock.stock_location_7
+      - product_id: product_gameboy_advance
+        product_uom: product.product_uom_unit
+        product_uom_qty: 130.0
+        product_uos_qty: 130.0
+        picking_type_id: stock.picking_type_out
+        location_id: stock.stock_location_stock
+        location_dest_id: stock.stock_location_7
+-
+  I reserve  the picking
+-
+ !python {model: stock.picking, id: outgoing_shipment_gameboys}: |
+     self.action_assign()
+-
+  Then I split my shipment
+-
+  !python {model: stock.transfer_details}: |
+    context.update({'active_model': 'stock.picking',
+                    'active_id': ref('outgoing_shipment_gameboys'),
+                    'active_ids': [ref('outgoing_shipment_gameboys')]})
+-
+  !record {model: stock.transfer_details, id: partial_pick_gameboys}:
+    picking_id: outgoing_shipment_gameboys
+    item_ids:
+        - quantity: 40
+          product_id: product_gameboy_color
+          product_uom_id: product.product_uom_unit
+          sourceloc_id: stock.stock_location_stock
+          destinationloc_id: stock.stock_location_7
+        - quantity: 40
+          product_id: product_gameboy_advance
+          product_uom_id: product.product_uom_unit
+          sourceloc_id: stock.stock_location_stock
+          destinationloc_id: stock.stock_location_7
+-
+  !python {model: stock.transfer_details}: |
+    wiz = self.browse(cr, uid, ref("partial_pick_gameboys"))
+    wiz.with_context(do_only_split=True).do_detailed_transfer()
+-
+  I check that the backorder has two lines with 40 units and the state set to assigned, not done
+-
+  !python {model: stock.picking, id: outgoing_shipment_gameboys}: |
+    # we switch self and backorder to mimick what Odoo is doing
+    # When creating a backorder
+    self = self.search([('backorder_id', '=', self.id)])
+    backorder = self.backorder_id
+    assert backorder, "Backorder should be created after partial split."
+    assert backorder.state == 'assigned', "Backorder should be assigned, not %r." % backorder.state
+    for move_line in backorder.move_lines:
+        assert move_line.product_qty == 40, "Qty in backorder does not correspond."
+        assert move_line.state == 'assigned', "Move line of backorder should be assigned, not %r." % move_line.state
+    for move_line in self.move_lines:
+        assert move_line.product_qty == 90, "Qty in backorder does not correspond."
+        assert move_line.state == 'assigned', "Move line of backorder should be assigned, not %r." % move_line.state


### PR DESCRIPTION
Fixed a bug in the function `split` which ignored all the records in
`pack_operation_ids` except the first. Fixes issue #175.
