### PR TITLE
[9.0] stock_picking_invoice_link: redo migration from 8.0 to 9.0

### DIFF
--- a/stock_picking_invoice_link/README.rst
+++ b/stock_picking_invoice_link/README.rst
@@ -6,11 +6,19 @@
 Link between invoices and their pickings
 ========================================
 
-This module adds a link between pickings and invoices.
-So that user can easily reach the invoices related to the picking
-and see the pickings related to the invoice.
+This module adds a link between pickings and invoices as well as on the lines.
+Invoices are generated from sales orders. With this module, you can find back
+which deliveries an invoice relates to.
 
-This only applies on the invoices generated from pickings.
+In standard, if you make a partial delivery and invoice it, then make remaining
+delivery and invoice it, it is impossible to known to what delivery the
+invoices relate to. You only have the quantity.
+
+This module is also useful if you want to present data on the invoice report
+grouped by deliveries.
+
+Note that the links are only for products with an invoicing policy set on
+delivery.
 
 Usage
 =====
@@ -29,6 +37,11 @@ help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------

--- a/stock_picking_invoice_link/README.rst
+++ b/stock_picking_invoice_link/README.rst
@@ -60,9 +60,9 @@ Contributors
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 

--- a/stock_picking_invoice_link/README.rst
+++ b/stock_picking_invoice_link/README.rst
@@ -70,4 +70,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_picking_invoice_link/README.rst
+++ b/stock_picking_invoice_link/README.rst
@@ -2,17 +2,15 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-==================================
-Link between invoices and pickings
-==================================
+========================================
+Link between invoices and their pickings
+========================================
 
 This module adds a link between pickings and invoices.
 So that user can easily reach the invoices related to the picking
 and see the pickings related to the invoice.
 
-As the invoincing flow has changed in odoo version 9,
-invoices linked to pickings (and vice versa), are shown independently from
-the invoicing method
+This only applies on the invoices generated from pickings.
 
 Usage
 =====
@@ -44,6 +42,7 @@ Contributors
 * Unai Alkorta
 * Iñaki Zabala
 * Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Maintainer
 ----------

--- a/stock_picking_invoice_link/__openerp__.py
+++ b/stock_picking_invoice_link/__openerp__.py
@@ -2,15 +2,17 @@
 # © 2013-15 Agile Business Group sagl (<http://www.agilebg.com>)
 # © 2016 AvanzOSC (<http://www.avanzosc.es>)
 # © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# © 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
     'name': 'Stock Picking Invoice Link',
-    'version': '9.0.1.1.0',
+    'version': '9.0.2.0.0',
     'category': 'Warehouse Management',
     'summary': 'Adds link between pickings and invoices',
     'author': 'Agile Business Group, '
               'Tecnativa, '
+              'BCIM sprl, '
               'Odoo Community Association (OCA)',
     'website': 'http://www.agilebg.com',
     'license': 'AGPL-3',

--- a/stock_picking_invoice_link/models/__init__.py
+++ b/stock_picking_invoice_link/models/__init__.py
@@ -4,3 +4,4 @@
 from . import account_invoice
 from . import stock_move
 from . import stock_picking
+from . import sale_order

--- a/stock_picking_invoice_link/models/account_invoice.py
+++ b/stock_picking_invoice_link/models/account_invoice.py
@@ -1,38 +1,27 @@
 # -*- coding: utf-8 -*-
 # © 2013-15 Agile Business Group sagl (<http://www.agilebg.com>)
-# © 2015-2016 AvanzOSC
-# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# © 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import api, fields, models
+from openerp import fields, models
 
 
 class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
-    picking_ids = fields.Many2many(
-        comodel_name='stock.picking', string='Related Pickings',
-        compute="_compute_picking_ids")
-
-    @api.multi
-    def _compute_picking_ids(self):
-        for invoice in self:
-            invoice.picking_ids = self.env['stock.picking']
-            for line in invoice.invoice_line_ids:
-                invoice.picking_ids |= line.move_line_ids.mapped('picking_id')
+    picking_ids = fields.One2many(
+        comodel_name='stock.picking', inverse_name='invoice_id',
+        string='Related Pickings', readonly=True,
+        copy=False,
+        help="Related pickings "
+             "(only when the invoice has been generated from the picking).")
 
 
 class AccountInvoiceLine(models.Model):
     _inherit = "account.invoice.line"
 
