### PR TITLE
[FIX] stock_no_negative: Use should_bypass_reservation

### DIFF
--- a/stock_no_negative/__manifest__.py
+++ b/stock_no_negative/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Stock Disallow Negative',
-    'version': '11.0.1.0.1',
+    'version': '11.0.1.0.2',
     'category': 'Inventory, Logistic, Storage',
     'license': 'AGPL-3',
     'summary': 'Disallow negative stock levels by default',

--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -28,7 +28,7 @@ class StockQuant(models.Model):
                 quant.product_id.type == 'product' and
                 not quant.product_id.allow_negative_stock and
                 not quant.product_id.categ_id.allow_negative_stock and
-                quant.location_id.usage in ['internal', 'transit']
+                not quant.location_id.should_bypass_reservation()
             ):
                 msg_add = ''
                 if quant.lot_id:

--- a/stock_no_negative/tests/test_stock_no_negative.py
+++ b/stock_no_negative/tests/test_stock_no_negative.py
@@ -71,8 +71,8 @@ class TestStockNoNegative(TransactionCase):
             self.stock_picking.button_validate()
 
     def test_check_constrains_scrap_location(self):
-        """Assert that constraint is raised when user
-        tries to validate the stock operation which would
+        """Assert that constraint is not raised when user
+        tries to validate the stock operation on a scrap location which would
         make the stock level of the product negative """
 
         self.location_id.scrap_location = True

--- a/stock_no_negative/tests/test_stock_no_negative.py
+++ b/stock_no_negative/tests/test_stock_no_negative.py
@@ -70,6 +70,19 @@ class TestStockNoNegative(TransactionCase):
         with self.assertRaises(ValidationError):
             self.stock_picking.button_validate()
 
+    def test_check_constrains_scrap_location(self):
+        """Assert that constraint is raised when user
+        tries to validate the stock operation which would
+        make the stock level of the product negative """
+
+        self.location_id.scrap_location = True
+        self.stock_picking.action_confirm()
+        self.stock_picking.button_validate()
+        quant = self.env['stock.quant'].search([
+            ('product_id', '=', self.product.id),
+            ('location_id', '=', self.location_id.id)])
+        self.assertEqual(quant.quantity, -100)
+
     def test_true_allow_negative_stock(self):
         """Assert that negative stock levels are allowed when
         the allow_negative_stock is set active in the product"""


### PR DESCRIPTION
It was giving errors when using scrap locations.