### PR TITLE
[10.0][FIX] stock_picking_package_preparation_line: Do not delete lines when the picking is not removed

### DIFF
--- a/stock_picking_package_preparation_line/__manifest__.py
+++ b/stock_picking_package_preparation_line/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Stock Picking Package Preparation Line',
-    'version': '10.0.1.0.2',
+    'version': '10.0.1.0.3',
     'author': 'Apulia Software srl, Odoo Italia Network,'
     'Odoo Community Association (OCA)',
     'maintainer': 'Odoo Community Association (OCA)',

--- a/stock_picking_package_preparation_line/models/stock_picking_package_preparation.py
+++ b/stock_picking_package_preparation_line/models/stock_picking_package_preparation.py
@@ -90,6 +90,8 @@ class StockPickingPackagePreparation(models.Model):
             # Collect new pickings to read the change
             changed_picking_ids = []
             for picking_ids in values['picking_ids']:
+                if picking_ids[0] == 1:
+                    changed_picking_ids.append(picking_ids[1])
                 if picking_ids[0] == 6:
                     changed_picking_ids.extend(picking_ids[2])
             for pack in self:

--- a/stock_picking_package_preparation_line/tests/test_package_preparation_line.py
+++ b/stock_picking_package_preparation_line/tests/test_package_preparation_line.py
@@ -144,6 +144,19 @@ class TestPackagePreparationLine(TransactionCase):
         self.preparation.picking_ids = [(3, self.picking.id)]
         self.assertEquals(len(self.preparation.line_ids), 1)
 
+    def test_edit_picking_from_package_preparation(self):
+        # Edit picking in package preparation to test what happens
+        # to package preparation line
+        self.picking2 = self._create_picking()
+        self._create_move(self.picking2, self.product2)
+        self.preparation.write({
+            'picking_ids': [
+                (6, 0, [self.picking.id, self.picking2.id])]})
+        self.preparation.write({
+            'picking_ids': [
+                (1, self.picking.id, {'name': 'Test change name'})]})
+        self.assertEquals(len(self.preparation.line_ids), 1)
+
     def test_standard_flow_with_detail_with_lot(self):
         # Test a standard flow of a package preparation but add a lot
         # on detail


### PR DESCRIPTION
Before this PR:
If the picking in the current stock_picking_package_preparation is edited (not removed), the `line_ids` of the current stock_picking_package_preparation get deleted

After this PR:
If the picking in the current stock_picking_package_preparation is edited (not removed), the `line_ids` of the current stock_picking_package_preparation _do not_ get deleted