### PR TITLE
[IMP] stock_picking_invoice_link: Consider invoicing without availability

### DIFF
--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -13,7 +13,7 @@ class SaleOrderLine(models.Model):
         self.mapped(
             'move_ids'
         ).filtered(
-            lambda x: x.state == 'done' and
+            lambda x: x.state not in ('draft', 'cancel') and
             not x.invoice_line_id and
             not x.location_dest_id.scrap_location and
             x.location_dest_id.usage == 'customer'
@@ -26,7 +26,7 @@ class SaleOrderLine(models.Model):
     def _prepare_invoice_line(self, qty):
         vals = super(SaleOrderLine, self)._prepare_invoice_line(qty)
         move_ids = self.mapped('move_ids').filtered(
-            lambda x: x.state == 'done' and
+            lambda x: x.state not in ('draft', 'cancel') and
             not x.invoice_line_id and
             not x.scrapped and (
                 x.location_dest_id.usage == 'customer' or


### PR DESCRIPTION
Include this scenarios on the formula:
- Sell to the client, invoice it even though the product is not *yet* available.
- The inventory staff needs to know the invoice related to the SO's picking to deliver the product once its available.

Before this commit, this was not possible as the picking were in the states: waiting, confirmed or assigned.