### PR TITLE
[8.0][FIX] stock_lock_lot: 

### DIFF
--- a/stock_lock_lot/__openerp__.py
+++ b/stock_lock_lot/__openerp__.py
@@ -6,7 +6,7 @@
 {
     "name": "Stock Lock Lot",
     "Summary": "Restrict blocked lots in Stock Moves and reservations",
-    "version": "8.0.2.0.0",
+    "version": "8.0.2.1.0",
     "author": "OdooMRP team,"
               "Avanzosc,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"

--- a/stock_lock_lot/models/res_config.py
+++ b/stock_lock_lot/models/res_config.py
@@ -23,18 +23,15 @@ class StockConfig(models.TransientModel):
         param_obj = self.env['ir.config_parameter']
         rec = self._get_parameter(key)
         if rec:
-            if not value:
-                rec.unlink()
-            else:
-                rec.value = value
-        elif value:
-            param_obj.create({'key': key, 'value': value})
+            rec.value = str(value)
+        else:
+            param_obj.create({'key': key, 'value': str(value)})
 
     @api.multi
     def get_default_parameter_stock_lock_lot_strict(self):
         def get_value(key, default=''):
             rec = self._get_parameter(key)
-            return rec and rec.value or default
+            return rec and rec.value and rec.value != 'False' or default
         return {'stock_lock_lot_strict': get_value('stock.lock.lot.strict',
                                                    False)}
 

--- a/stock_lock_lot/models/stock_quant.py
+++ b/stock_lock_lot/models/stock_quant.py
@@ -30,8 +30,9 @@ class StockQuant(models.Model):
                     lot_id=False, owner_id=False, src_package_id=False,
                     dest_package_id=False):
         """Refuse to move a blocked lot if strict locking is demanded"""
-        if lot_id and self.env['stock.config.settings']._get_parameter(
-                'stock.lock.lot.strict', False):
+        param = self.env['stock.config.settings']._get_parameter(
+            'stock.lock.lot.strict', False)
+        if lot_id and param and param.value != 'False':
             lot = self.env['stock.production.lot'].browse(lot_id)
             if lot.locked:
                 raise exceptions.ValidationError(


### PR DESCRIPTION
Configuration check "Strictly forbid move on blocked Serial Numbers/lots." is set as True every time the DB is updated