### PR TITLE
[12.0][IMP] stock_picking_invoice_link: Allow invoice lines linked with more than one stock move

### DIFF
--- a/stock_picking_invoice_link/README.rst
+++ b/stock_picking_invoice_link/README.rst
@@ -97,6 +97,7 @@ Contributors
 
   * Pedro M. Baeza <pedro.baeza@tecnativa.com>
   * David Vidal <david.vidal@tecnativa.com>
+  * Sergio Teruel <sergio.teruel@tecnativa.com>
 
 * Unai Alkorta
 * Iñaki Zabala

--- a/stock_picking_invoice_link/__manifest__.py
+++ b/stock_picking_invoice_link/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Stock Picking Invoice Link',
-    'version': '12.0.1.0.0',
+    'version': '12.0.2.0.0',
     'category': 'Warehouse Management',
     'summary': 'Adds link between pickings and invoices',
     'author': 'Agile Business Group, '

--- a/stock_picking_invoice_link/i18n/es.po
+++ b/stock_picking_invoice_link/i18n/es.po
@@ -9,27 +9,38 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-18 03:48+0000\n"
-"PO-Revision-Date: 2017-12-18 03:48+0000\n"
+"POT-Creation-Date: 2020-02-07 22:03+0000\n"
+"PO-Revision-Date: 2020-02-07 23:04+0100\n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>, 2017\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
+
+#. module: stock_picking_invoice_link
+#: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_picking_form
+msgid "<span class=\"o_stat_text\">Invoices</span>"
+msgstr "<span class=\"o_stat_text\">Facturas</span>"
 
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_invoice
-#: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_picking_form
 msgid "Invoice"
 msgstr "Factura"
 
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_invoice_line
-#: model:ir.model.fields,field_description:stock_picking_invoice_link.field_stock_move__invoice_line_id
+#: model:ir.model.fields,field_description:stock_picking_invoice_link.field_stock_move__invoice_line_ids
 msgid "Invoice Line"
 msgstr "Línea de factura"
+
+#. module: stock_picking_invoice_link
+#: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_move_form
+#: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_move_picking_form
+msgid "Invoice Lines"
+msgstr "Líneas de factura"
 
 #. module: stock_picking_invoice_link
 #: model:ir.model.fields,field_description:stock_picking_invoice_link.field_stock_picking__invoice_ids
@@ -85,9 +96,10 @@ msgid "Transfer"
 msgstr "Transferir"
 
 #. module: stock_picking_invoice_link
-#: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_picking_form
-msgid "View Invoice"
-msgstr "Ver factura"
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:34
+#, python-format
+msgid "You can not modify an invoiced stock move"
+msgstr "No puede modificar un movimiento de existencias facturado"
 
-#~ msgid "Invoice Lines"
-#~ msgstr "Líneas de factura"
+#~ msgid "View Invoice"
+#~ msgstr "Ver factura"

--- a/stock_picking_invoice_link/i18n/stock_picking_invoice_link.pot
+++ b/stock_picking_invoice_link/i18n/stock_picking_invoice_link.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-02-07 22:03+0000\n"
+"PO-Revision-Date: 2020-02-07 22:03+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,15 +16,25 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_picking_invoice_link
-#: model:ir.model,name:stock_picking_invoice_link.model_account_invoice
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_picking_form
+msgid "<span class=\"o_stat_text\">Invoices</span>"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:ir.model,name:stock_picking_invoice_link.model_account_invoice
 msgid "Invoice"
 msgstr ""
 
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_invoice_line
-#: model:ir.model.fields,field_description:stock_picking_invoice_link.field_stock_move__invoice_line_id
+#: model:ir.model.fields,field_description:stock_picking_invoice_link.field_stock_move__invoice_line_ids
 msgid "Invoice Line"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_move_form
+#: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_move_picking_form
+msgid "Invoice Lines"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -71,7 +83,8 @@ msgid "Transfer"
 msgstr ""
 
 #. module: stock_picking_invoice_link
-#: model_terms:ir.ui.view,arch_db:stock_picking_invoice_link.view_picking_form
-msgid "View Invoice"
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:34
+#, python-format
+msgid "You can not modify an invoiced stock move"
 msgstr ""
 