-    move_line_ids = fields.Many2many(
-        comodel_name='stock.move', string='Related Stock Moves',
-        compute="_compute_move_line_ids")
-
-    @api.multi
-    def _compute_move_line_ids(self):
-        for line in self:
-            line.move_line_ids = self.env['stock.move']
-            for sale_line in line.sale_line_ids:
-                for proc in sale_line.procurement_ids:
-                    line.move_line_ids |= proc.move_ids
+    move_line_ids = fields.One2many(
+        comodel_name='stock.move', inverse_name='invoice_line_id',
+        string='Related Stock Moves', readonly=True,
+        help="Related stock moves "
+             "(only when the invoice has been generated from the picking).")

--- a/stock_picking_invoice_link/models/account_invoice.py
+++ b/stock_picking_invoice_link/models/account_invoice.py
@@ -15,7 +15,7 @@ class AccountInvoice(models.Model):
         comodel_name='stock.picking', string='Related Pickings', readonly=True,
         copy=False,
         help="Related pickings "
-             "(only when the invoice has been generated from the picking).")
+             "(only when the invoice has been generated from a sale order).")
 
 
 class AccountInvoiceLine(models.Model):
@@ -27,4 +27,4 @@ class AccountInvoiceLine(models.Model):
         readonly=True,
         copy=False,
         help="Related stock moves "
-             "(only when the invoice has been generated from the picking).")
+             "(only when the invoice has been generated from a sale order).")

