### PR TITLE
Unreserve quants when blocking lots

### DIFF
--- a/stock_lock_lot/i18n/fr.po
+++ b/stock_lock_lot/i18n/fr.po
@@ -76,12 +76,6 @@ msgid "Demanded by product category"
 msgstr "Exigé par la catégorie d'article"
 
 #. module: stock_lock_lot
-#: code:addons/stock_lock_lot/models/stock_production_lot.py:59
-#, python-format
-msgid "Error! Serial Number/Lot \"%s\" currently has reservations."
-msgstr "Erreur ! Il existe actuellement des reservations pour le numéro de série/lot \"%s\"."
-
-#. module: stock_lock_lot
 #: field:wiz.lock.lot,id:0
 msgid "ID"
 msgstr "Id."
@@ -91,6 +85,11 @@ msgstr "Id."
 msgid ""
 "If checked, future Serial Numbers/lots will be created blocked by default"
 msgstr "Si coché, les lots de production seront créés verrouillés par défaut"
+
+#. module: stock_lock_lot
+#: view:stock.production.lot:stock_lock_lot.view_production_lot_form_inh_locklot
+msgid "If you block this Serial Number/Lot, all its reservations will be removed, and the pending stock moves will be marked 'unavailable'."
+msgstr "Si vous bloquez ce lot, toutes les réservations seront supprimées, et les mouvements de stock à venir seront marqués \"Indisponibles\"."
 
 #. module: stock_lock_lot
 #: field:wiz.lock.lot,write_uid:0

--- a/stock_lock_lot/tests/test_locking.py
+++ b/stock_lock_lot/tests/test_locking.py
@@ -89,6 +89,18 @@ class TestLockingUnlocking(TestStockCommon):
                 move.state, 'assigned',
                 'The stock move should be assigned')
 
+    def test_lock_unreserve(self):
+        """Blocking a lot must unreserve all the quants"""
+        # Reserve the lot
+        self.picking_out.action_assign()
+        # Check the lot has reservations
+        domain = [('lot_id', '=', self.lot.id),
+                  ('reservation_id', '!=', False)]
+        self.assertTrue(self.env['stock.quant'].search_count(domain))
+        # Lock and check the lot has no reservations anymore
+        self.lot.button_lock()
+        self.assertFalse(self.env['stock.quant'].search_count(domain))
+
     def test_category_locked(self):
         self.productA.categ_id.lot_default_locked = True
         lot1 = self.LotObj.create({'name': 'Lot in locked category',

--- a/stock_lock_lot/views/stock_production_lot_view.xml
+++ b/stock_lock_lot/views/stock_production_lot_view.xml
@@ -10,7 +10,8 @@
                     <header>
                         <button name="button_lock" string="Block"
                             groups="stock_lock_lot.group_lock_lot"
-                            type="object" attrs="{'invisible':[('locked','=',True)]}" />
+                            type="object" attrs="{'invisible':[('locked','=',True)]}"
+                            confirm="If you block this Serial Number/Lot, all its reservations will be removed, and the pending stock moves will be marked 'unavailable'."/>
                         <button name="button_unlock" string="Unblock"
                             groups="stock_lock_lot.group_lock_lot"
                             type="object" attrs="{'invisible':[('locked','=',False)]}" />


### PR DESCRIPTION
Users block lots when there is a problem with it (eg. quality issue), and it's important that no delivery is made when such a problem is found. So blocking is more important than reservations.
So, ask for user confirmation when blocking, and then break the reservations.
