### PR TITLE
FIX link invoice view on pickings

### DIFF
--- a/stock_picking_invoice_link/__openerp__.py
+++ b/stock_picking_invoice_link/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Stock Picking Invoice Link',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.1.0',
     'category': 'Warehouse Management',
     'summary': 'Adds link between pickings and invoices',
     'author': 'Agile Business Group, '

--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -10,7 +10,7 @@
             <field name="arch" type="xml">
                 <notebook position="inside">
                     <page string="Invoices" groups="account.group_account_invoice">
-                        <field name="invoice_ids" nolabel="1" context="{'tree_view_ref': 'account.invoice_tree', 'form_view_ref': 'invoice_form'}"/>
+                        <field name="invoice_ids" nolabel="1" context="{'tree_view_ref': 'account.invoice_tree', 'form_view_ref': 'stock_picking_invoice_link.invoice_form'}"/>
                     </page>
                 </notebook>
             </field>


### PR DESCRIPTION
Full reference is required so customer invoice form is correctly displayed.
Use "stock_picking_invoice_link.invoice_form" instead of "invoice_form".

Before this PR:
![seleccion_012](https://cloud.githubusercontent.com/assets/3016656/24566420/d5059994-162f-11e7-8d26-97bf0ad262ff.png)

After this PR:
![seleccion_011](https://cloud.githubusercontent.com/assets/3016656/24566445/ea054f42-162f-11e7-9086-2a06d1c1849c.png)

