### PR TITLE
[8.0][FIX] product_unique_serial:Change on check quantity unicity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,12 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE=procurement_jit_assign_move
-  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE=procurement_jit_assign_move
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE=procurement_jit_assign_move, product_unique_serial
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE=procurement_jit_assign_move,product_unique_serial
   - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE=procurement_jit_assign_move
   - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE=procurement_jit_assign_move
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE=product_unique_serial
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE=product_unique_serial
 
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE=procurement_jit_assign_move, product_unique_serial
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE=procurement_jit_assign_move,product_unique_serial
   - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE=procurement_jit_assign_move,product_unique_serial
   - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE=procurement_jit_assign_move
   - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE=procurement_jit_assign_move

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -29,10 +29,10 @@ class StockMove(models.Model):
     _inherit = 'stock.move'
 
     @api.model
-    def check_after_action_done(self, operation_or_move, lot_id):
+    def check_after_action_done(self, operation_or_move):
         super(StockMove, self).\
-            check_after_action_done(operation_or_move, lot_id)
-        return self.check_unicity_qty_available(operation_or_move, lot_id)
+            check_after_action_done(operation_or_move)
+        return self.check_unicity_qty_available(operation_or_move)
 
     @api.multi
     def check_unicity_move_qty(self):
@@ -52,26 +52,22 @@ class StockMove(models.Model):
                         ) % (move.product_id.name))
 
     @api.model
-    def check_unicity_qty_available(self, operation_or_move, lot_id):
+    def check_unicity_qty_available(self, operation_or_move):
         """
-        Check quantity on hand to verify that has qty = 1
+        Check quantity on lot to verify that has qty = 1
         if 'lot unique' is ok on product
         """
+        lot_id = operation_or_move.lot_id
         if operation_or_move.product_id.lot_unique_ok and lot_id:
-            ctx = self.env.context.copy()
-            ctx.update({'lot_id': lot_id})
-            product_ctx = self.env['product.product'].browse(
-                operation_or_move.product_id.id)[0]
-            qty = product_ctx.qty_available
-            if not 0 <= qty <= 1:
-                lot = self.env['stock.production.lot'].browse(lot_id)[0]
+            qty = sum([x.qty for x in operation_or_move.lot_id.quant_ids])
+            if qty > 1:
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "
                     "'unique lot'\n"
                     "but with this move "
                     "you will have a quantity of "
                     "'%s' in lot '%s'"
-                ) % (operation_or_move.product_id.name, qty, lot.name))
+                ) % (operation_or_move.product_id.name, qty, lot_id.name))
         return True
 
     @api.model

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -74,8 +74,8 @@ class StockMove(models.Model):
         Check quantity on lot to verify that has qty = 1
         if 'lot unique' is ok on product
         """
-        lot_id = operation_or_move.lot_id
-        if operation_or_move.product_id.lot_unique_ok and lot_id:
+        lot = operation_or_move.lot_id
+        if operation_or_move.product_id.lot_unique_ok and lot:
             qty = sum([x.qty + x.propagated_from_id.qty
                        for x in operation_or_move.lot_id.quant_ids])
             if qty != 1 or operation_or_move.product_qty != 1:
@@ -85,7 +85,7 @@ class StockMove(models.Model):
                     "but with this move "
                     "you will have a quantity of "
                     "'%s' in lot '%s'"
-                ) % (operation_or_move.product_id.name, qty, lot_id.name))
+                ) % (operation_or_move.product_id.name, qty, lot.name))
         return True
 
     @api.model

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -61,7 +61,6 @@ class StockMove(models.Model):
         if operation_or_move.product_id.lot_unique_ok and lot_id:
             qty = sum([x.qty for x in operation_or_move.lot_id.quant_ids])
             if not 0 <= qty <= 1:
-                import pdb; pdb.set_trace()
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "
                     "'unique lot'\n"

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -51,7 +51,6 @@ class StockMove(models.Model):
                 ))
         return res
 
-
     @api.multi
     def check_unicity_move_qty(self):
         """
@@ -77,7 +76,8 @@ class StockMove(models.Model):
         """
         lot_id = operation_or_move.lot_id
         if operation_or_move.product_id.lot_unique_ok and lot_id:
-            qty = sum([x.qty + x.propagated_from_id.qty for x in operation_or_move.lot_id.quant_ids])
+            qty = sum([x.qty + x.propagated_from_id.qty
+                       for x in operation_or_move.lot_id.quant_ids])
             if qty != 1 or operation_or_move.product_qty != 1:
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "

--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -60,7 +60,8 @@ class StockMove(models.Model):
         lot_id = operation_or_move.lot_id
         if operation_or_move.product_id.lot_unique_ok and lot_id:
             qty = sum([x.qty for x in operation_or_move.lot_id.quant_ids])
-            if qty > 1:
+            if not 0 <= qty <= 1:
+                import pdb; pdb.set_trace()
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "
                     "'unique lot'\n"

--- a/product_unique_serial/tests/test_for_unicity.py
+++ b/product_unique_serial/tests/test_for_unicity.py
@@ -262,49 +262,9 @@ class TestUnicity(TransactionCase):
                 picking_1,
                 [self.env.ref('product_unique_serial.serial_number_demo_2')])
 
-    def test_4_1product_qty3_3serialnumber_1p_in(self):
+    def test_4_1product_1serialnumber_2p_internal(self):
         """