--- a/stock_picking_invoice_link/models/account_invoice.py
+++ b/stock_picking_invoice_link/models/account_invoice.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2013-15 Agile Business Group sagl (<http://www.agilebg.com>)
+# © 2015-2016 AvanzOSC
+# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # © 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
@@ -9,9 +11,8 @@ from openerp import fields, models
 class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
-    picking_ids = fields.One2many(
-        comodel_name='stock.picking', inverse_name='invoice_id',
-        string='Related Pickings', readonly=True,
+    picking_ids = fields.Many2many(
+        comodel_name='stock.picking', string='Related Pickings', readonly=True,
         copy=False,
         help="Related pickings "
              "(only when the invoice has been generated from the picking).")
@@ -21,7 +22,9 @@ class AccountInvoiceLine(models.Model):
     _inherit = "account.invoice.line"
 
     move_line_ids = fields.One2many(
-        comodel_name='stock.move', inverse_name='invoice_line_id',
-        string='Related Stock Moves', readonly=True,
+        'stock.move', 'invoice_line_id',
+        string='Related Stock Moves',
+        readonly=True,
+        copy=False,
         help="Related stock moves "
              "(only when the invoice has been generated from the picking).")

--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# © 2013-15 Agile Business Group sagl (<http://www.agilebg.com>)
+# © 2017 Jacques-Etienne Baudoux <je@bcim.be>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.multi
+    def invoice_line_create(self, invoice_id, qty):
+        res = super(SaleOrderLine, self).invoice_line_create(invoice_id, qty)
+        self.mapped('procurement_ids') \
+            .mapped('move_ids') \
+            .filtered(
+                lambda x: x.state == 'done' and
+                not x.location_dest_id.scrap_location and
+                x.location_dest_id.usage == 'customer') \
+            .mapped('picking_id') \
+            .write({'invoice_id': invoice_id})
+        return res
+
+    @api.multi
+    def _prepare_invoice_line(self, qty):
+        vals = super(SaleOrderLine, self)._prepare_invoice_line(qty)
+        # move_ids = self.procurement_ids.mapped('move_ids').filtered(
+        #     lambda x: x.state == 'done' and
+        #     not x.location_dest_id.scrap_location and
+        #     x.location_dest_id.usage == 'customer').ids
+
+        # For performance reason, we compute the list of move in SQL
+        self._cr.execute("""
+            SELECT stock_move.id FROM stock_move
+            LEFT JOIN stock_location
+                ON stock_location.id=stock_move.location_dest_id
+            LEFT JOIN procurement_order
+                ON procurement_order.id=stock_move.procurement_id
+            LEFT JOIN sale_order_line
+                ON sale_order_line.id=procurement_order.sale_line_id
+            WHERE stock_move.state='done'
+                AND stock_location.scrap_location != 't'
+                AND stock_location.usage = 'customer'
+                AND sale_order_line.id in %s
+            """, (tuple(self.ids),))
+
+        move_ids = [row[0] for row in self._cr.fetchall()]
+        vals['move_line_ids'] = [(6, 0, move_ids)]
+        return vals

--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -11,40 +11,24 @@ class SaleOrderLine(models.Model):
 
     @api.multi
     def invoice_line_create(self, invoice_id, qty):
-        res = super(SaleOrderLine, self).invoice_line_create(invoice_id, qty)
         self.mapped('procurement_ids') \
             .mapped('move_ids') \
             .filtered(
                 lambda x: x.state == 'done' and
+                not x.invoice_line_id and
                 not x.location_dest_id.scrap_location and
                 x.location_dest_id.usage == 'customer') \
             .mapped('picking_id') \
-            .write({'invoice_id': invoice_id})
-        return res
+            .write({'invoice_ids': [(4, invoice_id)]})
+        return super(SaleOrderLine, self).invoice_line_create(invoice_id, qty)
 
     @api.multi
     def _prepare_invoice_line(self, qty):
         vals = super(SaleOrderLine, self)._prepare_invoice_line(qty)
-        # move_ids = self.procurement_ids.mapped('move_ids').filtered(
-        #     lambda x: x.state == 'done' and
-        #     not x.location_dest_id.scrap_location and
-        #     x.location_dest_id.usage == 'customer').ids
-
-        # For performance reason, we compute the list of move in SQL
-        self._cr.execute("""
-            SELECT stock_move.id FROM stock_move
-            LEFT JOIN stock_location
-                ON stock_location.id=stock_move.location_dest_id
-            LEFT JOIN procurement_order
-                ON procurement_order.id=stock_move.procurement_id
-            LEFT JOIN sale_order_line
-                ON sale_order_line.id=procurement_order.sale_line_id
-            WHERE stock_move.state='done'
-                AND stock_location.scrap_location != 't'
-                AND stock_location.usage = 'customer'
-                AND sale_order_line.id in %s
-            """, (tuple(self.ids),))
-
-        move_ids = [row[0] for row in self._cr.fetchall()]
+        move_ids = self.mapped('procurement_ids').mapped('move_ids').filtered(
+            lambda x: x.state == 'done' and
+            not x.invoice_line_id and
+            not x.location_dest_id.scrap_location and
+            x.location_dest_id.usage == 'customer').ids
         vals['move_line_ids'] = [(6, 0, move_ids)]
         return vals

--- a/stock_picking_invoice_link/models/stock_move.py
+++ b/stock_picking_invoice_link/models/stock_move.py
@@ -1,12 +1,25 @@
 # -*- coding: utf-8 -*-
 # © 2013-15 Agile Business Group sagl (<http://www.agilebg.com>)
+# © 2015-2016 AvanzOSC
+# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import fields, models
+from openerp import api, fields, models
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    invoice_line_id = fields.Many2one(comodel_name='account.invoice.line',
-                                      string='Invoice Line', readonly=True)
+    # Provide this field for backwards compatibility
+    invoice_line_ids = fields.Many2many(
+        comodel_name='account.invoice.line', string='Invoice Lines',
+        compute="_compute_invoice_line_ids")
+    invoice_line_id = fields.Many2one(
+        comodel_name='account.invoice.line', string='Invoice Line',
+        copy=False, readonly=True)
+
+    @api.multi
+    @api.depends('invoice_line_id')
+    def _compute_invoice_line_ids(self):
+        for move in self:
+            move.invoice_line_ids = move.invoice_line_id

--- a/stock_picking_invoice_link/models/stock_move.py
+++ b/stock_picking_invoice_link/models/stock_move.py
@@ -1,27 +1,12 @@
 # -*- coding: utf-8 -*-
 # © 2013-15 Agile Business Group sagl (<http://www.agilebg.com>)
-# © 2015-2016 AvanzOSC
-# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import api, fields, models
+from openerp import fields, models
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    invoice_line_ids = fields.Many2many(
-        comodel_name='account.invoice.line', string='Invoice Lines',
-        compute="_compute_invoice_line_ids")
-
-    @api.multi
-    def _compute_invoice_line_ids(self):
-        for move in self:
-            if (
-                move.procurement_id and move.procurement_id.sale_line_id and
-                move.procurement_id.sale_line_id.invoice_lines
-            ):
-                move.invoice_line_ids = (
-                    move.procurement_id.sale_line_id.invoice_lines)
-            else:
-                move.invoice_line_ids = []
+    invoice_line_id = fields.Many2one(comodel_name='account.invoice.line',
+                                      string='Invoice Line', readonly=True)

--- a/stock_picking_invoice_link/models/stock_picking.py
+++ b/stock_picking_invoice_link/models/stock_picking.py
@@ -1,13 +1,26 @@
 # -*- coding: utf-8 -*-
 # © 2013-15 Agile Business Group sagl (<http://www.agilebg.com>)
+# © 2015-2016 AvanzOSC
+# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # © 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import fields, models
+from openerp import api, fields, models
 
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    invoice_id = fields.Many2one(comodel_name='account.invoice',
-                                 string='Invoice', readonly=True)
+    invoice_ids = fields.Many2many(
+        comodel_name='account.invoice', copy=False, string='Invoices',
+        readonly=True)
+    # Provide this field for backwards compatibility
+    invoice_id = fields.Many2one(
+        comodel_name='account.invoice', string='Invoice',
+        compute="_compute_invoice_id")
+
+    @api.multi
+    @api.depends('invoice_ids')
+    def _compute_invoice_id(self):
+        for picking in self:
+            picking.invoice_id = picking.invoice_ids[:1]

--- a/stock_picking_invoice_link/models/stock_picking.py
+++ b/stock_picking_invoice_link/models/stock_picking.py
@@ -1,23 +1,13 @@
 # -*- coding: utf-8 -*-
 # © 2013-15 Agile Business Group sagl (<http://www.agilebg.com>)
-# © 2015-2016 AvanzOSC
-# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# © 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import api, fields, models
+from openerp import fields, models
 
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    invoice_ids = fields.Many2many(
-        comodel_name='account.invoice', string='Invoices',
-        compute="_compute_invoice_ids")
-
-    @api.multi
-    def _compute_invoice_ids(self):
-        for picking in self:
-            invoices = self.env['account.invoice']
-            for line in picking.move_lines:
-                invoices |= line.invoice_line_ids.mapped('invoice_id')
-            picking.invoice_ids = invoices
+    invoice_id = fields.Many2one(comodel_name='account.invoice',
+                                 string='Invoice', readonly=True)

--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -79,7 +79,7 @@ class TestStockPickingInvoiceLink(TestSale):
         self.assertEqual(
             inv_1.invoice_line_ids.mapped('move_line_ids'),
             pick_1.move_lines.filtered(
-                lambda x: x.product_id.invoice_policy=="delivery"),
+                lambda x: x.product_id.invoice_policy == "delivery"),
             "Invoice 1 lines must link to only First Partial Delivery lines")
         self.assertEqual(
             inv_2.picking_ids, pick_2,
@@ -87,5 +87,5 @@ class TestStockPickingInvoiceLink(TestSale):
         self.assertEqual(
             inv_2.invoice_line_ids.mapped('move_line_ids'),
             pick_2.move_lines.filtered(
-                lambda x: x.product_id.invoice_policy=="delivery"),
+                lambda x: x.product_id.invoice_policy == "delivery"),
             "Invoice 2 lines must link to only Second Delivery lines")

--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2016 Oihane Crucelaegui - AvanzOSC
 # © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# © 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from openerp.addons.sale.tests.test_sale_common import TestSale
@@ -8,6 +9,7 @@ from openerp.addons.sale.tests.test_sale_common import TestSale
 
 class TestStockPickingInvoiceLink(TestSale):
     def test_00_sale_stock_invoice(self):
+        inv_obj = self.env['account.invoice']
         self.so = self.env['sale.order'].create({
             'partner_id': self.partner.id,
             'partner_invoice_id': self.partner.id,
@@ -18,7 +20,57 @@ class TestStockPickingInvoiceLink(TestSale):
             }) for (_, p) in self.products.iteritems()],
         })
         self.so.action_confirm()
