### PR TITLE
[FIX][stock_pack_operation_auto_fill] - Wrong qty done when use diffe…

### DIFF
--- a/stock_pack_operation_auto_fill/models/stock_picking.py
+++ b/stock_pack_operation_auto_fill/models/stock_picking.py
@@ -1,4 +1,5 @@
 # Copyright 2017 ACSONE SA/NV
+# Copyright 2018 JARSA Sistemas S.A. de C.V.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -49,4 +50,4 @@ class StockPicking(models.Model):
             lambda op: not op.lots_visible and op.product_id and
             not op.qty_done)
         for op in operations_to_auto_fill:
-            op.qty_done = op.product_qty
+            op.qty_done = op.product_uom_qty


### PR DESCRIPTION
**Impacted Versions:**
-11.0

**Description of the issue/feature this PR addresses:**
When you click the autofill button in a stock picking with lines that have different UoM
**Product**
    - 2 Box of 10 units of Atún.

**Current behavior before PR:**
The qty done has 20 units instead 2 boxes.
![screenshot from 2018-02-14 10-50-34](https://user-images.githubusercontent.com/16236004/36216715-2d44e786-1175-11e8-9fd6-cee41e97e562.png)

**Desired behavior after PR is merged:**
The qty done has the correct value (2 boxes)
![screenshot from 2018-02-14 10-54-03](https://user-images.githubusercontent.com/16236004/36216797-67f0aee2-1175-11e8-94c0-c02db164c4c8.png)

Thanks & Regards!