### PR TITLE
[FIX][9.0] travis: Typo in travis_after_tests_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ script:
   - travis_run_tests
 
 after_success:
-  - travis_after_tests_successs
+  - travis_after_tests_success


### PR DESCRIPTION
This fixes a typo in the after_tests_success

Ironically enough, I typo-d my original commit and the title of this message.
