### PR TITLE
Log the reason when a lot is automatically locked

### DIFF
--- a/stock_lock_lot/i18n/fr.po
+++ b/stock_lock_lot/i18n/fr.po
@@ -71,7 +71,12 @@ msgid "Created on"
 msgstr "Créé le"
 
 #. module: stock_lock_lot
-#: code:addons/stock_lock_lot/models/stock_production_lot.py:62
+#: selection:stock.production.lot,lock_reason:0
+msgid "Demanded by product category"
+msgstr "Exigé par la catégorie d'article"
+
+#. module: stock_lock_lot
+#: code:addons/stock_lock_lot/models/stock_production_lot.py:59
 #, python-format
 msgid "Error! Serial Number/Lot \"%s\" currently has reservations."
 msgstr "Erreur ! Il existe actuellement des reservations pour le numéro de série/lot \"%s\"."
@@ -108,6 +113,11 @@ msgid "Lot/Serial"
 msgstr "Lot/n° de série"
 
 #. module: stock_lock_lot
+#: selection:stock.production.lot,lock_reason:0
+msgid "None"
+msgstr "Aucune"
+
+#. module: stock_lock_lot
 #: view:stock.production.lot:stock_lock_lot.search_product_lot_filter_inh_locklot
 msgid "Product"
 msgstr "Article"
@@ -121,6 +131,11 @@ msgstr "Catégorie d'articles"
 #: model:ir.model,name:stock_lock_lot.model_stock_quant
 msgid "Quants"
 msgstr "Quants"
+
+#. module: stock_lock_lot
+#: field:stock.production.lot,lock_reason:0
+msgid "Reason to block the lot"
+msgstr "Raison du blocage du lot"
 
 #. module: stock_lock_lot
 #: model:mail.message.subtype,description:stock_lock_lot.mt_lock_lot

--- a/stock_lock_lot/models/stock_production_lot.py
+++ b/stock_lock_lot/models/stock_production_lot.py
@@ -26,19 +26,32 @@ class StockProductionLot(models.Model):
         @param product: browse-record for product.product
         @return True when the category of the product or one of the parents
                 demand new lots to be locked"""
+        return self._get_lock_reason(product) != 'none'
+
+    def _get_lock_reason(self, product):
+        """Reason to create locked
+
+        @param product: browse-record for product.product"""
         _locked = product.categ_id.lot_default_locked
         categ = product.categ_id.parent_id
         while categ and not _locked:
             _locked = categ.lot_default_locked
             categ = categ.parent_id
-        return _locked
+        return _locked and 'category' or 'none'
 
     @api.one
     def _get_locked_value(self):
         return self._get_product_locked(self.product_id)
 
-    locked = fields.Boolean(string='Blocked', default='_get_locked_value',
-                            readonly=True)
+    locked = fields.Boolean(
+        string='Blocked', default=lambda x: x._get_locked_value(),
+        readonly=True)
+    lock_reason = fields.Selection(
+        selection=[('category', 'Demanded by product category'),
+                   ('none', 'None')],
+        string='Reason to block the lot',
+        track_visibility='onchange')
+    product_id = fields.Many2one(track_visibility='onchange')
 
     @api.one
     @api.onchange('product_id')
@@ -50,7 +63,7 @@ class StockProductionLot(models.Model):
     def button_lock(self):
         """"Lock the lot if the reservations and permissions allow it"""
         if not self.user_has_groups('stock_lock_lot.group_lock_lot'):
-            raise exceptions.Warning(
+            raise exceptions.AccessError(
                 _('You are not allowed to block Serial Numbers/Lots'))
         stock_quant_obj = self.env['stock.quant']
         for lot in self:
@@ -68,29 +81,26 @@ class StockProductionLot(models.Model):
     def button_unlock(self):
         """"Lock the lot if the permissions allow it"""
         if not self.user_has_groups('stock_lock_lot.group_lock_lot'):
-            raise exceptions.Warning(
+            raise exceptions.AccessError(
                 _('You are not allowed to unblock Serial Numbers/Lots'))
         return self.write({'locked': False})
 
-    # Kept in old API to maintain compatibility
-    def create(self, cr, uid, vals, context=None):
+    @api.model
+    def create(self, vals):
         """Force the locking/unlocking, ignoring the value of 'locked'."""
-        #  Web quick-create doesn't provide product_id in vals, but in context
-        if context is None:
-            context = {}
-        product_id = vals.get('product_id', context.get('product_id', False))
-        if product_id:
-            vals['locked'] = self._get_product_locked(
-                self.pool['product.product'].browse(
-                    cr, uid, product_id, context=context))
-        return super(StockProductionLot, self).create(
-            cr, uid, vals, context=context)
+        product = self.env['product.product'].browse(
+            vals.get('product_id',
+                     # Web quick-create provide in context
+                     self.env.context.get('product_id', False)))
+        vals['locked'] = self._get_product_locked(product)
+        vals['lock_reason'] = self._get_lock_reason(product)
+        return super(StockProductionLot, self).create(vals)
 
     @api.multi
     def write(self, values):
         """"Lock the lot if changing the product and locking is required"""
         if 'product_id' in values:
-            product = self.env['product.product'].browse(
-                values.get('product_id'))
+            product = self.env['product.product'].browse(values['product_id'])
             values['locked'] = self._get_product_locked(product)
+            values['lock_reason'] = self._get_lock_reason(product)
         return super(StockProductionLot, self).write(values)

--- a/stock_lock_lot/tests/test_locking.py
+++ b/stock_lock_lot/tests/test_locking.py
@@ -52,7 +52,7 @@ class TestLockingUnlocking(TestStockCommon):
         # Verify the button locks the lot
         self.lot.button_lock()
         # Verify unauthorized users can't unlock the lot
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaises(exceptions.AccessError):
             self.lot.sudo(self.unauthorized_user).button_lock()
         self.assertTrue(self.lot.locked,
                         "The lot should be locked when the button is pressed")
@@ -71,7 +71,7 @@ class TestLockingUnlocking(TestStockCommon):
     def test_unlock(self):
         self.lot.button_lock()
         # Verify unauthorized users can't unlock the lot
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaises(exceptions.AccessError):
             self.lot.sudo(self.unauthorized_user).button_unlock()
         # Verify the button unlocks the lot when it's been locked
         self.lot.button_unlock()


### PR DESCRIPTION
This is useful when custom submodules can lock lots for other reasons.

Additional changes : fix the default value for the blocked checkbox (no big deal, it was overwritten anyway) ; migrate create to api v8 ; use AccessError when permissions are wrong.
