### PR TITLE
[9.0][IMP]stock_auto_move: auto move from push rules

### DIFF
--- a/stock_auto_move/__openerp__.py
+++ b/stock_auto_move/__openerp__.py
@@ -12,7 +12,7 @@
         'data/stock_auto_move_data.xml',
         'views/stock_move.xml',
         'views/procurement_rule.xml',
-
+        'views/stock_location_path.xml',
     ],
     'demo': [
         'demo/stock_auto_move_demo.xml',

--- a/stock_auto_move/models/stock_location_path.py
+++ b/stock_auto_move/models/stock_location_path.py
@@ -16,12 +16,6 @@ class StockLocationPath(models.Model):
     )
 
     @api.model
-    def _apply(self, rule, move):
-        """Set auto move to the new move created by push rule."""
-        move.auto_move = rule.auto_confirm
-        return super(StockLocationPath, self)._apply(rule, move)
-
-    @api.model
     def _prepare_push_apply(self, rule, move):
         new_move_vals = super(StockLocationPath, self)._prepare_push_apply(
             rule, move)

--- a/stock_auto_move/models/stock_location_path.py
+++ b/stock_auto_move/models/stock_location_path.py
@@ -1,15 +1,29 @@
 # -*- coding: utf-8 -*-
 # © 2014-2015 NDP Systèmes (<http://www.ndp-systemes.fr>)
 
-from openerp import api, models
+from openerp import api, fields, models
 
 
 class StockLocationPath(models.Model):
 
     _inherit = 'stock.location.path'
 
+    auto_confirm = fields.Boolean(
+        help="If this option is selected, the generated moves will be "
+             "automatically processed as soon as the products are available. "
+             "This can be useful for situations with chained moves where we "
+             "do not want an operator action."
+    )
+
     @api.model
     def _apply(self, rule, move):
         """Set auto move to the new move created by push rule."""
-        move.auto_move = rule.auto == 'transparent'
+        move.auto_move = rule.auto_confirm
         return super(StockLocationPath, self)._apply(rule, move)
+
+    @api.model
+    def _prepare_push_apply(self, rule, move):
+        new_move_vals = super(StockLocationPath, self)._prepare_push_apply(
+            rule, move)
+        new_move_vals.update({'auto_move': rule.auto_confirm})
+        return new_move_vals

--- a/stock_auto_move/views/stock_location_path.xml
+++ b/stock_auto_move/views/stock_location_path.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="stock_location_path_form_view">
+        <field name="name">stock.location.path.form (in stock_auto_move)</field>
+        <field name="model">stock.location.path</field>
+        <field name="inherit_id" ref="stock.stock_location_path_form"/>
+        <field name="arch" type="xml">
+            <field name="auto" position="after">
+                <field name="auto_confirm"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
With this improvement, if the push rule is set to auto confirm, all the generated moves will be automatically processed as soon as the products are available in the source location.

As a use case to explain more the feature, In a reception on two steps, if the push rule is set to auto confirm, all the moves created in the second step will be processed automatically as soon as the first step is done.

