### PR TITLE
[10.0] FIX stock_picking_package_preparation_line: do not erase lines fields when picking is created from lines

### DIFF
--- a/stock_picking_package_preparation_line/__manifest__.py
+++ b/stock_picking_package_preparation_line/__manifest__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 #    Author: Francesco Apruzzese
 #    Copyright 2015 Apulia Software srl
-#    Copyright 2015 Lorenzo Battistini - Agile Business Group
+#    Copyright 2015-2018 Lorenzo Battistini - Agile Business Group
 #    Copyright 2016 Alessio Gerace - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Stock Picking Package Preparation Line',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'author': 'Apulia Software srl, Odoo Italia Network,'
     'Odoo Community Association (OCA)',
     'maintainer': 'Odoo Community Association (OCA)',

--- a/stock_picking_package_preparation_line/models/stock_picking_package_preparation.py
+++ b/stock_picking_package_preparation_line/models/stock_picking_package_preparation.py
@@ -180,6 +180,9 @@ class StockPickingPackagePreparation(models.Model):
                         })
                 # Set the picking as "To DO" and try to set it as
                 # assigned
+                # skip_update_line_ids because picking is created based on
+                # preparation lines, updating lines would erase some fields
+                picking = picking.with_context(skip_update_line_ids=True)
                 picking.action_confirm()
                 # Show an error if a picking is not confirmed
                 if picking.state != 'confirmed':

--- a/stock_picking_package_preparation_line/tests/test_package_preparation_line.py
+++ b/stock_picking_package_preparation_line/tests/test_package_preparation_line.py
@@ -37,6 +37,7 @@ class TestPackagePreparationLine(TransactionCase):
             'product_uom_qty': quantity,
             'product_uom_id': product and product.uom_id.id or False,
             'package_preparation_id': preparation.id,
+            'note': 'note',
             })
 
     def _create_preparation(self, pickings=None):
@@ -130,6 +131,8 @@ class TestPackagePreparationLine(TransactionCase):
         self.assertEqual(
             self.preparation.picking_ids[0].move_lines[0].product_id,
             self.product2)
+        for line in self.preparation.line_ids:
+            self.assertEqual(line.note, 'note')
 
     def test_remove_picking_from_package_preparation(self):
         # Remove picking from package preparation to test what happens


### PR DESCRIPTION
Use case:
 - Create a preparation, add a line with a product and fill 'note' field
 - Put in pack

'note' field is empty