### PR TITLE
[12.0] [FIX] stock_picking_line_sequence install with unuseful and very slow update of stock moves

### DIFF
--- a/stock_picking_line_sequence/init_hooks.py
+++ b/stock_picking_line_sequence/init_hooks.py
@@ -12,4 +12,4 @@ def post_init_hook(cr, pool):
     """
     env = Environment(cr, SUPERUSER_ID, {})
     stock = env['stock.picking'].search([])
-    stock._reset_sequence()
+    stock.with_context(skip_update_line_ids=True)._reset_sequence()


### PR DESCRIPTION
When install module stock_picking_line_sequence on an existing db with data, it force recomputation of all stock.move with deletion and re-creation of all stock.picking.package.preparation.line