### PR TITLE
[FIX] resolve bug for mass transfer

### DIFF
--- a/stock_picking_mass_action/wizard/mass_action.py
+++ b/stock_picking_mass_action/wizard/mass_action.py
@@ -105,7 +105,9 @@ class StockPickingMassAction(TransientModel):
                       ('id', 'in', picking_ids)]
             assigned_picking_lst = picking_obj.search(domain, order='min_date')
             for picking in assigned_picking_lst:
-                transfert_wizard = transfert_wizard_obj.create(
+                # Change context to give only one picking.id
+                transfert_wizard = transfert_wizard_obj.with_context(
+                    active_ids=[picking.id]).create(
                     {'picking_id': picking.id})
                 transfert_wizard.do_detailed_transfer()
 


### PR DESCRIPTION
PR to fix the bug that happens when you try to mass transfer some stock.picking.

Before that, creation of transfert_wizard returned null because there were several active_ids.


 