### PR TITLE
[10.0][FIX] stock_no_negative: show product name_get instead of name

### DIFF
--- a/stock_no_negative/__manifest__.py
+++ b/stock_no_negative/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Stock Disallow Negative',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'category': 'Inventory, Logistic, Storage',
     'license': 'AGPL-3',
     'summary': 'Disallow negative stock levels by default',

--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -33,5 +33,5 @@ class StockQuant(models.Model):
                     "stock level of the product '%s'%s would become negative "
                     "(%s) on the stock location '%s' and negative stock is "
                     "not allowed for this product.") % (
-                        quant.product_id.name, msg_add, quant.qty,
+                        quant.product_id.display_name, msg_add, quant.qty,
                         quant.location_id.complete_name))


### PR DESCRIPTION
Use `product.name_get` instead of `product.name`