### PR TITLE
[FIX] stock_lock_lot: from picking product_id from production default_product_id

### DIFF
--- a/stock_lock_lot/models/stock_production_lot.py
+++ b/stock_lock_lot/models/stock_production_lot.py
@@ -90,7 +90,9 @@ class StockProductionLot(models.Model):
         product = self.env['product.product'].browse(
             vals.get('product_id',
                      # Web quick-create provide in context
-                     self.env.context.get('default_product_id', False)))
+                     self.env.context.get(
+                         'product_id',
+                         self.env.context.get('default_product_id', False))))
         vals['locked'] = self._get_product_locked(product)
         vals['lock_reason'] = self._get_lock_reason(product)
         return super(StockProductionLot, self).create(vals)


### PR DESCRIPTION
when a lot is created from the production wizard the context has 'default_product_id' but when it is created from the transferring wizard of pickings the context has 'product_id' so to have both options, I've done this change. Not sure if it is correct.