### PR TITLE
[FIX] enforce lot locking when using quick-create in web client

### DIFF
--- a/stock_lock_lot/models/stock_production_lot.py
+++ b/stock_lock_lot/models/stock_production_lot.py
@@ -68,9 +68,12 @@ class StockProductionLot(models.Model):
     # Kept in old API to maintain compatibility
     def create(self, cr, uid, vals, context=None):
         '''Force the locking/unlocking, ignoring the value of 'locked'.'''
-        product = self.pool['product.product'].browse(
-            cr, uid, vals.get('product_id'))
-        vals['locked'] = self._get_product_locked(product)
+        #  Web quick-create doesn't provide product_id in vals, but in context
+        product_id = vals.get('product_id', context.get('product_id', False))
+        if product_id:
+            vals['locked'] = self._get_product_locked(
+                self.pool['product.product'].browse(
+                    cr, uid, product_id, context=context))
         return super(StockProductionLot, self).create(
             cr, uid, vals, context=context)
 


### PR DESCRIPTION
In the web client, if you type a new lot name and select "create" from the pop-up menu, the client calls the `create()` method with only the name attribute. All the other fields must be passed in the context.
As a consequence, stock_lock_lot silently failed to block the lots because it didn't find the product.
Fix it by looking for a product id in both the create values and the context.