--- a/stock_picking_invoice_link/migrations/12.0.2.0.0/post-migrate.py
+++ b/stock_picking_invoice_link/migrations/12.0.2.0.0/post-migrate.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Sergio Teruel <sergio.teruel@tecnativa.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Convert invoice_line_id Many2one field to Many2many field if relation
+    # table is empty.
+    # This is due to a commit from v11 done after v12 migration, so is possible
+    # that this field is already converted
+    sql = "SELECT COUNT(*) FROM  stock_move_invoice_line_rel;"""
+    env.cr.execute(sql)
+    if not env.cr.fetchone():
+        openupgrade.m2o_to_x2m(env.cr, env['stock.move'], 'stock_move',
+                               'invoice_line_ids', 'invoice_line_id')

--- a/stock_picking_invoice_link/models/account_invoice.py
+++ b/stock_picking_invoice_link/models/account_invoice.py
@@ -4,7 +4,7 @@
 # Copyright 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountInvoice(models.Model):
@@ -19,16 +19,28 @@ class AccountInvoice(models.Model):
              "(only when the invoice has been generated from a sale order).",
     )
 
+    @api.model
+    def _refund_cleanup_lines(self, lines):
+        result = super()._refund_cleanup_lines(lines)
+        if self.env.context.get('mode') == 'modify':
+            for i, line in enumerate(lines):
+                for name, field in line._fields.items():
+                    if name == 'move_line_ids':
+                        result[i][2][name] = [(6, 0, line[name].ids)]
+                        line[name] = False
+        return result
+
 
 class AccountInvoiceLine(models.Model):
     _inherit = "account.invoice.line"
 
