### PR TITLE
[12.0][ADD] stock_picking_filter_lot: add logic to filter by lots in stock scrap

### DIFF
--- a/stock_picking_filter_lot/__manifest__.py
+++ b/stock_picking_filter_lot/__manifest__.py
@@ -19,5 +19,6 @@
     "data": [
         "views/stock_move_line_view.xml",
         "views/stock_picking_view.xml",
+        "views/stock_scrap_view.xml",
     ]
 }

--- a/stock_picking_filter_lot/readme/CONTRIBUTORS.rst
+++ b/stock_picking_filter_lot/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Simone Rubino <simone.rubino@agilebg.com> (www.agilebg.com)
 * Lois Rilo <lois.rilo@eficent.com> (www.eficent.com)
+* Alan Ramos <alan.ramos@jarsa.com.mx> (www.jarsa.com.mx)

--- a/stock_picking_filter_lot/readme/DESCRIPTION.rst
+++ b/stock_picking_filter_lot/readme/DESCRIPTION.rst
@@ -1,2 +1,2 @@
-This module extends the functionality of stock: in a picking out the user
+This module extends the functionality of stock: in a picking out or a scrap the user
 can only select the lots available in the origin location.

--- a/stock_picking_filter_lot/readme/USAGE.rst
+++ b/stock_picking_filter_lot/readme/USAGE.rst
@@ -1,5 +1,5 @@
 To use this module:
 
-#. Go to an open picking with products that are tracked by lots.
+#. Go to an open picking or a scrap with products that are tracked by lots.
 #. When you enter detailed operations you will notice that the lots available
    to select are filtered by the origin of the operation.

--- a/stock_picking_filter_lot/views/stock_scrap_view.xml
+++ b/stock_picking_filter_lot/views/stock_scrap_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_stock_scrap_form" model="ir.ui.view">
+        <field name="name">stock.scrap.form - stock_picking_filter_lot</field>
+        <field name="model">stock.scrap</field>
+        <field name="inherit_id" ref="stock.stock_scrap_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='lot_id']" position="attributes">
+                <attribute name="domain">[('product_id','=', product_id),('location_ids', 'child_of', location_id)]</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR logic to show only lots that can be scrapped