### PR TITLE
[9.0][IMP] stock_picking_transfer_lot_autoassign: Allow autocomplete units from ordered qty in backorder wizard when the picking has products without lots tracking

### DIFF
--- a/stock_picking_transfer_lot_autoassign/README.rst
+++ b/stock_picking_transfer_lot_autoassign/README.rst
@@ -14,6 +14,9 @@ This module automatically assigns the reserved quantity as the done one, so
 that you only have to change it in case of divergence, but having the
 possibility of transferring directly.
 
+Also this module adds a button in backorder confirmation wizard to auto
+complete to do quantities for products without lots.
+
 Configuration
 =============
 
@@ -43,6 +46,7 @@ Contributors
 ------------
 
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Sergio Teruel <sergio.teruel@tecnativa.com>
 
 Maintainer
 ----------

--- a/stock_picking_transfer_lot_autoassign/__openerp__.py
+++ b/stock_picking_transfer_lot_autoassign/__openerp__.py
@@ -13,5 +13,8 @@
     'depends': [
         'stock',
     ],
+    'data': [
+        'wizards/stock_backorder_confirmation.xml',
+    ],
     'installable': True,
 }

--- a/stock_picking_transfer_lot_autoassign/i18n/es.po
+++ b/stock_picking_transfer_lot_autoassign/i18n/es.po
@@ -1,22 +1,33 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * stock_picking_transfer_lot_autoassign
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-23 11:56+0000\n"
-"PO-Revision-Date: 2017-01-23 11:56+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2017-03-08 17:09+0100\n"
+"PO-Revision-Date: 2017-03-08 17:10+0100\n"
+"Last-Translator: Sergio Teruel <sergio.teruel@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#. module: stock_picking_transfer_lot_autoassign
+#: model:ir.ui.view,arch_db:stock_picking_transfer_lot_autoassign.view_backorder_confirmation
+msgid "Assign Ordered Qty"
+msgstr "Asignar unidades pedidas"
+
+#. module: stock_picking_transfer_lot_autoassign
+#: model:ir.model,name:stock_picking_transfer_lot_autoassign.model_stock_backorder_confirmation
+msgid "Backorder Confirmation"
+msgstr "Confirmación de entrega parcial"
 
 #. module: stock_picking_transfer_lot_autoassign
 #: model:ir.model,name:stock_picking_transfer_lot_autoassign.model_stock_picking

--- a/stock_picking_transfer_lot_autoassign/wizards/__init__.py
+++ b/stock_picking_transfer_lot_autoassign/wizards/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import models
-from . import wizards
+from . import stock_backorder_confirmation

--- a/stock_picking_transfer_lot_autoassign/wizards/stock_backorder_confirmation.py
+++ b/stock_picking_transfer_lot_autoassign/wizards/stock_backorder_confirmation.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Sergio Teruel <sergio.teruel@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, models
+
+
+class StockBackorderConfirmation(models.TransientModel):
+    _inherit = 'stock.backorder.confirmation'
+
+    @api.multi
+    def process_assign_ordered_qty(self):
+        """Autocomplete product qty with producto ordered qty only for
+        products without lots track
+        """
+        self.ensure_one()
+        for pack_operation in self.pick_id.pack_operation_ids:
+            if pack_operation.pack_lot_ids:
+                continue
+            pack_operation.qty_done = pack_operation.product_qty
+        self._process()

--- a/stock_picking_transfer_lot_autoassign/wizards/stock_backorder_confirmation.xml
+++ b/stock_picking_transfer_lot_autoassign/wizards/stock_backorder_confirmation.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_backorder_confirmation" model="ir.ui.view">
+        <field name="model">stock.backorder.confirmation</field>
+        <field name="inherit_id" ref="stock.view_backorder_confirmation"/>
+        <field name="arch" type="xml">
+            <button special="cancel" position="before">
+                <button name="process_assign_ordered_qty"
+                        string="Assign Ordered Qty"
+                        type="object"
+                        class="btn-primary"/>
+            </button>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
cc @Tecnativa