### PR TITLE
[8.0] stock_scanner sentinel: fix menu display

### DIFF
--- a/stock_scanner/hardware/sentinel.py
+++ b/stock_scanner/hardware/sentinel.py
@@ -793,7 +793,7 @@ class Sentinel(object):
                 # First line to be displayed
                 first_line = 0
                 nb_lines = self.window_height - 1
-                middle = int(math.floor((nb_lines - 1) / 2))
+                middle = int(math.floor(nb_lines / 2))
 
                 # Change the first line if there is too much lines for the
                 # screen
@@ -849,7 +849,7 @@ class Sentinel(object):
             self.screen.addch(0, self.window_width - 1, curses.ACS_UARROW)
         if first_line + nb_lines < len(entries):
             self.screen.addch(
-                nb_lines - 1, self.window_width - 1, curses.ACS_DARROW)
+                nb_lines, self.window_width - 1, curses.ACS_DARROW)
 
         # Diplays number of the selected entry
         self._display(_('Selected : %d') % highlighted, y=self.window_height-1,
@@ -858,7 +858,7 @@ class Sentinel(object):
         # Set the cursor position
         if nb_lines < len(entries):
             position_percent = float(highlighted) / len(entries)
-            position = int(round((nb_lines - 1) * position_percent))
+            position = int(round(nb_lines * position_percent))
             self._display(
                 ' ', x=self.window_width - 1, y=position, color='info',
                 modifier=curses.A_REVERSE)

--- a/stock_scanner/hardware/sentinel.py
+++ b/stock_scanner/hardware/sentinel.py
@@ -828,8 +828,9 @@ class Sentinel(object):
         # First line to be displayed
         first_line = 0
         nb_lines = self.window_height - 1
+        if len(entries) > nb_lines:
+            nb_lines -= 1
         middle = int(math.floor((nb_lines - 1) / 2))
-
         # Change the first line if there is too much lines for the screen
         if len(entries) > nb_lines and highlighted >= middle:
             first_line = min(highlighted - middle, len(entries) - nb_lines)
@@ -851,7 +852,7 @@ class Sentinel(object):
                 nb_lines - 1, self.window_width - 1, curses.ACS_DARROW)
 
         # Diplays number of the selected entry
-        self._display(_('Selected : %d') % highlighted, y=nb_lines,
+        self._display(_('Selected : %d') % highlighted, y=self.window_height-1,
                       color='info', modifier=curses.A_BOLD)
 
         # Set the cursor position


### PR DESCRIPTION
when the number of elements to display is long, the
'Selected' display is written on top of the last element.
This makes selecting the last element of the string difficult
because the label can be completely hidden from view.

This fixes the issue by reserving the last line for the Selection
display.