### PR TITLE
[12.0] Add module product_expiry_stock_move_line_use_date

### DIFF
--- a/product_expiry_stock_move_line_use_date/__init__.py
+++ b/product_expiry_stock_move_line_use_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_expiry_stock_move_line_use_date/__manifest__.py
+++ b/product_expiry_stock_move_line_use_date/__manifest__.py
@@ -13,6 +13,7 @@
     ],
     "data": [
         "views/stock_move_line.xml",
+        "views/stock_picking.xml",
         "views/product.xml",
     ],
     "demo": [

--- a/product_expiry_stock_move_line_use_date/__manifest__.py
+++ b/product_expiry_stock_move_line_use_date/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Product Expiry Stock Move Line Entry",
+    "summary": "Enter Best before date on stock move line before lot creation",
+    "version": "12.0.1.0.0",
+    "category": "Inventory",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "depends": [
+        "product_expiry",
+    ],
+    "data": [
+        "views/stock_move_line.xml",
+        "views/product.xml",
+    ],
+    "demo": [
+        "demo/product.xml",
+    ],
+    "installable": True,
+}

--- a/product_expiry_stock_move_line_use_date/demo/product.xml
+++ b/product_expiry_stock_move_line_use_date/demo/product.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_quince_jam" model="product.product">
+        <field name="default_code">QUINCE-JAM</field>
+        <field name="name">Quince jam jar</field>
+        <field name="type">product</field>
+        <field name="categ_id" ref="product.product_category_5"/>
+        <field name="lst_price">1.0</field>
+        <field name="standard_price">0.7</field>
+        <field name="tracking">lot</field>
+        <field name="display_use_date_at_lot_creation" eval="True" />
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+    </record>
+</odoo>

--- a/product_expiry_stock_move_line_use_date/models/__init__.py
+++ b/product_expiry_stock_move_line_use_date/models/__init__.py
@@ -1,3 +1,3 @@
 from . import product
-from . import stock_move_line
+from . import stock_move
 from . import stock_production_lot

--- a/product_expiry_stock_move_line_use_date/models/__init__.py
+++ b/product_expiry_stock_move_line_use_date/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product
 from . import stock_move
+from . import stock_picking
 from . import stock_production_lot

--- a/product_expiry_stock_move_line_use_date/models/__init__.py
+++ b/product_expiry_stock_move_line_use_date/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product
+from . import stock_move_line
+from . import stock_production_lot

--- a/product_expiry_stock_move_line_use_date/models/product.py
+++ b/product_expiry_stock_move_line_use_date/models/product.py
@@ -1,0 +1,15 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+
+    _inherit = 'product.template'
+
+    display_use_date_at_lot_creation = fields.Boolean(
+        string="Enter 'Best before Date' date at lot creation",
+        help="If this is checked, you will be able to enter a 'Best before "
+             "date' on the stock move lines before the creation of new "
+             "Lots/Serial Numbers."
+    )

--- a/product_expiry_stock_move_line_use_date/models/stock_move.py
+++ b/product_expiry_stock_move_line_use_date/models/stock_move.py
@@ -43,7 +43,5 @@ class StockMoveLine(models.Model):
     lot_use_date_name = fields.Datetime(string='Best before Date')
 
     def _action_done(self):
-        self = self.with_context(
-            copy_date_name_to_lot=True, copy_date_name_to_lot_mls=self.ids
-        )
+        self = self.with_context(copy_date_name_to_lot_mls=self.ids)
         return super()._action_done()

