### PR TITLE
[10.0][FIX]stock_ownership_availability_rules: in case of return, virtual location id does not have any company

### DIFF
--- a/stock_ownership_availability_rules/__manifest__.py
+++ b/stock_ownership_availability_rules/__manifest__.py
@@ -4,7 +4,7 @@
 
 {'name': 'Stock Ownership Availability Rules',
  'summary': 'Enforce ownership on stock availability',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Purchase Management',
  'license': 'AGPL-3',

--- a/stock_ownership_availability_rules/model/quant.py
+++ b/stock_ownership_availability_rules/model/quant.py
@@ -45,6 +45,7 @@ class Quant(models.Model):
             if not move.restrict_partner_id:
                 restrict_partner_id = (
                     move.location_id.partner_id.id or
-                    move.location_id.company_id.partner_id.id)
+                    move.location_id.company_id.partner_id.id or
+                    move.company_id.partner_id.id)
                 domain += [('owner_id', '=', restrict_partner_id)]
         return domain


### PR DESCRIPTION
On a return, the "Reserve" feature can be useless because virtual locations (like Customers) does not have any company_id and no partner_id, so picking stay in Waiting state because quant owns to the company partner.