-        self.so.action_invoice_create()
-        self.assertEqual(len(self.so.invoice_ids.picking_ids), 1)
-        self.assertEqual(self.so.picking_ids, self.so.invoice_ids.picking_ids)
-        self.assertEqual(self.so.invoice_ids, self.so.picking_ids.invoice_ids)
+        self.assertTrue(self.so.picking_ids,
+                        'Sale Stock: no picking created for '
+                        '"invoice on delivery" stockable products')
+
+        # deliver partially
+        self.assertEqual(self.so.invoice_status, 'no',
+                         'Sale Stock: so invoice_status should be '
+                         '"nothing to invoice" after invoicing')
+        pick_1 = self.so.picking_ids
+        pick_1.force_assign()
+        pick_1.pack_operation_product_ids.write({'qty_done': 1})
+        wiz_act = pick_1.do_new_transfer()
+        wiz = self.env[wiz_act['res_model']].browse(wiz_act['res_id'])
+        wiz.process()
+        self.assertEqual(self.so.invoice_status, 'to invoice',
+                         'Sale Stock: so invoice_status should be '
+                         '"to invoice" after partial delivery')
+        inv_id = self.so.action_invoice_create()
+        inv_1 = inv_obj.browse(inv_id)
+
+        # complete the delivery
+        self.assertEqual(self.so.invoice_status, 'no',
+                         'Sale Stock: so invoice_status should be '
+                         '"nothing to invoice" after partial delivery '
+                         'and invoicing')
+        self.assertEqual(len(self.so.picking_ids), 2,
+                         'Sale Stock: number of pickings should be 2')
+        pick_2 = self.so.picking_ids[0]
+        pick_2.force_assign()
+        pick_2.pack_operation_product_ids.write({'qty_done': 1})
+        self.assertIsNone(pick_2.do_new_transfer(),
+                          'Sale Stock: second picking should be '
+                          'final without need for a backorder')
+        self.assertEqual(self.so.invoice_status, 'to invoice',
+                         'Sale Stock: so invoice_status should be '
+                         '"to invoice" after complete delivery')
+        inv_id = self.so.action_invoice_create()
+        inv_2 = inv_obj.browse(inv_id)
+        self.assertEqual(self.so.invoice_status, 'invoiced',
+                         'Sale Stock: so invoice_status should be '
+                         '"fully invoiced" after complete delivery and '
+                         'invoicing')
+
+        # Check links
+        self.assertEqual(inv_1.picking_ids, pick_1,
+                         "Invoice 1 must link to only First Partial Delivery")
+        self.assertEqual(inv_1.invoice_line_ids, pick_1.move_lines,
+                         "Invoice 1 lines must link to only "
+                         "First Partial Delivery lines")
+        self.assertEqual(inv_2.picking_ids, pick_2,
+                         "Invoice 2 must link to only Second Delivery")
+        self.assertEqual(inv_1.invoice_line_ids, pick_1.move_lines,
+                         "Invoice 2 lines must link to only "
+                         "Second Delivery lines")

