### PR TITLE
Enforce strict locking of lots (vs forced availability)

### DIFF
--- a/stock_lock_lot/README.rst
+++ b/stock_lock_lot/README.rst
@@ -20,6 +20,16 @@ To allow a user to block or unblock a Lot:
 #. in the "Warehouse" section, check the box
    "Allow to block/unblock Serial Numbers/Lots"
 
+Optional: enforce strict blocking
+---------------------------------
+By default, users are not allowed to force-move a blocked Serial Number/lot
+by forcing the availability of a stock operation.
+If you do not want to enforce such a strict blocking of Serial Numbers/lots:
+
+#. open the warehouse settings (menu "Configuration > Warehouse")
+#. in the "Lot blocking" section, uncheck the box
+   "Strictly forbid moves on blocked Serial Numbers/lots."
+
 Usage
 =====
 

--- a/stock_lock_lot/__openerp__.py
+++ b/stock_lock_lot/__openerp__.py
@@ -24,6 +24,7 @@
         "views/product_category_view.xml",
         "views/stock_production_lot_view.xml",
         "views/stock_quant_view.xml",
+        "views/res_config_view.xml",
     ],
     "installable": True,
     "license": "AGPL-3",

--- a/stock_lock_lot/data/stock_lock_lot_data.xml
+++ b/stock_lock_lot/data/stock_lock_lot_data.xml
@@ -15,4 +15,10 @@
             <field name="description">Serial Number/lot unblocked</field>
         </record>
     </data>
+    <data noupdate="1">
+        <record forcecreate="True" id="config_parameter_stock_lock_lot_strict" model="ir.config_parameter">
+            <field name="key">stock.lock.lot.strict</field>
+            <field name="value" eval="True"/>
+        </record>
+    </data>
 </openerp>

--- a/stock_lock_lot/models/__init__.py
+++ b/stock_lock_lot/models/__init__.py
@@ -6,3 +6,4 @@
 from . import product_category
 from . import stock_production_lot
 from . import stock_quant
+from . import res_config

--- a/stock_lock_lot/models/res_config.py
+++ b/stock_lock_lot/models/res_config.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class StockConfig(models.TransientModel):
+    """Add an option for strict locking"""
+    _inherit = 'stock.config.settings'
+
+    stock_lock_lot_strict = fields.Boolean(
+        string='Strictly forbid moves on blocked Serial Numbers/lots.',
+        help="When this box is checked, users are not allowed to force the"
+             "availability on blocked Serial Numbers/lots.")
+
+    def _get_parameter(self, key, default=False):
+        param_obj = self.env['ir.config_parameter']
+        rec = param_obj.search([('key', '=', key)])
+        return rec or default
+
+    def _write_or_create_param(self, key, value):
+        param_obj = self.env['ir.config_parameter']
+        rec = self._get_parameter(key)
+        if rec:
+            if not value:
+                rec.unlink()
+            else:
+                rec.value = value
+        elif value:
+            param_obj.create({'key': key, 'value': value})
+
+    @api.multi
+    def get_default_parameter_stock_lock_lot_strict(self):
+        def get_value(key, default=''):
+            rec = self._get_parameter(key)
+            return rec and rec.value or default
+        return {'stock_lock_lot_strict': get_value('stock.lock.lot.strict',
+                                                   False)}
+
+    @api.multi
+    def set_parameter_stock_lock_lot_strict(self):
+        self._write_or_create_param('stock.lock.lot.strict',
+                                    self.stock_lock_lot_strict)

--- a/stock_lock_lot/models/stock_quant.py
+++ b/stock_lock_lot/models/stock_quant.py
@@ -3,7 +3,7 @@
 # © 2015 AvanzOsc (http://www.avanzosc.es)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields
+from openerp import models, fields, api, exceptions, _
 
 
 class StockQuant(models.Model):
@@ -23,3 +23,20 @@ class StockQuant(models.Model):
             cr, uid, location, product, qty, domain=domain,
             restrict_lot_id=restrict_lot_id,
             restrict_partner_id=restrict_partner_id, context=context)
+
+    @api.model
+    def quants_move(self, quants, move, location_to, location_from=False,
+                    lot_id=False, owner_id=False, src_package_id=False,
+                    dest_package_id=False):
+        """Refuse to move a blocked lot if strict locking is demanded"""
+        if lot_id and self.env['stock.config.settings']._get_parameter(
+                'stock.lock.lot.strict', False):
+            lot = self.env['stock.production.lot'].browse(lot_id)
+            if lot.locked:
+                raise exceptions.ValidationError(
+                    _("The following lots/serial number is blocked and "
+                      "cannot be moved:\n%s") % lot.name)
+        super(StockQuant, self).quants_move(
+            quants, move, location_to, location_from=location_from,
+            lot_id=lot_id, owner_id=owner_id, src_package_id=src_package_id,
+            dest_package_id=dest_package_id)

--- a/stock_lock_lot/tests/__init__.py
+++ b/stock_lock_lot/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_locking
+from . import test_strict_locking

--- a/stock_lock_lot/tests/test_locking.py
+++ b/stock_lock_lot/tests/test_locking.py
@@ -9,6 +9,8 @@ from openerp import exceptions
 class TestLockingUnlocking(TestStockCommon):
     def setUp(self):
         super(TestLockingUnlocking, self).setUp()
+        self.env['stock.config.settings']._write_or_create_param(
+            'stock.lock.lot.strict', False)
 
         self.LotObj = self.env['stock.production.lot']
 

--- a/stock_lock_lot/tests/test_strict_locking.py
+++ b/stock_lock_lot/tests/test_strict_locking.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# © 2016 Numérigraphe
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_locking
+from openerp import exceptions
+
+
+class TestStrictLocking(test_locking.TestLockingUnlocking):
+    """Redo all the same tests as stock_lock_lot, and some more"""
+    def setUp(self):
+        super(TestStrictLocking, self).setUp()
+        self.env['stock.config.settings']._write_or_create_param(
+            'stock.lock.lot.strict', True)
+
+    def test_force_assign(self):
+        """We mustn't move locked lots even by forcing availability"""
+        self.lot.button_lock()
+        self.picking_out.force_assign()
+        with self.assertRaises(exceptions.ValidationError):
+            self.picking_out.action_done()
+
+    def test_done_directly(self):
+        """We mustn't move locked lots by skipping to done state"""
+        self.lot.button_lock()
+        with self.assertRaises(exceptions.ValidationError):
+            self.picking_out.move_lines[0].action_done()

--- a/stock_lock_lot/views/res_config_view.xml
+++ b/stock_lock_lot/views/res_config_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_stock_configuration" model="ir.ui.view">
+            <field name="name">Stock settings: Strict locking</field>
+            <field name="model">stock.config.settings</field>
+            <field name="inherit_id" ref="stock.view_stock_config_settings" />
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//group[last()]" position="after">
+                        <group>
+                            <label for="id" string="Lot blocking" />
+                            <div>
+                                <field name="stock_lock_lot_strict" class="oe_inline" />
+                                <label for="stock_lock_lot_strict" />
+                            </div>
+                        </group>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Optional ~~module~~ feature to strictly enforce the blocking of lots defined in `stock_lock_lot`, by refusing to move force-assigned goods.
A checkbox lets users ~~install this module~~ disable this strict checking from the warehouse.
