### PR TITLE
[7.0] add cancel assign all

### DIFF
--- a/picking_dispatch/__openerp__.py
+++ b/picking_dispatch/__openerp__.py
@@ -38,6 +38,7 @@
                 'wizard/create_dispatch_view.xml',
                 'wizard/dispatch_assign_picker_view.xml',
                 'wizard/dispatch_start_view.xml',
+                'wizard/cancel_assign_all_view.xml',
                 'wizard/check_assign_all_view.xml',
                 'report.xml',
                 'cron_data.xml',

--- a/picking_dispatch/i18n/de.po
+++ b/picking_dispatch/i18n/de.po
@@ -74,6 +74,17 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 #. module: picking_dispatch
+#: model:ir.actions.act_window,name:picking_dispatch.action_dispatch_cancel_assign_all
+#: view:picking.dispatch.cancel.assign.all:0
+msgid "Cancel Availability"
+msgstr "Verwerfe Verfügbarkeit"
+
+#. module: picking_dispatch
+#: view:picking.dispatch.cancel.assign.all:0
+msgid "Cancel the availability of the selected dispatches"
+msgstr "Verfügbarkeit der ausgewählten Sendungen verwerfen"
+
+#. module: picking_dispatch
 #: selection:picking.dispatch,state:0
 msgid "Cancelled"
 msgstr "Abgebrochen"

--- a/picking_dispatch/i18n/fr.po
+++ b/picking_dispatch/i18n/fr.po
@@ -77,6 +77,17 @@ msgid "Cancel"
 msgstr "Annulé"
 
 #. module: picking_dispatch
+#: model:ir.actions.act_window,name:picking_dispatch.action_dispatch_cancel_assign_all
+#: view:picking.dispatch.cancel.assign.all:0
+msgid "Cancel Availability"
+msgstr "Annuler la disponibilité"
+
+#. module: picking_dispatch
+#: view:picking.dispatch.cancel.assign.all:0
+msgid "Cancel the availability of the selected dispatches"
+msgstr "Annuler la disponibilité sur les bons de préparation sélectionnés"
+
+#. module: picking_dispatch
 #: selection:picking.dispatch,state:0
 msgid "Cancelled"
 msgstr "Annulé"

--- a/picking_dispatch/i18n/picking_dispatch.pot
+++ b/picking_dispatch/i18n/picking_dispatch.pot
@@ -77,6 +77,17 @@ msgid "Cancel"
 msgstr ""
 
 #. module: picking_dispatch
+#: model:ir.actions.act_window,name:picking_dispatch.action_dispatch_cancel_assign_all
+#: view:picking.dispatch.cancel.assign.all:0
+msgid "Cancel Availability"
+msgstr ""
+
+#. module: picking_dispatch
+#: view:picking.dispatch.cancel.assign.all:0
+msgid "Cancel the availability of the selected dispatches"
+msgstr ""
+
+#. module: picking_dispatch
 #: selection:picking.dispatch,state:0
 msgid "Cancelled"
 msgstr ""

--- a/picking_dispatch/wizard/__init__.py
+++ b/picking_dispatch/wizard/__init__.py
@@ -22,3 +22,4 @@ from . import create_dispatch
 from . import dispatch_assign_picker
 from . import dispatch_start
 from . import check_assign_all
+from . import cancel_assign_all

--- a/picking_dispatch/wizard/cancel_assign_all.py
+++ b/picking_dispatch/wizard/cancel_assign_all.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+from openerp.tools.translate import _
+
+
+class cancel_assign_all(orm.TransientModel):
+    _name = 'picking.dispatch.cancel.assign.all'
+    _description = 'Picking Dispatch Cancel Availability'
+
+    def cancel_availability(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+
+        dispatch_ids = context.get('active_ids')
+        if not dispatch_ids:
+            raise orm.except_orm(
+                _('Error'),
+                _('No selected dispatch'))
+
+        move_obj = self.pool['stock.move']
+        move_ids = move_obj.search(
+            cr, uid, [('dispatch_id', 'in', dispatch_ids),
+                      ('state', '=', 'assigned')], context=context)
+        move_obj.cancel_assign(cr, uid, move_ids, context=context)
+        return {'type': 'ir.actions.act_window_close'}

--- a/picking_dispatch/wizard/cancel_assign_all_view.xml
+++ b/picking_dispatch/wizard/cancel_assign_all_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="0">
+    <record id="view_dispatch_cancel_assign_all" model="ir.ui.view">
+      <field name="name">picking.dispatch.cancel.assign.all.form</field>
+      <field name="model">picking.dispatch.cancel.assign.all</field>
+      <field name="arch" type="xml">
+        <form string="Cancel the availability of the selected dispatches" version="7.0">
+          <footer>
+            <button name="cancel_availability" string="Cancel Availability" type="object" class="oe_highlight"/>
+            or
+            <button string="Cancel" class="oe_link" special="cancel"/>
+          </footer>
+        </form>
+      </field>
+    </record>
+
+    <record id="action_dispatch_cancel_assign_all" model="ir.actions.act_window">
+      <field name="name">Cancel Availability</field>
+      <field name="res_model">picking.dispatch.cancel.assign.all</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="view_id" ref="view_dispatch_cancel_assign_all"/>
+      <field name="target">new</field>
+    </record>
+
+    <record id="action_dispatch_cancel_assign_all_values" model="ir.values">
+      <field name="model_id" ref="model_picking_dispatch" />
+      <field name="name">Cancel Availability</field>
+      <field name="key2">client_action_multi</field>
+      <field name="value" eval="'ir.actions.act_window,' + str(ref('action_dispatch_cancel_assign_all'))"/>
+      <field name="key">action</field>
+      <field name="model">picking.dispatch</field>
+    </record>
+  </data>
+</openerp>
+


### PR DESCRIPTION
This PR adds a "Cancel Availability" action, in order to pass all the 'Available' moves in selected dispatches to 'Waiting Availability'.
