### PR TITLE
[12.0] FIX stock_picking_package_preparation_line: crash opening inventory settings

### DIFF
--- a/stock_picking_package_preparation_line/__manifest__.py
+++ b/stock_picking_package_preparation_line/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Stock Picking Package Preparation Line',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'author': 'Apulia Software srl, Odoo Italia Network, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',

--- a/stock_picking_package_preparation_line/models/ir_config.py
+++ b/stock_picking_package_preparation_line/models/ir_config.py
@@ -10,6 +10,7 @@ class ResConfigSettings(models.TransientModel):
 
     _inherit = 'res.config.settings'
 
-    default_picking_type_for_package_preparation_id = fields.Many2one(
+    picking_type_for_package_preparation_id = fields.Many2one(
         'stock.picking.type',
-        related='company_id.default_picking_type_for_package_preparation_id')
+        related='company_id.default_picking_type_for_package_preparation_id',
+        readonly=False)

--- a/stock_picking_package_preparation_line/views/ir_config_view.xml
+++ b/stock_picking_package_preparation_line/views/ir_config_view.xml
@@ -9,10 +9,10 @@
             <xpath expr="//field[@name='group_stock_packaging']/ancestor::div[hasclass('o_setting_box')]" position="after">
                 <div class="col-xs-12 col-md-6 o_setting_box" title="Package Preparation">
                     <div class="o_setting_right_pane">
-                        <label for="default_picking_type_for_package_preparation_id"/>
+                        <label for="picking_type_for_package_preparation_id"/>
                         <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."
                               groups="base.group_multi_company"/>
-                        <field name="default_picking_type_for_package_preparation_id"/>
+                        <field name="picking_type_for_package_preparation_id"/>
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
```
  File "/.repo_requirements/odoo/odoo/addons/base/models/res_config.py", line 497, in default_get
    classified = self._get_classified_fields()
  File "/.repo_requirements/odoo/odoo/addons/base/models/res_config.py", line 463, in _get_classified_fields
    raise Exception("Field %s without attribute 'default_model'" % field)
Exception: Field res.config.settings.default_picking_type_for_package_preparation_id without attribute 'default_model'
```