### PR TITLE
[9.0][REF]stock_pack_operation_auto_fill: move auto fill button to header

### DIFF
--- a/stock_pack_operation_auto_fill/views/stock_picking.xml
+++ b/stock_pack_operation_auto_fill/views/stock_picking.xml
@@ -9,17 +9,15 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
-            <field name="recompute_pack_op" position="before">
-                <group>
-                    <button name="action_pack_operation_auto_fill"
-                            type="object"
-                            class="btn btn-primary"
-                            string="Auto fill operations"
-                            attrs="{'invisible': [('action_pack_op_auto_fill_allowed','=', False)]}"
-                            help="This button will automatically fill all operations that have no tracking set on the product, no processed qty and no selected package."/>
-                    <field name="action_pack_op_auto_fill_allowed" invisible="1"/>
-                </group>
-            </field>
+            <button name="force_assign" position="after">
+                <button name="action_pack_operation_auto_fill"
+                        type="object"
+                        class="btn btn-primary"
+                        string="Auto fill operations"
+                        attrs="{'invisible': [('action_pack_op_auto_fill_allowed','=', False)]}"
+                        help="This button will automatically fill all operations that have no tracking set on the product, no processed qty and no selected package."/>
+                <field name="action_pack_op_auto_fill_allowed" invisible="1"/>
+            </button>
         </field>
     </record>
 


### PR DESCRIPTION
Move the auto fill button from the operation tab to the picking form header