### PR TITLE
[10.0][FIX][stock_picking_package_preparation] Fix check_tracking() c…

### DIFF
--- a/stock_picking_package_preparation/__manifest__.py
+++ b/stock_picking_package_preparation/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Stock Picking Package Preparation',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'author': 'Camptocamp,Odoo Community Association (OCA)',
     'maintainer': 'Camptocamp',
     'license': 'AGPL-3',

--- a/stock_picking_package_preparation/models/stock_picking_package_preparation.py
+++ b/stock_picking_package_preparation/models/stock_picking_package_preparation.py
@@ -206,7 +206,7 @@ class StockPickingPackagePreparation(models.Model):
             for record in operation.linked_move_operation_ids:
                 moves |= record.move_id
             for move in moves:
-                moves.check_tracking(operation)
+                move.check_tracking(operation)
 
             operation.qty_done = operation.product_qty
 


### PR DESCRIPTION
…all to use move instead of moves.

This PR fix a call to `check_tracking()` by using `move` instead `moves`. However we could use straight `moves.check_tracking()` and remove totally the `for`. What do you think?