### PR TITLE
[9.0][ADD] stock_picking_show_backorder

### DIFF
--- a/stock_picking_show_backorder/README.rst
+++ b/stock_picking_show_backorder/README.rst
@@ -1,0 +1,63 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+============================
+Stock Picking Show Backorder
+============================
+
+This module provide a new field on stock pickings, allowing to see the
+backorders associated to a picking.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to 'Inventory' and create a picking.
+#. Edit the 'Done' quantity of some operation line to be less than the 'To
+   Do' quantity.
+#. Save, validate and 'Create Backorder'.
+#. A new page in the notebook has appeared with a list of the picking that
+   are backorders of this picking.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/154/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-workflow/issues>`_. In case of trouble,
+please check there if your issue has already been reported. If you spotted it
+first, help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Lois Rilo <lois.rilo@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_picking_show_backorder/__init__.py
+++ b/stock_picking_show_backorder/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/stock_picking_show_backorder/__openerp__.py
+++ b/stock_picking_show_backorder/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Stock Picking Show Backorder',
+    'version': '9.0.1.0.0',
+    'category': 'Warehouse Management',
+    'summary': "Provides a new field on stock pickings, allowing to display "
+               "the corresponding backorders.",
+    'author': "Eficent, "
+              "Odoo Community Association (OCA)",
+    'website': 'http://www.eficent.com',
+    'depends': ['stock'],
+    'data': [
+        'views/stock_view.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'license': "AGPL-3",
+}

--- a/stock_picking_show_backorder/models/__init__.py
+++ b/stock_picking_show_backorder/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import stock

--- a/stock_picking_show_backorder/models/stock.py
+++ b/stock_picking_show_backorder/models/stock.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    backorder_ids = fields.One2many(comodel_name='stock.picking',
+                                    inverse_name='backorder_id', copy=False,
+                                    string='Backorders', readonly=True)

--- a/stock_picking_show_backorder/views/stock_view.xml
+++ b/stock_picking_show_backorder/views/stock_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page name="backorders" string="Backorders"
+                      attrs="{'invisible': [('backorder_ids','=',[])]}">
+                    <field name="backorder_ids" string="Backorders" />
+                </page>
+            </notebook>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Stock Picking Show Backorder
======================

This module provide a new field on stock pickings, allowing to see the
backorders associated to a picking.

Usage
=====

To use this module, you need to:

#. Go to 'Inventory' and create a picking.
#. Edit the 'Done' quantity of some operation line to be less than the 'To
   Do' quantity.
#. Save, validate and 'Create Backorder'.
#. A new page in the notebook has appeared with a list of the picking that
   are backorders of this picking.