--- a/product_expiry_stock_move_line_use_date/models/stock_move_line.py
+++ b/product_expiry_stock_move_line_use_date/models/stock_move_line.py
@@ -1,0 +1,49 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class StockMove(models.Model):
+
+    _inherit = "stock.move"
+
+    show_lots_use_date_text = fields.Boolean(
+        compute='_compute_show_lots_use_date_text'
+    )
+
+    @api.depends(
+        'picking_id', 'picking_id.show_lots_text', 'product_id',
+        'product_id.display_use_date_at_lot_creation'
+    )
+    def _compute_show_lots_use_date_text(self):
+        for move in self:
+            move.show_lots_use_date_text = (
+                move.picking_id.show_lots_text and
+                move.product_id.display_use_date_at_lot_creation
+            )
+
+    def action_show_details(self):
+        res = super().action_show_details()
+        context = res.get('context').copy()
+        context['show_lots_date_use'] = (
+            context.get('show_lots_text') and
+            self.product_id.display_use_date_at_lot_creation
+        )
+        res['context'] = context
+        return res
+
+
+class StockMoveLine(models.Model):
+
+    _inherit = "stock.move.line"
+
+    show_lots_use_date_text = fields.Boolean(
+        related='move_id.show_lots_use_date_text',
+    )
+    lot_use_date_name = fields.Datetime(string='Best before Date')
+
+    def _action_done(self):
+        self = self.with_context(
+            copy_date_name_to_lot=True, copy_date_name_to_lot_mls=self.ids
+        )
+        return super()._action_done()

--- a/product_expiry_stock_move_line_use_date/models/stock_picking.py
+++ b/product_expiry_stock_move_line_use_date/models/stock_picking.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class StockPicking(models.Model):
+
+    _inherit = "stock.picking"
+
+    has_use_date_text = fields.Boolean(compute='_compute_has_use_date_text')
+
+    @api.depends('move_lines', 'move_lines.show_lots_use_date_text')
+    def _compute_has_use_date_text(self):
+        for picking in self:
+            picking.has_use_date_text = any(
+                m.show_lots_use_date_text for m in picking.move_lines
+            )

--- a/product_expiry_stock_move_line_use_date/models/stock_production_lot.py
+++ b/product_expiry_stock_move_line_use_date/models/stock_production_lot.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, models
+
+
+class StockProductionLot(models.Model):
+
+    _inherit = "stock.production.lot"
+
+    @api.model
+    def create(self, vals):
+        if self.env.context.get('copy_date_name_to_lot'):
+            move_line = self.env['stock.move.line'].search(
+                [
+                    ('id', 'in', self.env.context.get('copy_date_name_to_lot_mls')),
+                    ('lot_name', '=', vals.get('name'))
+                ]
+            )
+            if move_line:
+                vals.update({
+                    'use_date': move_line.lot_use_date_name,
+                })
+        return super().create(vals)

--- a/product_expiry_stock_move_line_use_date/models/stock_production_lot.py
+++ b/product_expiry_stock_move_line_use_date/models/stock_production_lot.py
@@ -9,10 +9,16 @@ class StockProductionLot(models.Model):
 
     @api.model
     def create(self, vals):
-        if self.env.context.get('copy_date_name_to_lot'):
+        # copy_date_name_to_lot_mls is set by stock.move.line._action_done
+        # which is calling create in order to find the right move line whose
+        # stock.production.lot is being created, as no clean extension hook
+        # is available in Odoo
+        move_line_ids = self.env.context.get('copy_date_name_to_lot_mls')
+        if move_line_ids:
             move_line = self.env['stock.move.line'].search(
                 [
-                    ('id', 'in', self.env.context.get('copy_date_name_to_lot_mls')),
+                    ('id', 'in', move_line_ids),
+                    ('product_id', '=', vals.get('product_id')),
                     ('lot_name', '=', vals.get('name'))
                 ]
             )

--- a/product_expiry_stock_move_line_use_date/readme/CONFIGURE.rst
+++ b/product_expiry_stock_move_line_use_date/readme/CONFIGURE.rst
@@ -1,0 +1,2 @@
+On selected products, mark the checkbox "Enter 'Best before Date' date at lot
+creation" to allow manual entry of "Best before Date" on the stock move lines.

--- a/product_expiry_stock_move_line_use_date/readme/CONTRIBUTORS.rst
+++ b/product_expiry_stock_move_line_use_date/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/product_expiry_stock_move_line_use_date/readme/DESCRIPTION.rst
+++ b/product_expiry_stock_move_line_use_date/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module extends the functionality of `product_expiry` module in order to
+allow users to enter a 'Best before Date' on the stock move line before the lot
+creation.

--- a/product_expiry_stock_move_line_use_date/tests/__init__.py
+++ b/product_expiry_stock_move_line_use_date/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_use_date_entry