--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -73,13 +73,19 @@ class TestStockPickingInvoiceLink(TestSale):
                          'invoicing')
 
         # Check links
-        self.assertEqual(inv_1.picking_ids, pick_1,
-                         "Invoice 1 must link to only First Partial Delivery")
-        self.assertEqual(inv_1.invoice_line_ids, pick_1.move_lines,
-                         "Invoice 1 lines must link to only "
-                         "First Partial Delivery lines")
-        self.assertEqual(inv_2.picking_ids, pick_2,
-                         "Invoice 2 must link to only Second Delivery")
-        self.assertEqual(inv_1.invoice_line_ids, pick_1.move_lines,
-                         "Invoice 2 lines must link to only "
-                         "Second Delivery lines")
+        self.assertEqual(
+            inv_1.picking_ids, pick_1,
+            "Invoice 1 must link to only First Partial Delivery")
+        self.assertEqual(
+            inv_1.invoice_line_ids.mapped('move_line_ids'),
+            pick_1.move_lines.filtered(
+                lambda x: x.product_id.invoice_policy=="delivery"),
+            "Invoice 1 lines must link to only First Partial Delivery lines")
+        self.assertEqual(
+            inv_2.picking_ids, pick_2,
+            "Invoice 2 must link to only Second Delivery")
+        self.assertEqual(
+            inv_2.invoice_line_ids.mapped('move_line_ids'),
+            pick_2.move_lines.filtered(
+                lambda x: x.product_id.invoice_policy=="delivery"),
+            "Invoice 2 lines must link to only Second Delivery lines")

