### PR TITLE
[IMP] stock_no_negative: implement use case of tranfers using lot

### DIFF
--- a/stock_no_negative/__manifest__.py
+++ b/stock_no_negative/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Stock Disallow Negative',
-    'version': '11.0.1.1.1',
+    'version': '11.0.1.2.1',
     'category': 'Inventory, Logistic, Storage',
     'license': 'AGPL-3',
     'summary': 'Disallow negative stock levels by default',

--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -36,7 +36,15 @@ class StockQuant(models.Model):
             ):
                 msg_add = ''
                 if quant.lot_id:
-                    msg_add = _(" lot '%s'") % quant.lot_id.name_get()[0][1]
+                    # Now find a quant we can compensate the negative quants
+                    #  with some untracked quants.
+                    untracked_qty = quant._get_available_quantity(
+                        quant.product_id, quant.location_id, lot_id=False,
+                        strict=True)
+                    if float_compare(abs(quant.quantity),
+                                     untracked_qty, precision_digits=p) < 1:
+                        return True
+                    msg_add = _(" lot '%s'") % quant.lot_id.display_name
                 raise ValidationError(_(
                     "You cannot validate this stock operation because the "
                     "stock level of the product '%s'%s would become negative "


### PR DESCRIPTION
In the case if you want to transfer products by a lot and hasn't availability in a quant with this lot,
find a quantity by a quant with not lot and with quantity availability.

This is because odoo do the same in this case like see in this https://github.com/odoo/odoo/blob/11.0/addons/stock/models/stock_move_line.py#L437

More details in this [video](https://drive.google.com/file/d/1Vd8i5CxzJCiBXp-XIN1BVQu0scS1Qu4H/view)