-    move_line_ids = fields.One2many(
+    move_line_ids = fields.Many2many(
         comodel_name='stock.move',
-        inverse_name='invoice_line_id',
+        relation='stock_move_invoice_line_rel',
+        column1='invoice_line_id',
+        column2='move_id',
         string='Related Stock Moves',
         readonly=True,
-        copy=False,
         help="Related stock moves "
              "(only when the invoice has been generated from a sale order).",
     )

--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -2,37 +2,39 @@
 # Copyright 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, models
+from odoo import models
+from odoo.tools import float_compare
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    @api.multi
-    def invoice_line_create_vals(self, invoice_id, qty):
-        self.mapped(
-            'move_ids'
-        ).filtered(
-            lambda x: x.state == 'done' and
-            not x.invoice_line_id and
-            not x.location_dest_id.scrap_location and
-            x.location_dest_id.usage == 'customer'
-        ).mapped(
-            'picking_id'
-        ).write({'invoice_ids': [(4, invoice_id)]})
-        return super(SaleOrderLine, self).invoice_line_create_vals(invoice_id,
-                                                                   qty)
+    def get_stock_moves_link_invoice(self):
+        return self.mapped('move_ids').filtered(
+            lambda x: (
+                x.state == 'done' and not (any(
+                    inv.state != 'cancel' for inv in x.invoice_line_ids.mapped(
+                        'invoice_id'))) and not x.scrapped and (
+                    x.location_dest_id.usage == 'customer' or
+                    (x.location_id.usage == 'customer' and
+                     x.to_refund))
+            )
+        )
 
-    @api.multi
+    def invoice_line_create_vals(self, invoice_id, qty):
+        stock_moves = self.get_stock_moves_link_invoice()
+        stock_moves.mapped('picking_id').write({
+            'invoice_ids': [(4, invoice_id)],
+        })
+        return super().invoice_line_create_vals(invoice_id, qty)
+
     def _prepare_invoice_line(self, qty):
-        vals = super(SaleOrderLine, self)._prepare_invoice_line(qty)
-        move_ids = self.mapped('move_ids').filtered(
-            lambda x: x.state == 'done' and
-            not x.invoice_line_id and
-            not x.scrapped and (
-                x.location_dest_id.usage == 'customer' or
-                (x.location_id.usage == 'customer' and
-                 x.to_refund)
-            )).ids
-        vals['move_line_ids'] = [(6, 0, move_ids)]
+        vals = super()._prepare_invoice_line(qty)
+        stock_moves = self.get_stock_moves_link_invoice()
+        # Invoice returned moves marked as to_refund
+        if float_compare(
+                qty, 0.0, precision_rounding=self.currency_id.rounding) < 0:
+            stock_moves = stock_moves.filtered(
+                lambda m: m.to_refund and not m.invoice_line_ids)
+        vals['move_line_ids'] = [(4, m.id) for m in stock_moves]
         return vals

--- a/stock_picking_invoice_link/models/stock_move.py
+++ b/stock_picking_invoice_link/models/stock_move.py
@@ -3,15 +3,33 @@
 # Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    invoice_line_id = fields.Many2one(
+    invoice_line_ids = fields.Many2many(
         comodel_name='account.invoice.line',
+        relation='stock_move_invoice_line_rel',
+        column1='move_id',
+        column2='invoice_line_id',
         string='Invoice Line',
         copy=False,
         readonly=True,
     )
+
+    def write(self, vals):
+        """
+        User can update any picking in done state, but if this picking already
+        invoiced the stock move done quantities can be different to invoice
+        line quantities. So to avoid this inconsistency you can not update any
+        stock move line in done state and have invoice lines linked.
+        """
+        if 'product_uom_qty' in vals:
+            for move in self:
+                if move.state == 'done' and move.invoice_line_ids:
+                    raise UserError(
+                        _('You can not modify an invoiced stock move'))
+        return super().write(vals)

--- a/stock_picking_invoice_link/models/stock_picking.py
+++ b/stock_picking_invoice_link/models/stock_picking.py
@@ -25,12 +25,21 @@ class StockPicking(models.Model):
         one invoice to show.
         """
         self.ensure_one()
-        action = self.env.ref('account.action_invoice_tree1')
+        # Determine display out invoices views or in invoices views
+        if (self.location_dest_id.usage == 'customer'
+                or self.location_id.usage == 'customer'):
+            action_name = 'account.action_invoice_tree1'
+            form_view_name = 'account.invoice_form'
+        else:
+            action_name = 'account.action_invoice_tree2'
+            form_view_name = 'account.invoice_supplier_form'
+
+        action = self.env.ref(action_name)
         result = action.read()[0]
         if len(self.invoice_ids) > 1:
             result['domain'] = "[('id', 'in', %s)]" % self.invoice_ids.ids
         else:
-            form_view = self.env.ref('account.invoice_form')
+            form_view = self.env.ref(form_view_name)
             result['views'] = [(form_view.id, 'form')]
             result['res_id'] = self.invoice_ids.id
         return result

--- a/stock_picking_invoice_link/readme/CONTRIBUTORS.rst
+++ b/stock_picking_invoice_link/readme/CONTRIBUTORS.rst
@@ -18,6 +18,7 @@
 
   * Pedro M. Baeza <pedro.baeza@tecnativa.com>
   * David Vidal <david.vidal@tecnativa.com>
+  * Sergio Teruel <sergio.teruel@tecnativa.com>
 
 * Unai Alkorta
 * Iñaki Zabala

--- a/stock_picking_invoice_link/static/description/index.html
+++ b/stock_picking_invoice_link/static/description/index.html
@@ -442,6 +442,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a><ul>
 <li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;tecnativa.com">pedro.baeza&#64;tecnativa.com</a>&gt;</li>
 <li>David Vidal &lt;<a class="reference external" href="mailto:david.vidal&#64;tecnativa.com">david.vidal&#64;tecnativa.com</a>&gt;</li>
+<li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
 </ul>
 </li>
 <li>Unai Alkorta</li>

--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -4,6 +4,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo.addons.sale.tests.test_sale_common import TestSale
+from odoo.exceptions import UserError
 
 
 class TestStockPickingInvoiceLink(TestSale):
@@ -26,28 +27,34 @@ class TestStockPickingInvoiceLink(TestSale):
         for (_, p) in self.products.items():
             if p.type == 'product':
                 self._update_product_qty(p, stock_location)
-        prod_order = self.products['prod_order']
-        prod_del = self.products['prod_del']
-        serv_order = self.products['serv_order']
+        self.prod_order = self.products['prod_order']
+        self.prod_del = self.products['prod_del']
+        self.serv_order = self.products['serv_order']
         self.so = self.env['sale.order'].create({
             'partner_id': self.partner.id,
             'partner_invoice_id': self.partner.id,
             'partner_shipping_id': self.partner.id,
             'order_line': [
                 (0, 0, {
-                    'name': prod_order.name, 'product_id': prod_order.id,
-                    'product_uom_qty': 2, 'product_uom': prod_order.uom_id.id,
-                    'price_unit': prod_order.list_price
+                    'name': self.prod_order.name,
+                    'product_id': self.prod_order.id,
+                    'product_uom_qty': 2,
+                    'product_uom': self.prod_order.uom_id.id,
+                    'price_unit': self.prod_order.list_price
                 }),
                 (0, 0, {
-                    'name': prod_del.name, 'product_id': prod_del.id,
-                    'product_uom_qty': 2, 'product_uom': prod_del.uom_id.id,
-                    'price_unit': prod_del.list_price
+                    'name': self.prod_del.name,
+                    'product_id': self.prod_del.id,
+                    'product_uom_qty': 2,
+                    'product_uom': self.prod_del.uom_id.id,
+                    'price_unit': self.prod_del.list_price
                 }),
                 (0, 0, {
-                    'name': serv_order.name, 'product_id': serv_order.id,
-                    'product_uom_qty': 2, 'product_uom': serv_order.uom_id.id,
-                    'price_unit': serv_order.list_price
+                    'name': self.serv_order.name,
+                    'product_id': self.serv_order.id,
+                    'product_uom_qty': 2,
+                    'product_uom': self.serv_order.uom_id.id,
+                    'price_unit': self.serv_order.list_price
                 }),
             ],
             'pricelist_id': self.env.ref('product.list0').id,
@@ -128,3 +135,90 @@ class TestStockPickingInvoiceLink(TestSale):
         inv_3.picking_ids |= pick_1
         result = pick_1.action_view_invoice()
         self.assertEqual(result['views'][0][1], 'tree')
+
+        # Cancel invoice and invoice
+        inv_1.action_cancel()
+        self.so.action_invoice_create()
+        self.assertEqual(
+            inv_1.picking_ids, pick_1,
+            "Invoice 1 must link to only First Partial Delivery")
+        self.assertEqual(
+            inv_1.invoice_line_ids.mapped('move_line_ids'),
+            pick_1.move_lines.filtered(
+                lambda x: x.product_id.invoice_policy == "delivery"),
+            "Invoice 1 lines must link to only First Partial Delivery lines")
+        # Try to update a picking move which has a invoice line linked
+        with self.assertRaises(UserError):
+            pick_1.move_line_ids.write({'qty_done': 20.0})
+
+    def test_return_picking_to_refund(self):
+        pick_1 = self.so.picking_ids.filtered(
+            lambda x: x.picking_type_code == 'outgoing' and
+            x.state in ('confirmed', 'assigned', 'partially_available'))
+        pick_1.move_line_ids.write({'qty_done': 2})
+        pick_1.action_done()
+
+        # Create invoice
+        inv_id = self.so.action_invoice_create()
+        inv = self.env['account.invoice'].browse(inv_id)
+        inv_line_prod_del = inv.invoice_line_ids.filtered(
+            lambda l: l.product_id == self.prod_del)
+        self.assertEqual(
+            inv_line_prod_del.move_line_ids,
+            pick_1.move_lines.filtered(
+                lambda m: m.product_id == self.prod_del)
+        )
+
+        # Create return picking
+        StockReturnPicking = self.env['stock.return.picking']
+        default_data = StockReturnPicking.with_context(
+            active_ids=pick_1.ids,
+            active_id=pick_1.ids[0]
+        ).default_get([
+            'move_dest_exists', 'original_location_id', 'product_return_moves',
+            'parent_location_id', 'location_id'])
+        return_wiz = StockReturnPicking.with_context(
+            active_ids=pick_1.ids, active_id=pick_1.ids[0]
+        ).create(default_data)
+        # Remove product ordered line
+        return_wiz.product_return_moves.filtered(
+            lambda l: l.product_id == self.prod_order).unlink()
+        return_wiz.product_return_moves.quantity = 1.0
+        return_wiz.product_return_moves.to_refund = True
+        res = return_wiz.create_returns()
+        return_pick = self.env['stock.picking'].browse(res['res_id'])
+        # Validate picking
+        return_pick.move_lines.quantity_done = 1.0
+        return_pick.button_validate()
+        inv_id = self.so.action_invoice_create(final=True)
+        inv = self.env['account.invoice'].browse(inv_id)
+        inv_line_prod_del = inv.invoice_line_ids.filtered(
+            lambda l: l.product_id == self.prod_del)
+        self.assertEqual(
+            inv_line_prod_del.move_line_ids, return_pick.move_lines)
+
+    def test_invoice_refund(self):
+        pick_1 = self.so.picking_ids.filtered(
+            lambda x: x.picking_type_code == 'outgoing' and
+            x.state in ('confirmed', 'assigned', 'partially_available'))
+        pick_1.move_line_ids.write({'qty_done': 2})
+        pick_1.action_done()
+        # Create invoice
+        inv_id = self.so.action_invoice_create()
+        inv = self.env['account.invoice'].browse(inv_id)
+        inv.action_invoice_open()
+        move_line_prod_del = pick_1.move_lines.filtered(
+            lambda l: l.product_id == self.prod_del)
+        wiz_invoice_refund = self.env['account.invoice.refund'].with_context(
+            active_ids=inv_id
+        ).create({
+            'description': 'test',
+            'filter_refund': 'modify',
+        })
+        wiz_invoice_refund.invoice_refund()
+        refund_invoice = self.so.invoice_ids.filtered(
+            lambda i: i.type == 'out_invoice' and i.state == 'draft')
+        inv_line_refund_prod_del = refund_invoice.invoice_line_ids.filtered(
+            lambda l: l.product_id == self.prod_del)
+        self.assertEqual(move_line_prod_del,
+                         inv_line_refund_prod_del.move_line_ids)

--- a/stock_picking_invoice_link/views/account_invoice_view.xml
+++ b/stock_picking_invoice_link/views/account_invoice_view.xml
@@ -9,7 +9,7 @@
         <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page string="Pickings" name="pickings">
+                <page string="Pickings" name="pickings" attrs="{'invisible': [('picking_ids', '=', [])]}">
                     <field name="picking_ids"/>
                 </page>
             </notebook>

--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -7,19 +7,18 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
-            <field name="state" position="before">
-                    <button name="action_view_invoice" type="object"
-                        string="View Invoice" class="oe_highlight"
-                        attrs="{'invisible': [('invoice_ids', '=', [])]}"
-                        groups="base.group_user"/>
-            </field>
-            <xpath expr="//group/field[@name='picking_type_id']" position="after">
-                <field name="invoice_ids" string="Invoice"
-                    groups="account.group_account_invoice"
-                    attrs="{'invisible':[('invoice_ids', '=', False)]}"
-                    widget="many2many_tags"
-                    context="{'tree_view_ref': 'account.invoice_tree', 'form_view_ref': 'account.invoice_form'}"/>
-            </xpath>
+            <div name="button_box" position="inside">
+                <field name="invoice_ids" invisible="1"/>
+                <button name="action_view_invoice"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-pencil-square-o"
+                    attrs="{'invisible': [('invoice_ids', '=', [])]}" groups="base.group_user">
+                    <div class="o_form_field o_stat_info">
+                        <span class="o_stat_text">Invoices</span>
+                    </div>
+                </button>
+            </div>
         </field>
     </record>
 
@@ -29,9 +28,13 @@
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_form"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="invoice_line_id" groups="account.group_account_invoice"/>
-            </field>
+            <group name="linked_group" position="after">
+                <group name="invoice_line" string="Invoice Lines" colspan="2" attrs="{'invisible':[('invoice_line_ids', '=', [])]}">
+                    <field name="invoice_line_ids" nolabel="1"
+                           groups="account.group_account_invoice"
+                           widget="one2many_list"/>
+                </group>
+            </group>
         </field>
     </record>
 
@@ -40,9 +43,13 @@
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_picking_form"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="invoice_line_id" groups="account.group_account_invoice"/>
-            </field>
+            <group position="after">
+                <group name="invoice_line" string="Invoice Lines" attrs="{'invisible':[('invoice_line_ids', '=', [])]}">
+                    <field name="invoice_line_ids" nolabel="1"
+                           groups="account.group_account_invoice"
+                           widget="one2many_list"/>
+                </group>
+            </group>
         </field>
     </record>
 


### PR DESCRIPTION
This commit is forwardport from a v11.0 commit (https://github.com/OCA/stock-logistics-workflow/commit/c087ce6c20cade3823f4b8ae985b0fab51bfe519)

Mybe I need a migration script for new v12..0 installations, but if the instance come from a v11.0 the field is many2many yet... 
openupgrade.m2o_to_x2m(env.cr, env['stock.move'], 'stock_move', 'invoice_line_ids', 'invoice_line_id')

cc @Tecnativa