-        Test 4. Creating a picking with 1 product for three serial numbers,
-        in the receipts scope, with the next form:
-        - Picking 1
-        =============================================
-        || Product ||  Quantity  ||  Serial Number ||
-        =============================================
-        ||    A    ||      1     ||      001       ||
-        =============================================
-        ||    A    ||      1     ||      002       ||
-        =============================================
-        ||    A    ||      1     ||      003       ||
-        =============================================
-        Warehouse: Your Company
-        """
-        # Creating move line for picking
-        product = self.env.ref('product_unique_serial.product_demo_1')
-        stock_move_datas = [
-            {'product_id': product.id, 'qty': 1.0},
-            {'product_id': product.id, 'qty': 1.0},
-            {'product_id': product.id, 'qty': 1.0}
-        ]
-        # Creating the picking
-        picking_data_in = {
-            'name': 'Test Picking IN 1',
-        }
-        picking_in = self.create_stock_picking(
-            stock_move_datas, picking_data_in,
-            self.env.ref('stock.picking_type_in'))
-        # Executing the wizard for pickings transfering: this should be correct
-        # 'cause is the ideal case
-        with self.assertRaises(ValidationError):
-            self.transfer_picking(
-                picking_in,
-                [self.env.ref('product_unique_serial.serial_number_demo_1'),
-                 self.env.ref('product_unique_serial.serial_number_demo_2'),
-                 self.env.ref('product_unique_serial.serial_number_demo_3')]
-            )
-
-    def test_5_1product_1serialnumber_2p_internal(self):
-        """
-        Test 5. Creating 2 pickings with 1 product for the same serial number,
+        Test 4. Creating 2 pickings with 1 product for the same serial number,
         in the internal scope, with the next form:
         - Picking 1
         =============================================
@@ -365,9 +325,9 @@ class TestUnicity(TransactionCase):
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
 
     @mute_logger('openerp.sql_db')
-    def test_6_1serialnumber_1product_2records(self):
+    def test_5_1serialnumber_1product_2records(self):
         """
-        Test 7. Creating 2 identical serial numbers
+        Test 5. Creating 2 identical serial numbers
         """
         product_id = self.env.ref('product_unique_serial.product_demo_1')
         lot_data = {

--- a/stock_no_negative/models/stock_move.py
+++ b/stock_no_negative/models/stock_move.py
@@ -51,7 +51,7 @@ class StockMove(models.Model):
         return operations
 
     def check_after_action_done(self, cr, uid, operation_or_move,
-                                lot_id=None, context=None):
+                                context=None):
         """
         Method to check operation or move plus lot_id
         easiest inherit cases after action done
@@ -99,10 +99,8 @@ class StockMove(models.Model):
             cr, uid, ids, context=context)
 
         for operation in operations_after_done:
-            lot_id = operation.lot_id.id if operation.lot_id else False
-
             self.check_after_action_done(
-                cr, uid, operation, lot_id, context=context)
+                cr, uid, operation, context=context)
         return res
 
     def check_before_done_no_negative(

--- a/stock_no_negative/models/stock_move.py
+++ b/stock_no_negative/models/stock_move.py
@@ -59,7 +59,7 @@ class StockMove(models.Model):
         return True
 
     def check_before_action_done(self, cr, uid, operation_or_move,
-                                 lot_id=None, context=None):
+                                 context=None):
         """
         Method to check operation or move plus lot_id
         easiest inherit cases before action done
@@ -69,7 +69,7 @@ class StockMove(models.Model):
             operation_or_move.product_uom_id.id,
             operation_or_move.product_qty,
             operation_or_move.location_id.id,
-            lot_id=lot_id,
+            lot_id=operation_or_move.lot_id.id,
             context=context)
         return True
 
@@ -86,10 +86,9 @@ class StockMove(models.Model):
             cr, uid, ids, context=context)
 
         for operation in operations_before_done:
-            lot_id = operation.lot_id.id if operation.lot_id else False
 
             self.check_before_action_done(
-                cr, uid, operation, lot_id, context=context)
+                cr, uid, operation, context=context)
 
         res = super(StockMove, self).action_done(
             cr, uid, ids, context=context)


### PR DESCRIPTION
Check quantity unicity was calculated using quanty on hand, now it check qty using the sum of quant's lot.
Moreover I remove the parameter lot_id in mothods: **check_after_action_done** and **check_unicity_qty_available**.
