### PR TITLE
[8.0][FIX] stock_picking_mass_action: Fixing no pack operation creation.

### DIFF
--- a/stock_picking_mass_action/test/test_stock_picking_mass_action.yml
+++ b/stock_picking_mass_action/test/test_stock_picking_mass_action.yml
@@ -66,3 +66,28 @@
                ref("ship_mlas_2"): 'assigned',
                ref("ship_mlas_3"): 'assigned'}
    assert states == expected, 'wrong picking states %s (expected: %s)' % (states, expected)
+
+-
+ Check the returned transfer
+-
+ !python {model: stock.picking}: |
+   picking_ids = [ref("ship_mlas_2"), ref("ship_mlas_3")]
+   returns = {}
+   states = {}
+   for picking in self.browse(cr, uid, picking_ids, context=context):
+       context.update({
+           'active_ids': picking.ids,
+           'active_id': picking.id,
+           'active_model': 'stock.picking'
+       })
+       transfert_wizard = self.pool.get('stock.transfer_details').create(cr, uid,
+           {'picking_id': picking.id}, context=context)
+       returns[picking.id] = self.pool.get('stock.transfer_details').do_detailed_transfer(
+           cr, uid, transfert_wizard, context=context)
+       states[picking.id] = picking.state
+   expected_returns = {ref("ship_mlas_2"): [True],
+                       ref("ship_mlas_3"): [True]}
+   expected_states = {ref("ship_mlas_2"): 'done',
+                      ref("ship_mlas_3"): 'done'}
+   assert returns == expected_returns, 'wrong transfer returns %s (expected: %s)' % (returns, expected_returns)
+   assert states == expected_states, 'wrong picking state after transfer %s (expected: %s)' % (states, expected_states)

--- a/stock_picking_mass_action/wizard/mass_action.py
+++ b/stock_picking_mass_action/wizard/mass_action.py
@@ -105,8 +105,10 @@ class StockPickingMassAction(TransientModel):
                       ('id', 'in', picking_ids)]
             assigned_picking_lst = picking_obj.search(domain, order='min_date')
             for picking in assigned_picking_lst:
-                transfert_wizard = transfert_wizard_obj.create(
-                    {'picking_id': picking.id})
+                transfert_wizard = transfert_wizard_obj.with_context(
+                    active_ids=picking.ids,
+                    active_id=picking.id).create(
+                        {'picking_id': picking.id})
                 transfert_wizard.do_detailed_transfer()
 
         # Get all pickings ready to invoice and invoice them if asked


### PR DESCRIPTION
When several pickings are transferred, because of context has several active ids, function default_get() of stock.transfer_details is not creating the pack operations. This is critical for products with lot traceability.