### PR TITLE
[FIX] never create pickings for services

### DIFF
--- a/stock_picking_package_preparation_line/models/stock_picking_package_preparation_line.py
+++ b/stock_picking_package_preparation_line/models/stock_picking_package_preparation_line.py
@@ -207,7 +207,8 @@ class StockPickingPackagePreparation(models.Model):
                 # ----- If line has 'move_id' this means we don't need to
                 #       recreate picking and move again
                 if (line.product_id and
-                        line.product_id.type != 'service' and not line.move_id):
+                        line.product_id.type != 'service' and not
+                        line.move_id):
                     move_data = line.get_move_data()
                     move_data.update({
                         'partner_id': package.partner_id.id,

--- a/stock_picking_package_preparation_line/models/stock_picking_package_preparation_line.py
+++ b/stock_picking_package_preparation_line/models/stock_picking_package_preparation_line.py
@@ -206,7 +206,8 @@ class StockPickingPackagePreparation(models.Model):
             for line in package.line_ids:
                 # ----- If line has 'move_id' this means we don't need to
                 #       recreate picking and move again
-                if line.product_id and not line.move_id:
+                if (line.product_id and line.product_id.type != 'service'
+                        and not line.move_id):
                     move_data = line.get_move_data()
                     move_data.update({
                         'partner_id': package.partner_id.id,

--- a/stock_picking_package_preparation_line/models/stock_picking_package_preparation_line.py
+++ b/stock_picking_package_preparation_line/models/stock_picking_package_preparation_line.py
@@ -206,8 +206,8 @@ class StockPickingPackagePreparation(models.Model):
             for line in package.line_ids:
                 # ----- If line has 'move_id' this means we don't need to
                 #       recreate picking and move again
-                if (line.product_id and line.product_id.type != 'service'
-                        and not line.move_id):
+                if (line.product_id and
+                        line.product_id.type != 'service' and not line.move_id):
                     move_data = line.get_move_data()
                     move_data.update({
                         'partner_id': package.partner_id.id,


### PR DESCRIPTION
while it's fine (at least to me) to add services to the package preparation (e.g.: packaging tasks, delivery options, ...), we must not create pickings for these lines.
