### PR TITLE
[8.0] stock_ownership_availability_rules: update restrict_partner_id

### DIFF
--- a/stock_ownership_availability_rules/model/quant.py
+++ b/stock_ownership_availability_rules/model/quant.py
@@ -71,6 +71,9 @@ class Quant(models.Model):
         if not restrict_partner_id:
             restrict_partner_id = (location.partner_id.id or
                                    location.company_id.partner_id.id)
+        if not restrict_partner_id:
+            # location can be customer, so use partner from user company
+            restrict_partner_id = self.env.user.company_id.partner_id.id
 
         domain += [
             ('owner_id', '=', restrict_partner_id),

--- a/stock_ownership_availability_rules/tests/test_delivery_without_owner.py
+++ b/stock_ownership_availability_rules/tests/test_delivery_without_owner.py
@@ -43,6 +43,19 @@ class TestDeliveryWithoutOwner(TransactionCase):
         self.move.product_uom_qty = 80
         self.picking.action_assign()
         self.assertEqual('assigned', self.picking.state)
+        # finalize picking
+        self.picking.do_prepare_partial()
+        self.picking.do_transfer()
+        self.assertEqual('done', self.picking.state)
+        # return picking
+        return_pick_wiz = self.env['stock.return.picking'].with_context(
+            active_id=self.picking.id, active_ids=[self.picking.id]).create({})
+        return_pick_id = int(
+            return_pick_wiz.create_returns()['domain'].
+            split('[')[2].split(']')[0])
+        return_picking = self.env['stock.picking'].browse(return_pick_id)
+        return_picking.action_assign()
+        self.assertEqual('assigned', return_picking.state)
 
     def test_it_partially_reserves_my_stock(self):
         self.move.product_uom_qty = 150


### PR DESCRIPTION
When search prefered quants, there is some cases where location is not attached to a company or a partner. For example the location "Customers".