--- a/product_expiry_stock_move_line_use_date/tests/test_use_date_entry.py
+++ b/product_expiry_stock_move_line_use_date/tests/test_use_date_entry.py
@@ -48,7 +48,9 @@ class TestUseDateEntry(SavepointCase):
         cable_box_move = self._create_stock_move(
             picking, self.product_cable_box, 10.0
         )
+        self.assertFalse(picking.has_use_date_text)
         picking.action_confirm()
+        self.assertTrue(picking.has_use_date_text)
         self.assertEqual(picking.state, 'assigned')
         self.assertTrue(quince_jam_move.show_lots_use_date_text)
         self.assertFalse(cable_box_move.show_lots_use_date_text)

--- a/product_expiry_stock_move_line_use_date/tests/test_use_date_entry.py
+++ b/product_expiry_stock_move_line_use_date/tests/test_use_date_entry.py
@@ -1,0 +1,82 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
+from odoo import fields
+
+
+class TestUseDateEntry(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_quince_jam = cls.env.ref(
+            'product_expiry_stock_move_line_use_date.product_quince_jam'
+        )
+        cls.product_cable_box = cls.env.ref(
+            'stock.product_cable_management_box'
+        )
+        cls.picking_type_receipt = cls.env.ref('stock.picking_type_in')
+        cls.location_suppliers = cls.env.ref('stock.stock_location_suppliers')
+        cls.location_stock = cls.env.ref('stock.stock_location_stock')
+
+    def _create_receipt_picking(self):
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': self.picking_type_receipt.id,
+            'location_id': self.location_suppliers.id,
+            'location_dest_id': self.location_stock.id,
+        })
+        picking.onchange_picking_type()
+        return picking
+
+    def _create_stock_move(self, picking, product, quantity):
+        return self.env['stock.move'].create({
+            'name': 'Test receipt %s' % product.name,
+            'picking_id': picking.id,
+            'picking_type_id': picking.picking_type_id.id,
+            'location_id': self.location_suppliers.id,
+            'location_dest_id': self.location_stock.id,
+            'product_id': product.id,
+            'product_uom': product.uom_id.id,
+            'product_uom_qty': quantity,
+        })
+
+    def test_display_lot_use_date_name(self):
+        picking = self._create_receipt_picking()
+        quince_jam_move = self._create_stock_move(
+            picking, self.product_quince_jam, 10.0
+        )
+        cable_box_move = self._create_stock_move(
+            picking, self.product_cable_box, 10.0
+        )
+        picking.action_confirm()
+        self.assertEqual(picking.state, 'assigned')
+        self.assertTrue(quince_jam_move.show_lots_use_date_text)
+        self.assertFalse(cable_box_move.show_lots_use_date_text)
+        self.assertTrue(quince_jam_move.move_line_ids.show_lots_use_date_text)
+        self.assertFalse(cable_box_move.move_line_ids.show_lots_use_date_text)
+        quince_jam_act = quince_jam_move.action_show_details()
+        self.assertTrue(
+            quince_jam_act.get('context').get('show_lots_date_use')
+        )
+        cable_box_act = cable_box_move.action_show_details()
+        self.assertFalse(
+            cable_box_act.get('context').get('show_lots_date_use')
+        )
+
+    def test_lot_use_date_name_product_lot(self):
+        picking = self._create_receipt_picking()
+        quince_jam_move = self._create_stock_move(
+            picking, self.product_quince_jam, 10.0
+        )
+        picking.action_confirm()
+        quince_jam_move.move_line_ids.write({
+            'lot_name': '123456',
+            'lot_use_date_name': '2050-01-01',
+            'qty_done': 10.0,
+        })
+        picking.button_validate()
+        quince_jam_lot = quince_jam_move.move_line_ids.lot_id
+        self.assertEqual(quince_jam_lot.name, '123456')
+        self.assertEqual(
+            quince_jam_lot.use_date, fields.Datetime.to_datetime('2050-01-01')
+        )

