### PR TITLE
[8.0][FIX] stock_split_picking: do not write date_done when splitting closes

### DIFF
--- a/stock_split_picking/__openerp__.py
+++ b/stock_split_picking/__openerp__.py
@@ -20,7 +20,7 @@
 #
 {'name': 'Split picking',
  'summary': 'Split a picking in two unconfirmed pickings',
- 'version': '8.0.1.0.0',
+ 'version': '8.0.1.1.0',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',
  'license': 'AGPL-3',

--- a/stock_split_picking/model/stock.py
+++ b/stock_split_picking/model/stock.py
@@ -23,7 +23,7 @@
 from openerp import models, api, _
 
 
-class stock_picking(models.Model):
+class StockPicking(models.Model):
     """Adds picking split without done state."""
 
     _inherit = "stock.picking"
@@ -52,6 +52,12 @@ class stock_picking(models.Model):
             'target': 'new',
             'context': ctx,
         }
+
+    @api.multi
+    def write(self, values):
+        if self.env.context.get('do_only_split') and 'date_done' in values:
+            del values['date_done']
+        return super(StockPicking, self).write(values)
 
 
 class StockMove(models.Model):

--- a/stock_split_picking/test/test_assigned_picking_split.yml
+++ b/stock_split_picking/test/test_assigned_picking_split.yml
@@ -73,6 +73,8 @@
     backorder = self.backorder_id
     assert backorder, "Backorder should be created after partial split."
     assert backorder.state == 'assigned', "Backorder should be assigned, not %r." % backorder.state
+    assert not backorder.date_done, "Backorder should not have date done"
+    assert not self.date_done, "Date done should be empty"
     for move_line in backorder.move_lines:
         assert move_line.product_qty == 40, "Qty in backorder does not correspond."
         assert move_line.state == 'assigned', "Move line of backorder should be assigned, not %r." % move_line.state

--- a/stock_split_picking/test/test_picking_split.yml
+++ b/stock_split_picking/test/test_picking_split.yml
@@ -68,6 +68,8 @@
     backorder = self.backorder_id
     assert backorder, "Backorder should be created after partial split."
     assert backorder.state == 'confirmed', "Backorder should not be close."
+    assert not backorder.date_done, "Backorder should not have date done"
+    assert not self.date_done, "Date done should be empty"
     for move_line in backorder.move_lines:
         assert move_line.product_qty == 40, "Qty in backorder does not correspond."
         assert move_line.state == 'confirmed', "Move line of backorder should not be closed."

--- a/stock_split_picking/test/test_picking_split_two_move_lines.yml
+++ b/stock_split_picking/test/test_picking_split_two_move_lines.yml
@@ -103,6 +103,8 @@
     backorder = self.backorder_id
     assert backorder, "Backorder should be created after partial split."
     assert backorder.state == 'assigned', "Backorder should be assigned, not %r." % backorder.state
+    assert not backorder.date_done, "Backorder should not have date done"
+    assert not self.date_done, "Date done should be empty"
     for move_line in backorder.move_lines:
         assert move_line.product_qty == 40, "Qty in backorder does not correspond."
         assert move_line.state == 'assigned', "Move line of backorder should be assigned, not %r." % move_line.state


### PR DESCRIPTION
issue #375

Proposed change to odoo / ocb
https://github.com/OCA/OCB/pull/661
https://github.com/odoo/odoo/pull/20131