### PR TITLE
[FIX] Partially revert a83b66705e6d49ce33293c7b7164bd440da255b1

### DIFF
--- a/stock_move_backdating/wizard/stock_partial_picking.py
+++ b/stock_move_backdating/wizard/stock_partial_picking.py
@@ -39,10 +39,10 @@ class stock_partial_picking(osv.TransientModel):
     _inherit = 'stock.partial.picking'
     name = 'stock.partial.picking'
 
-    def _partial_move_for(self, cr, uid, move, context=None):
+    def _partial_move_for(self, cr, uid, move):
         partial_move = \
             super(stock_partial_picking, self)._partial_move_for(
-                cr, uid, move, context=context)
+                cr, uid, move)
         partial_move.update({'date_backdating': move.date_backdating},)
         return partial_move
 


### PR DESCRIPTION
- Signature of function in inherited model doesn't match parent class
  function signature. 

Code broken because of:

```
TypeError: _partial_move_for() got an unexpected keyword argument
'context'
```
