### PR TITLE
[10.0] product_expiry_simple: Replace stored display_name by name_get()

### DIFF
--- a/product_expiry_simple/__manifest__.py
+++ b/product_expiry_simple/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Product Expiry Simple',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Product',
     'license': 'AGPL-3',
     'summary':

--- a/product_expiry_simple/models/stock_production_lot.py
+++ b/product_expiry_simple/models/stock_production_lot.py
@@ -7,18 +7,15 @@ from odoo import models, fields, api
 
 class StockProductionLot(models.Model):
     _inherit = 'stock.production.lot'
-    _rec_name = 'display_name'
 
     expiry_date = fields.Date(string='Expiry Date')
-    display_name = fields.Char(
-        compute='compute_display_name_field',
-        string='Lot/Serial Number Display', store=True, readonly=True)
 
-    @api.multi
     @api.depends('name', 'expiry_date')
-    def compute_display_name_field(self):
+    def name_get(self):
+        res = []
         for lot in self:
             dname = lot.name
             if lot.expiry_date:
                 dname = '[%s] %s' % (lot.expiry_date, dname)
-            lot.display_name = dname
+            res.append((lot.id, dname))
+        return res


### PR DESCRIPTION
Replace stored display_name by name_get: make things simpler and avoid troubles when you need to modify the behavior of display_name in another module.