### PR TITLE
[10.0][FIX] stock_picking_line_sequence

### DIFF
--- a/stock_picking_line_sequence/__manifest__.py
+++ b/stock_picking_line_sequence/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Stock picking lines with sequence number',
     'summary': 'Manages the order of stock moves by displaying its sequence',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Warehouse Management',
     'author': "Camptocamp, "
               "Eficent, "

--- a/stock_picking_line_sequence/models/__init__.py
+++ b/stock_picking_line_sequence/models/__init__.py
@@ -5,3 +5,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import stock
+from . import procurement

--- a/stock_picking_line_sequence/models/procurement.py
+++ b/stock_picking_line_sequence/models/procurement.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class ProcurementOrder(models.Model):
+    _inherit = "procurement.order"
+
+    # Needed to propagate the sequence to the picking
+    def _get_stock_move_values(self):
+        vals = super(ProcurementOrder, self)._get_stock_move_values()
+        if self.sale_line_id:
+            vals.update({'sequence': self.sale_line_id.sequence})
+        return vals

--- a/stock_picking_line_sequence/models/stock.py
+++ b/stock_picking_line_sequence/models/stock.py
@@ -21,7 +21,7 @@ class StockMove(models.Model):
     def create(self, values):
         move = super(StockMove, self).create(values)
         # We do not reset the sequence if we are copying a complete picking
-        if self.env.context.get('keep_line_sequence'):
+        if not self.env.context.get('keep_line_sequence', False):
             move.picking_id._reset_sequence()
         return move
 
@@ -53,12 +53,6 @@ class StockPicking(models.Model):
             for line in rec.move_lines:
                 line.sequence = current_sequence
                 current_sequence += 1
-
-    @api.multi
-    def write(self, values):
-        res = super(StockPicking, self).write(values)
-        self._reset_sequence()
-        return res
 
     @api.multi
     def copy(self, default=None):


### PR DESCRIPTION
Fix for stock_picking_line_sequence:

* Sequence was not propagated correctly from procurement to picking
* Remove sequence resetting in write method that was preventing correct propagation of sequences from sales orders.
* Prevent sequence resetting on picking copy.

cc ~ @aheficent @bjeficent 