### PR TITLE
[9.0][IMP] Delete zero operations on batch picking

### DIFF
--- a/stock_batch_picking/models/stock_picking.py
+++ b/stock_batch_picking/models/stock_picking.py
@@ -71,6 +71,10 @@ class StockPicking(models.Model):
                     continue
                 else:
                     for pack in pick.pack_operation_ids:
-                        pack.product_qty = pack.qty_done
+                        if not pack.qty_done:
+                            pack.unlink()
+                        else:
+                            pack.product_qty = pack.qty_done
+
 
             pick.do_transfer()

--- a/stock_batch_picking/models/stock_picking.py
+++ b/stock_batch_picking/models/stock_picking.py
@@ -76,5 +76,4 @@ class StockPicking(models.Model):
                         else:
                             pack.product_qty = pack.qty_done
 
-
             pick.do_transfer()


### PR DESCRIPTION
In odoo, when you confirma  picking, al operations with qty zero are deleted.
We fix stock_batch_picking so that it works same way.

NOTE: still default behavior if you have all qtys with zero, then everything is transfered