### PR TITLE
[FIX] stock_pack_operation_auto_fill: Autofill button permissions

### DIFF
--- a/stock_pack_operation_auto_fill/__manifest__.py
+++ b/stock_pack_operation_auto_fill/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Stock Pack Operation Auto Fill',
     'summary': "Stock pack operation auto fill",
-    'version': '11.0.2.0.0',
+    'version': '11.0.2.0.1',
     'license': 'AGPL-3',
     'author': 'ACSONE SA/NV,'
               'Tecnativa,'

--- a/stock_pack_operation_auto_fill/views/stock_picking.xml
+++ b/stock_pack_operation_auto_fill/views/stock_picking.xml
@@ -3,6 +3,7 @@
     <record model="ir.ui.view" id="stock_picking_form_view">
         <field name="name">stock.picking.form (in stock_pack_operation_auto_fill)</field>
         <field name="model">stock.picking</field>
+        <field name="groups_id" eval="[(4,ref('stock.group_stock_user'))]"/>
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
             <button name="button_validate" position="before">


### PR DESCRIPTION
Only stock users should be able to process done quantities.

cc @Tecnativa