### PR TITLE
[IMP] 9.0 stock_batch_picking: unreserve picking on cancel

### DIFF
--- a/stock_batch_picking/__openerp__.py
+++ b/stock_batch_picking/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Stock batch picking',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'author': "Camptocamp, Odoo Community Association (OCA)",
     'maintainer': 'Camptocamp',
     'category': 'Inventory',

--- a/stock_batch_picking/models/stock_picking.py
+++ b/stock_batch_picking/models/stock_picking.py
@@ -21,6 +21,10 @@ class StockPicking(models.Model):
         """In addition to what the method in the parent class does,
         cancel the batches for which all pickings are cancelled
         """
+        # we need to unreserve the picking before canceling it as other way
+        # it will still have the pack_operation_ids, which will be seen
+        # in the report, which is undesirable
+        self.do_unreserve()
         result = super(StockPicking, self).action_cancel()
         self.mapped('batch_picking_id').verify_state()
 


### PR DESCRIPTION
Fix for cancelled pickings appearing in the batch picking report