### PR TITLE
[10.0][FIX] stock_picking_invoice_link

### DIFF
--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -72,7 +72,7 @@ class TestStockPickingInvoiceLink(TestSale):
         pick_1 = self.so.picking_ids.filtered(
             lambda x: x.picking_type_code == 'outgoing' and
             x.state in ('confirmed', 'assigned', 'partially_available'))
-        pick_1.force_assign()
+        pick_1.action_assign()
         pick_1.pack_operation_product_ids.write({'qty_done': 1})
         wiz_act = pick_1.do_new_transfer()
         wiz = self.env[wiz_act['res_model']].browse(wiz_act['res_id'])
@@ -93,11 +93,11 @@ class TestStockPickingInvoiceLink(TestSale):
         pick_2 = self.so.picking_ids.filtered(
             lambda x: x.picking_type_code == 'outgoing' and
             x.state in ('confirmed', 'assigned', 'partially_available'))
-        pick_2.force_assign()
+        pick_2.action_assign()
         pick_2.pack_operation_product_ids.write({'qty_done': 1})
-        self.assertIsNone(pick_2.do_new_transfer(),
-                          'Sale Stock: second picking should be '
-                          'final without need for a backorder')
+        self.assertTrue(pick_2.do_new_transfer(),
+                        'Sale Stock: second picking should be '
+                        'final without need for a backorder')
         self.assertEqual(self.so.invoice_status, 'to invoice',
                          'Sale Stock: so invoice_status should be '
                          '"to invoice" after complete delivery')


### PR DESCRIPTION
Adapt to https://github.com/odoo/odoo/commit/ef444da57a0e5b3a8426a6fac8cef3f6d856b148.

Also, changed `force_assign()` to `action_assign()` because the needed quantity is in stock, don't need to force.