### PR TITLE
[10.0][ADD] module stock_picking_filter_lot

### DIFF
--- a/stock_picking_filter_lot/README.rst
+++ b/stock_picking_filter_lot/README.rst
@@ -1,0 +1,54 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
+ :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+========================
+Stock picking filter lot
+========================
+
+This module extends the functionality of stock: in a picking out the user can only select the lots available in the specified location.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+ :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/154/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Simone Rubino <simone.rubino@agilebg.com> (www.agilebg.com)
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+ :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_picking_filter_lot/__init__.py
+++ b/stock_picking_filter_lot/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/stock_picking_filter_lot/__manifest__.py
+++ b/stock_picking_filter_lot/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Stock picking filter lot",
+    "summary": "In picking out lots' selection, "
+               "filter lots based on their location",
+    "version": "10.0.1.0.0",
+    "category": "Warehouse",
+    "website": "https://github.com/OCA/stock-logistics-workflow/tree/"
+               "10.0/stock_filter_lots",
+    "author": "Agile Business Group, "
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "stock"
+    ],
+    "data": [
+        "views/stock_pack_operation.xml"
+    ]
+}

--- a/stock_picking_filter_lot/i18n/it.po
+++ b/stock_picking_filter_lot/i18n/it.po
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_picking_filter_lot
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-01-29 11:57+0000\n"
+"PO-Revision-Date: 2018-01-29 11:57+0000\n"
+"Last-Translator: Simone Rubino <simone.rubino@agilebg.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_picking_filter_lot
+#: model:ir.model.fields,field_description:stock_picking_filter_lot.field_stock_pack_operation_filter_location_id
+msgid "Filter location id"
+msgstr "Filtra per punto di stoccaggio"
+
+#. module: stock_picking_filter_lot
+#: model:ir.model.fields,field_description:stock_picking_filter_lot.field_stock_production_lot_location_ids
+msgid "Location ids"
+msgstr "Punti di stoccaggio"
+
+#. module: stock_picking_filter_lot
+#: model:ir.model,name:stock_picking_filter_lot.model_stock_production_lot
+msgid "Lot/Serial"
+msgstr "Lotto/Seriale"
+
+#. module: stock_picking_filter_lot
+#: model:ir.model,name:stock_picking_filter_lot.model_stock_pack_operation
+msgid "Packing Operation"
+msgstr "Impacchettamento"

--- a/stock_picking_filter_lot/models/__init__.py
+++ b/stock_picking_filter_lot/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import stock_pack_operation
+from . import stock_production_lot

--- a/stock_picking_filter_lot/models/stock_pack_operation.py
+++ b/stock_picking_filter_lot/models/stock_pack_operation.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+
+
+class StockPackOperation(models.Model):
+    _inherit = 'stock.pack.operation'
+
+    filter_location_id = fields.Many2one(
+        comodel_name='stock.location',
+        default=lambda self: self.env.ref('stock.stock_location_stock'))

--- a/stock_picking_filter_lot/models/stock_production_lot.py
+++ b/stock_picking_filter_lot/models/stock_production_lot.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api
+
+
+class StockProductionLot(models.Model):
+    _inherit = 'stock.production.lot'
+
+    location_ids = fields.Many2many(
+        comodel_name='stock.location', compute='_compute_location_ids',
+        store=True)
+
+    @api.depends('quant_ids', 'quant_ids.location_id')
+    def _compute_location_ids(self):
+        for lot in self:
+            lot.location_ids = lot.mapped('quant_ids.location_id')

--- a/stock_picking_filter_lot/views/stock_pack_operation.xml
+++ b/stock_picking_filter_lot/views/stock_pack_operation.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Simone Rubino - Agile Business Group
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="pack_operation_lot_filter_form" model="ir.ui.view">
+        <field name="name">Add filter to stock pack operation lot form</field>
+        <field name="model">stock.pack.operation</field>
+        <field name="inherit_id" ref="stock.view_pack_operation_lot_form"/>
+        <field name="arch" type="xml">
+            <field name="pack_lot_ids" position="before">
+                <field name="filter_location_id" invisible="context.get('only_create', False)"/>
+            </field>
+            <field name="pack_lot_ids" position="attributes">
+                <attribute name="colspan">2</attribute>
+                <attribute name="attrs">{'readonly': ['|', ('state', '=', 'done'), ('filter_location_id', '=', False)]}</attribute>
+            </field>
+            <field name="lot_id" position="attributes">
+                <attribute name="domain">[('product_id','=', parent.product_id),('location_ids', 'child_of', parent.filter_location_id)]</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module allows the user to filter lots based on their location, when performing a _picking out_.

This is useful for instance in sale orders: in the linked _picking out_ the system proposes all the lots but the user usually wants to select only the lots in Stock location (that is the default filter).