--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -18,11 +18,16 @@ class TestStockPickingInvoiceLink(TestSale):
                 'name': p.name, 'product_id': p.id, 'product_uom_qty': 2,
                 'product_uom': p.uom_id.id, 'price_unit': p.list_price
             }) for (_, p) in self.products.iteritems()],
+            'pricelist_id': self.env.ref('product.list0').id,
+            'picking_policy': 'direct',
         })
         self.so.action_confirm()
         self.assertTrue(self.so.picking_ids,
                         'Sale Stock: no picking created for '
                         '"invoice on delivery" stockable products')
+
+        # invoice on order
+        self.so.action_invoice_create()
 
         # deliver partially
         self.assertEqual(self.so.invoice_status, 'no',

--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -8,7 +8,7 @@ from openerp.addons.sale.tests.test_sale_common import TestSale
 
 
 class TestStockPickingInvoiceLink(TestSale):
-    def test_00_sale_stock_invoice(self):
+    def test_00_sale_stock_invoice_link(self):
         inv_obj = self.env['account.invoice']
         self.so = self.env['sale.order'].create({
             'partner_id': self.partner.id,
@@ -33,7 +33,9 @@ class TestStockPickingInvoiceLink(TestSale):
         self.assertEqual(self.so.invoice_status, 'no',
                          'Sale Stock: so invoice_status should be '
                          '"nothing to invoice" after invoicing')
-        pick_1 = self.so.picking_ids
+        pick_1 = self.so.picking_ids.filtered(
+            lambda x: x.picking_type_code == 'outgoing' and
+            x.state in ('confirmed', 'partially_available'))
         pick_1.force_assign()
         pick_1.pack_operation_product_ids.write({'qty_done': 1})
         wiz_act = pick_1.do_new_transfer()
@@ -52,7 +54,9 @@ class TestStockPickingInvoiceLink(TestSale):
                          'and invoicing')
         self.assertEqual(len(self.so.picking_ids), 2,
                          'Sale Stock: number of pickings should be 2')
-        pick_2 = self.so.picking_ids[0]
+        pick_2 = self.so.picking_ids.filtered(
+            lambda x: x.picking_type_code == 'outgoing' and
+            x.state in ('confirmed', 'partially_available'))
         pick_2.force_assign()
         pick_2.pack_operation_product_ids.write({'qty_done': 1})
         self.assertIsNone(pick_2.do_new_transfer(),

--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -13,7 +13,7 @@
                         groups="account.group_account_invoice"
                         attrs="{'invisible':[('invoice_ids', '=', False)]}"
                         widget="many2many_tags"
-                        context="{'tree_view_ref': 'account.invoice_tree', 'form_view_ref': 'invoice_form'}"/>
+                        context="{'tree_view_ref': 'account.invoice_tree', 'form_view_ref': 'account.invoice_form'}"/>
                 </field>
             </field>
         </record>

--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -8,11 +8,12 @@
             <field name="model">stock.picking</field>
             <field name="inherit_id" ref="stock.view_picking_form"/>
             <field name="arch" type="xml">
-                <notebook position="inside">
-                    <page string="Invoices" groups="account.group_account_invoice">
-                        <field name="invoice_ids" nolabel="1" context="{'tree_view_ref': 'account.invoice_tree', 'form_view_ref': 'stock_picking_invoice_link.invoice_form'}"/>
-                    </page>
-                </notebook>
+                <field name="picking_type_id" position="after">
+                    <field name="invoice_id" string="Invoice"
+                        groups="account.group_account_invoice"
+                        attrs="{'invisible':[('invoice_id', '=', False)]}"
+                        context="{'tree_view_ref': 'account.invoice_tree', 'form_view_ref': 'invoice_form'}"/>
+                </field>
             </field>
         </record>
 
@@ -22,11 +23,20 @@
             <field name="model">stock.move</field>
             <field name="inherit_id" ref="stock.view_move_form"/>
             <field name="arch" type="xml">
-                <group name="moved_quants_grp" position="after">
-                    <group name="invoice_line_ids" string="Invoice Lines" colspan="4" groups="account.group_account_invoice">
-                        <field name="invoice_line_ids" nolabel="1"/>
-                    </group>
-                </group>
+                <field name="name" position="after">
+                    <field name="invoice_line_id" groups="account.group_account_invoice"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_move_picking_form" model="ir.ui.view">
+            <field name="name">stock_picking_invoice_link.stock.move.picking.form</field>
+            <field name="model">stock.move</field>
+            <field name="inherit_id" ref="stock.view_move_picking_form"/>
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                    <field name="invoice_line_id" groups="account.group_account_invoice"/>
+                </field>
             </field>
         </record>
 

--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -9,9 +9,10 @@
             <field name="inherit_id" ref="stock.view_picking_form"/>
             <field name="arch" type="xml">
                 <field name="picking_type_id" position="after">
-                    <field name="invoice_id" string="Invoice"
+                    <field name="invoice_ids" string="Invoice"
                         groups="account.group_account_invoice"
-                        attrs="{'invisible':[('invoice_id', '=', False)]}"
+                        attrs="{'invisible':[('invoice_ids', '=', False)]}"
+                        widget="many2many_tags"
                         context="{'tree_view_ref': 'account.invoice_tree', 'form_view_ref': 'invoice_form'}"/>
                 </field>
             </field>
@@ -24,7 +25,7 @@
             <field name="inherit_id" ref="stock.view_move_form"/>
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                    <field name="invoice_line_id" groups="account.group_account_invoice"/>
+                    <field name="invoice_line_ids" widget="many2many_tags" groups="account.group_account_invoice"/>
                 </field>
             </field>
         </record>
@@ -35,7 +36,7 @@
             <field name="inherit_id" ref="stock.view_move_picking_form"/>
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                    <field name="invoice_line_id" groups="account.group_account_invoice"/>
+                    <field name="invoice_line_ids" widget="many2many_tags" groups="account.group_account_invoice"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Previous migration did not keep the business functionnality of the previous module. Link from invoice to picking must link only related delivery and not all deliveries in case of partial deivery.

The previous port of this module changed the purpose of the module that is to link invoice (and lines) to the related picking (moves) to allows to find out exactly what move is invoiced. This was broken as each invoice was linked to all deliveries of all related sales orders.

I reverted the code to the original functionality in v8.0 and performed again the migration to the v9.0.
From version 9.0, you invoice always from the sale order based on quantites to invoice. With this module, you can know exactly what delivery is in the invoice.