### PR TITLE
Improve batch picking report

### DIFF
--- a/stock_batch_picking/report/print_batch.py
+++ b/stock_batch_picking/report/print_batch.py
@@ -11,6 +11,8 @@ from . batch_aggregation import BatchAggregation
 
 class PrintBatch(report_sxw.rml_parse):
 
+    _aggregation_class = BatchAggregation
+
     def __init__(self, cursor, uid, name, context):
         super(PrintBatch, self).__init__(cursor, uid, name, context=context)
         self.pool = pooler.get_pool(self.cr.dbname)
@@ -44,6 +46,6 @@ class PrintBatch(report_sxw.rml_parse):
 
                 key = key_dict[id1], key_dict[id2]
                 pack_operations.setdefault(key, []).append(op)
-            new_objects.append(BatchAggregation(batch, pack_operations))
+            new_objects.append(self._aggregation_class(batch, pack_operations))
         return super(PrintBatch, self).set_context(new_objects, data, ids,
                                                    report_type=report_type)

--- a/stock_batch_picking/views/report_batch_picking.xml
+++ b/stock_batch_picking/views/report_batch_picking.xml
@@ -88,10 +88,10 @@
                                             </td>
                                             <td>stock error<br/>breakage
                                             </td>
-                                            <tr align="left">
+                                            <tr align="left" t-if="product.description_warehouse">
                                                 <td colspan="4">
                                                     <pre class="description ">
-                                                        <span t-esc="product.description_warehouse and product.description_warehouse or ''"></span>
+                                                        <span t-esc="product.description_warehouse"></span>
                                                     </pre>
                                                 </td>
                                             </tr>

--- a/stock_batch_picking/views/report_batch_picking.xml
+++ b/stock_batch_picking/views/report_batch_picking.xml
@@ -61,7 +61,6 @@
                                     </b>
                                 </caption>
                                 <thead>
-                                    <th>Product Code</th>
                                     <th>Product</th>
                                     <th>Carrier</th>
                                     <th class="text-right">QTY</th>
@@ -75,10 +74,7 @@
 
                                         <tr>
                                             <td>
-                                                <span t-field="product.default_code"/>
-                                            </td>
-                                            <td>
-                                                <span t-field="product.name"/>
+                                                <span t-field="product.display_name"/>
                                             </td>
                                             <td>
                                                 <span t-esc="carrier"/>


### PR DESCRIPTION
* Show display name of the product
  * So the variants are displayed correctly
  * It is now consistent with the picking reports too
* Allow to define what aggregation class to use
* Display warehouse description area only if set otherwise a weird empty grey
  rectangle is displayed under every operation.