### PR TITLE
[8.0] stock_ownership_availability_rules : product change quantity

### DIFF
--- a/stock_ownership_availability_rules/model/__init__.py
+++ b/stock_ownership_availability_rules/model/__init__.py
@@ -2,3 +2,4 @@
 
 from . import quant
 from . import product
+from . import stock_change_product_qty

--- a/stock_ownership_availability_rules/model/stock_change_product_qty.py
+++ b/stock_ownership_availability_rules/model/stock_change_product_qty.py
@@ -23,4 +23,3 @@ class StockChangeProductQty(models.TransientModel):
         )
 
         return line_data
-

--- a/stock_ownership_availability_rules/model/stock_change_product_qty.py
+++ b/stock_ownership_availability_rules/model/stock_change_product_qty.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, models
+
+
+class StockChangeProductQty(models.TransientModel):
+    _inherit = "stock.change.product.qty"
+
+    @api.model
+    def _finalize_inventory_line(self, data):
+        line_data = super(StockChangeProductQty,
+                          self)._finalize_inventory_line(data)
+
+        Company = self.env['res.company']
+        location = data.location_id
+        line_data['partner_id'] = (
+            location.partner_id.id or
+            location.company_id.partner_id.id or
+            Company.browse(
+                Company._company_default_get('stock.quant')
+            ).partner_id.id
+        )
+
+        return line_data

--- a/stock_ownership_availability_rules/model/stock_change_product_qty.py
+++ b/stock_ownership_availability_rules/model/stock_change_product_qty.py
@@ -9,10 +9,9 @@ class StockChangeProductQty(models.TransientModel):
     _inherit = "stock.change.product.qty"
 
     @api.model
-    def _finalize_inventory_line(self, data):
+    def _prepare_inventory_line(self, inventory_id, data):
         line_data = super(StockChangeProductQty,
-                          self)._finalize_inventory_line(data)
-
+                          self)._prepare_inventory_line(inventory_id, data)
         Company = self.env['res.company']
         location = data.location_id
         line_data['partner_id'] = (
@@ -24,3 +23,4 @@ class StockChangeProductQty(models.TransientModel):
         )
 
         return line_data
+

--- a/stock_ownership_availability_rules/tests/__init__.py
+++ b/stock_ownership_availability_rules/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_delivery_without_owner
 from . import test_delivery_with_company_owner
 from . import test_delivery_with_owner
 from . import test_default_quant_owner
+from . import test_change_product

--- a/stock_ownership_availability_rules/tests/test_change_product.py
+++ b/stock_ownership_availability_rules/tests/test_change_product.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import openerp.tests.common as common
+
+
+class TestChangeProduct(common.TransactionCase):
+
+    def test_product_change_qty(self):
+        """ Inventory product quantity to 3
+            Check product quantity is 3
+            Change product quantity to 5
+            Check product quantity is 5
+        """
+
+        myProduct = self.env.ref('product.product_product_37')
+        myLocation = self.env.ref('stock.stock_location_14')
+
+        inventory = self.env['stock.inventory'].create(
+            {'name': 'Inventory Product %s' % myProduct.name})
+        self.env['stock.inventory.line'].create(
+            {'inventory_id': inventory.id,
+             'product_id': myProduct.id,
+             'product_uom_id': self.env.ref('product.product_uom_unit').id,
+             'product_qty': 3,
+             'location_id': myLocation.id
+             })
+        inventory.action_done()
+        self.assertEqual(myProduct.qty_available, 3)
+
+        wizard_model = self.env['stock.change.product.qty']
+        wizard = wizard_model.create({'product_id': myProduct.id,
+                                      'location_id': myLocation.id,
+                                      'new_quantity': 5})
+        wizard.change_product_qty()
+        self.assertEqual(myProduct.qty_available, 5)

--- a/stock_ownership_availability_rules/tests/test_default_quant_owner.py
+++ b/stock_ownership_availability_rules/tests/test_default_quant_owner.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #    Author: Leonardo Pistone
 #    Copyright 2014 Camptocamp SA
 #

--- a/stock_ownership_availability_rules/tests/test_delivery_with_company_owner.py
+++ b/stock_ownership_availability_rules/tests/test_delivery_with_company_owner.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #    Author: Leonardo Pistone
 #    Copyright 2014 Camptocamp SA
 #

--- a/stock_ownership_availability_rules/tests/test_delivery_with_owner.py
+++ b/stock_ownership_availability_rules/tests/test_delivery_with_owner.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #    Author: Leonardo Pistone
 #    Copyright 2014 Camptocamp SA
 #

--- a/stock_ownership_availability_rules/tests/test_delivery_without_owner.py
+++ b/stock_ownership_availability_rules/tests/test_delivery_without_owner.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #    Author: Leonardo Pistone
 #    Copyright 2014 Camptocamp SA
 #


### PR DESCRIPTION
The problem is the following :
- use link "update quantity" on product form, set a quantity
- reuse link "update quantity" on product form , set a quantity

The final quantity is the sum instead of the new quantity.

The cause is :
- the created inventory line don't contains the link to the owner,
- all quants  have an owner
- inventory line compute theorical quantity based on quants owner

depends :
- [x] https://github.com/odoo/odoo/pull/10598
