### PR TITLE
[FIX] stock_picking_show_return: Typo

### DIFF
--- a/stock_picking_show_return/models/stock_picking.py
+++ b/stock_picking_show_return/models/stock_picking.py
@@ -15,5 +15,5 @@ class StockPicking(models.Model):
     @api.multi
     def _compute_returned_ids(self):
         for picking in self:
-            picking.returned_ids = self.mapped(
+            picking.returned_ids = picking.mapped(
                 'move_lines.returned_move_ids.picking_id')


### PR DESCRIPTION
The returned picking must be obtained from the picking of the iteration,
not the set of pickings to be calculated.