### PR TITLE
[FIX] product_unique_serial: Original quant qty is not reduced if …

### DIFF
--- a/product_unique_serial/models/stock_move.py
+++ b/product_unique_serial/models/stock_move.py
@@ -77,7 +77,10 @@ class StockMove(models.Model):
         lot = operation_or_move.lot_id
         if operation_or_move.product_id.lot_unique_ok and lot:
             qty = sum([x.qty + x.propagated_from_id.qty
-                       for x in operation_or_move.lot_id.quant_ids])
+                       for x in operation_or_move.lot_id.quant_ids.filtered(
+                           lambda q: q.location_id.usage not in [
+                               'inventory', 'production', 'supplier'])
+                       ])
             if qty != 1 or operation_or_move.product_qty != 1:
                 raise exceptions.ValidationError(_(
                     "Product '%s' has active "


### PR DESCRIPTION
…location usage is 'inventory', 'production' or 'supplier'

https://github.com/odoo/odoo/blob/c51af6b6d8f75e311bf90edac046dec0de4c676f/addons/stock/stock.py#L448

@Tecnativa TT19323