### PR TITLE
[FIX] stock_ownership_availability_rules: apply a workaround to get the module compatible with Perpetual inventory valuation

### DIFF
--- a/stock_ownership_availability_rules/README.rst
+++ b/stock_ownership_availability_rules/README.rst
@@ -38,3 +38,4 @@ Contributors
 ------------
 
 * Leonardo Pistone <leonardo.pistone@camptocamp.com>
+* Alex Comba <alex.comba@agilebg.com>

--- a/stock_ownership_availability_rules/__manifest__.py
+++ b/stock_ownership_availability_rules/__manifest__.py
@@ -4,11 +4,10 @@
 
 {'name': 'Stock Ownership Availability Rules',
  'summary': 'Enforce ownership on stock availability',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Purchase Management',
  'license': 'AGPL-3',
- 'images': [],
  'depends': ['stock',
              ],
  'demo': [],

--- a/stock_ownership_availability_rules/model/quant.py
+++ b/stock_ownership_availability_rules/model/quant.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ALeonardo Pistone, Camptocamp SA
+# Copyright 2018 Alex Comba - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models, api, fields
@@ -48,3 +49,15 @@ class Quant(models.Model):
                     move.location_id.company_id.partner_id.id)
                 domain += [('owner_id', '=', restrict_partner_id)]
         return domain
+
+    def _account_entry_move(self, move):
+        quant_owner_id = self.owner_id
+        if quant_owner_id:
+            # workaraound to get this module
+            # compatible with Perpetual inventory valuation
+            self.owner_id = False
+            res = super(Quant, self)._account_entry_move(move)
+            self.owner_id = quant_owner_id
+        else:
+            res = super(Quant, self)._account_entry_move(move)
+        return res


### PR DESCRIPTION
Whithout that, any stock valuation will be done automatically.
See https://github.com/odoo/odoo/blob/10.0/addons/stock_account/models/stock.py#L92 for further info.