### PR TITLE
[FIX] sale_stock_auto_move: README makes travis pylint fail

### DIFF
--- a/sale_stock_auto_move/README.rst
+++ b/sale_stock_auto_move/README.rst
@@ -24,11 +24,6 @@ be in done state.
 .. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
 .. branch is "8.0" for example
 
-Known issues / Roadmap
-======================
-
-* ...
-
 Bug Tracker
 ===========
 

--- a/sale_stock_auto_move/data/sale_workflow.xml
+++ b/sale_stock_auto_move/data/sale_workflow.xml
@@ -8,3 +8,4 @@
         </record>
     </data>
 </openerp>
+


### PR DESCRIPTION
```
************* Module sale_stock_auto_move
sale_stock_auto_move/README.rst:30: [E7901(rst-syntax-error), ]  Unexpected possible title overline or transition.|Treating it as ordinary text because it's so short.
sale_stock_auto_move/data/sale_workflow.xml:1: [W7908(missing-newline-extrafiles), ]  Missing newline
```