### PR TITLE
[11.0][FIX] stock_picking_auto_create_lot: Not create lot if lot_name is stored in move_line

### DIFF
--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -15,7 +15,7 @@ class StockPicking(models.Model):
     def button_validate(self):
         if self.picking_type_id.auto_create_lot:
             for line in self.move_line_ids.filtered(lambda x: (
-                    not x.lot_id and
+                    not x.lot_id and not x.lot_name and
                     x.product_id.tracking != 'none' and
                     x.product_id.auto_create_lot)):
                 line.lot_id = self.env['stock.production.lot'].create({


### PR DESCRIPTION
cc @Tecnativa