### PR TITLE
[FIX][8.0]Stock Move Backdating: Fix context in do_detailed_transfer wizard

### DIFF
--- a/stock_move_backdating/__openerp__.py
+++ b/stock_move_backdating/__openerp__.py
@@ -16,5 +16,6 @@
         'wizards/stock_transfer_details_view.xml',
     ],
     'installable': True,
+    "license": "AGPL-3",
     'auto_install': False,
 }

--- a/stock_move_backdating/tests/test_stock_move_backdating.py
+++ b/stock_move_backdating/tests/test_stock_move_backdating.py
@@ -33,9 +33,22 @@ class TestStockMoveBackdating(TransactionCase):
 
     def test_account_move_creation(self):
         date_backdating = self._get_date_backdating(1)
+        product_8 = self.env.ref('product.product_product_8')
+        product_9 = self.env.ref('product.product_product_9')
+        product_8.categ_id.property_stock_account_output_categ = self.env.ref(
+            'account.stk')
+        product_8.categ_id.property_stock_valutation_account_id = self.env.ref(
+            'account.cas')
+        product_8.valutation = 'real_time'
+        product_9.categ_id.property_stock_account_output_categ = self.env.ref(
+            'account.stk')
+        product_9.categ_id.property_stock_valutation_account_id = self.env.ref(
+            'account.cas')
+        product_9.valutation = 'real_time'
         self._transfer_picking_with_date(date_backdating)
-        self.assertEqual(
-            self.picking.move_lines[0].date[0:10], date_backdating)
+        account_move = self.env['account.move'].search(
+            [('ref', '=', self.picking.name)])
+        self.assertEqual(account_move.date[0:10], date_backdating)
 
     def _move_factory(self, product, qty):
         return self.env['stock.move'].create({

--- a/stock_move_backdating/tests/test_stock_move_backdating.py
+++ b/stock_move_backdating/tests/test_stock_move_backdating.py
@@ -31,6 +31,12 @@ class TestStockMoveBackdating(TransactionCase):
         date_backdating_2 = self._get_date_backdating(2)
         self._transfer_picking_with_dates(date_backdating_1, date_backdating_2)
 
+    def test_account_move_creation(self):
+        date_backdating = self._get_date_backdating(1)
+        self._transfer_picking_with_date(date_backdating)
+        self.assertEqual(
+            self.picking.move_lines[0].date[0:10], date_backdating)
+
     def _move_factory(self, product, qty):
         return self.env['stock.move'].create({
             'name': '/',

--- a/stock_move_backdating/wizards/stock_transfer_details.py
+++ b/stock_move_backdating/wizards/stock_transfer_details.py
@@ -40,6 +40,12 @@ class StockTransferDetails(models.TransientModel):
             packop['date'] = now
         return res
 
+    @api.one
+    def do_detailed_transfer(self):
+        res = super(StockTransferDetails, self.with_context(
+            {'move_date': self.date_backdating})).do_detailed_transfer()
+        return res
+
 
 class StockTransferDetailsItems(models.TransientModel):
     _inherit = 'stock.transfer_details_items'


### PR DESCRIPTION
Go on runbot and do this steps:
- create a purchase or sale order.
- confirm it and go to the delivery order.
- transfer the delivery order and select a different date in date_backdating
- go to the Accounting -> Journal Entries list and take the move related to sale/purchase order
- the journal entry date is different from date_backdating.
This happens because [here](https://github.com/OCA/stock-logistics-workflow/blob/8.0/stock_move_backdating/models/account_move.py#L16) self._context.get('move_date') is always false