### PR TITLE
Add "Cancel availability" option on mass assign

### DIFF
--- a/stock_picking_mass_assign/i18n/de.po
+++ b/stock_picking_mass_assign/i18n/de.po
@@ -26,6 +26,11 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 #. module: stock_picking_mass_assign
+#: model:ir.actions.act_window,name:stock_picking_mass_assign.action_cancel_availability_all
+msgid "Cancel Availability"
+msgstr "Verwerfe Verfügbarkeit"
+
+#. module: stock_picking_mass_assign
 #: model:ir.actions.act_window,name:stock_picking_mass_assign.action_check_assign_all
 #: field:stock.picking.check.assign.all,check_availability:0
 msgid "Check Availability"

--- a/stock_picking_mass_assign/i18n/fr.po
+++ b/stock_picking_mass_assign/i18n/fr.po
@@ -26,6 +26,11 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #. module: stock_picking_mass_assign
+#: model:ir.actions.act_window,name:stock_picking_mass_assign.action_cancel_availability_all
+msgid "Cancel Availability"
+msgstr "Annuler la disponibilité"
+
+#. module: stock_picking_mass_assign
 #: model:ir.actions.act_window,name:stock_picking_mass_assign.action_check_assign_all
 #: field:stock.picking.check.assign.all,check_availability:0
 msgid "Check Availability"

--- a/stock_picking_mass_assign/i18n/stock_picking_mass_assign.pot
+++ b/stock_picking_mass_assign/i18n/stock_picking_mass_assign.pot
@@ -26,6 +26,11 @@ msgid "Cancel"
 msgstr ""
 
 #. module: stock_picking_mass_assign
+#: model:ir.actions.act_window,name:stock_picking_mass_assign.action_cancel_availability_all
+msgid "Cancel Availability"
+msgstr ""
+
+#. module: stock_picking_mass_assign
 #: model:ir.actions.act_window,name:stock_picking_mass_assign.action_check_assign_all
 #: field:stock.picking.check.assign.all,check_availability:0
 msgid "Check Availability"

--- a/stock_picking_mass_assign/wizard/check_assign_all_view.xml
+++ b/stock_picking_mass_assign/wizard/check_assign_all_view.xml
@@ -9,6 +9,7 @@
               <group>
                   <field name="check_availability"/>
                   <field name="force_availability"/>
+                  <field name="cancel_availability"/>
                   <field name="process_picking"/>
                   <field name="create_invoice"/>
               </group>
@@ -54,6 +55,25 @@
       <field name="name">Force Availability</field>
       <field name="key2">client_action_multi</field>
       <field name="value" eval="'ir.actions.act_window,' + str(ref('action_force_availability_all'))"/>
+      <field name="key">action</field>
+      <field name="model">stock.picking.out</field>
+    </record>
+
+<!-- Cancel Availability Action -->
+    <record id="action_cancel_availability_all" model="ir.actions.act_window">
+      <field name="name">Cancel Availability</field>
+      <field name="res_model">stock.picking.check.assign.all</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="target">new</field>
+      <field name="context">{'cancel_availability': 1}</field>
+    </record>
+
+    <record id="action_cancel_availability_all_values" model="ir.values">
+      <field name="model_id" ref="stock.model_stock_picking_out" />
+      <field name="name">Cancel Availability</field>
+      <field name="key2">client_action_multi</field>
+      <field name="value" eval="'ir.actions.act_window,' + str(ref('action_cancel_availability_all'))"/>
       <field name="key">action</field>
       <field name="model">stock.picking.out</field>
     </record>


### PR DESCRIPTION
This PR is to add another option to the stock.picking mass assign, "cancel availability", which allows to change "Available" pickings to "Waiting Availability", with a checkbox, an action for default value, and translations.