--- a/product_expiry_stock_move_line_use_date/views/product.xml
+++ b/product_expiry_stock_move_line_use_date/views/product.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_product_form_expiry_inherit" model="ir.ui.view">
+        <field name="name">product.template.inherit.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product_expiry.view_product_form_expiry" />
+        <field name="arch" type="xml">
+            <xpath expr="//label[@for='use_time']" position="before">
+                <field name="display_use_date_at_lot_creation" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_expiry_stock_move_line_use_date/views/stock_move_line.xml
+++ b/product_expiry_stock_move_line_use_date/views/stock_move_line.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_move_line_form_inherit" model="ir.ui.view">
+        <field name="name">stock.move.line.form.inherit</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_move_line_form" />
+        <field name="arch" type="xml">
+            <field name="lot_name" position="after">
+                <field name="show_lots_use_date_text" invisible="1" />
+                <field name="lot_use_date_name" groups="stock.group_production_lot" attrs="{'invisible': ['|',('lot_id', '!=', False),('show_lots_use_date_text', '=', False)]}" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_stock_move_line_kanban_inherit" model="ir.ui.view">
+        <field name="name">stock.move.line.kanban.inherit</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_stock_move_line_kanban" />
+        <field name="arch" type="xml">
+            <field name="lot_name" position="after">
+                <field name="lot_use_date_name" invisible="not context.get('show_lots_date_use')" groups="stock.group_production_lot" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_stock_move_line_operation_tree_inherit" model="ir.ui.view">
+        <field name="name">stock.move.line.operations.tree.inherit</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
+        <field name="arch" type="xml">
+            <field name="lot_name" position="after">
+                <field name="lot_use_date_name" attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}" invisible="not context.get('show_lots_date_use')" groups="stock.group_production_lot"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/product_expiry_stock_move_line_use_date/views/stock_picking.xml
+++ b/product_expiry_stock_move_line_use_date/views/stock_picking.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_picking_type_form_inherit">
+        <field name="name">Operation Types Inherit</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <field name="use_create_lots" position="after">
+                <field name="use_create_lots_with_use_date" attrs="{'invisible': [('use_create_lots', '=', False)]}" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_picking_form_inherit" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <field name="lot_name" position="after">
+                <field name="show_lots_use_date_text" invisible="1"/>
+                <field name="lot_name" groups="stock.group_production_lot" attrs="{'column_invisible': [('show_lots_use_date_text', '=', False)], 'invisible': [('lots_visible', '=', False)]}" context="{'default_product_id': product_id}"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/product_expiry_stock_move_line_use_date/views/stock_picking.xml
+++ b/product_expiry_stock_move_line_use_date/views/stock_picking.xml
@@ -1,25 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <record model="ir.ui.view" id="view_picking_type_form_inherit">
-        <field name="name">Operation Types Inherit</field>
-        <field name="model">stock.picking.type</field>
-        <field name="inherit_id" ref="stock.view_picking_type_form" />
-        <field name="arch" type="xml">
-            <field name="use_create_lots" position="after">
-                <field name="use_create_lots_with_use_date" attrs="{'invisible': [('use_create_lots', '=', False)]}" />
-            </field>
-        </field>
-    </record>
-
     <record id="view_picking_form_inherit" model="ir.ui.view">
         <field name="name">stock.picking.form.inherit</field>
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
-            <field name="lot_name" position="after">
-                <field name="show_lots_use_date_text" invisible="1"/>
-                <field name="lot_name" groups="stock.group_production_lot" attrs="{'column_invisible': [('show_lots_use_date_text', '=', False)], 'invisible': [('lots_visible', '=', False)]}" context="{'default_product_id': product_id}"/>
+            <field name="show_lots_text" position="after">
+                <field name="has_use_date_text" invisible="1" />
             </field>
+            <xpath expr="//field[@name='move_line_ids_without_package']//field[@name='lot_name']" position="after">
+                <field name="lot_use_date_name" groups="stock.group_production_lot" attrs="{'column_invisible': [('parent.has_use_date_text', '=', False)], 'invisible': [('lots_visible', '=', False)]}" context="{'default_product_id': product_id}"/>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This module extends the functionality of `product_expiry` module in order to
allow users to enter a 'Best before Date' on the stock move line before the lot
creation.