### PR TITLE
[9.0][FIX] greenifying stock-workflow repository

### DIFF
--- a/stock_account_deposit/tests/test_stock_account_deposit.py
+++ b/stock_account_deposit/tests/test_stock_account_deposit.py
@@ -60,7 +60,6 @@ class TestStockAccountDeposit(common.TransactionCase):
                 'product_id': self.product.product_variant_ids[:1].id,
                 'product_uom_qty': 20.0,
                 'product_uom': self.product.uom_id.id,
-                'restrict_partner_id': self.customer.id,
             })]
         })
         return picking

--- a/stock_deposit/tests/test_stock_deposit.py
+++ b/stock_deposit/tests/test_stock_deposit.py
@@ -64,7 +64,6 @@ class TestStockDeposit(TransactionCase):
                 'product_id': self.product.product_variant_ids[:1].id,
                 'product_uom_qty': 20.0,
                 'product_uom': self.product.uom_id.id,
-                'restrict_partner_id': self.customer.id,
             })]
         })
         return picking

--- a/stock_no_negative/__openerp__.py
+++ b/stock_no_negative/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Stock Disallow Negative',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Inventory, Logistic, Storage',
     'license': 'AGPL-3',
     'summary': 'Disallow negative stock levels by default',

--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -5,7 +5,7 @@
 
 from openerp import api, models, _
 from openerp.exceptions import ValidationError
-from openerp.tools import float_compare
+from openerp.tools import config, float_compare
 
 
 class StockQuant(models.Model):
@@ -16,9 +16,14 @@ class StockQuant(models.Model):
     def check_negative_qty(self):
         p = self.env['decimal.precision'].precision_get(
             'Product Unit of Measure')
+        check_negative_qty = (
+            config['test_enable'] and self.env.context.get(
+                'test_stock_no_negative')) or (
+            'test_enable' not in config.options)
+        if not check_negative_qty:
+            return
         for quant in self:
-            if (
-                    float_compare(quant.qty, 0, precision_digits=p) == -1 and
+            if (float_compare(quant.qty, 0, precision_digits=p) == -1 and
                     quant.product_id.type == 'product' and
                     not quant.product_id.allow_negative_stock and
                     not quant.product_id.categ_id.allow_negative_stock):

--- a/stock_no_negative/tests/test_stock_no_negative.py
+++ b/stock_no_negative/tests/test_stock_no_negative.py
@@ -70,7 +70,8 @@ class TestStockNoNegative(TransactionCase):
         self.stock_immediate_transfer = self.env['stock.immediate.transfer'].\
             create({'pick_id': self.stock_picking.id})
         with self.assertRaises(ValidationError):
-            self.stock_immediate_transfer.process()
+            self.stock_immediate_transfer.with_context(
+                test_stock_no_negative=True).process()
 
     def test_true_allow_negative_stock(self):
         """Assert that negative stock levels are allowed when
@@ -82,7 +83,8 @@ class TestStockNoNegative(TransactionCase):
         self.stock_picking.do_new_transfer()
         self.stock_immediate_transfer = self.env['stock.immediate.transfer'].\
             create({'pick_id': self.stock_picking.id})
-        self.stock_immediate_transfer.process()
+        self.stock_immediate_transfer.with_context(
+            test_stock_no_negative=True).process()
         quant = self.env['stock.quant'].search([('product_id', '=',
                                                  self.product.id),
                                                 ('location_id', '=',


### PR DESCRIPTION
This PR includes:
- Fixes the tests of stock_deposit and stock_account_deposit modules.
- Improves test for stock_picking_invoice_link module.
- Improves the stock_no_negative module with the approach that @pedrobaeza suggested. With this improvement, the negative stock is enabled when testing other modules.

cc: @jbeficent 