### PR TITLE
[13.0][ADD] stock_partner_delivery_window

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,0 @@
-partner-contact
-server-tools

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,2 @@
+partner-contact
+server-tools

--- a/setup/stock_partner_delivery_window/odoo/addons/stock_partner_delivery_window
+++ b/setup/stock_partner_delivery_window/odoo/addons/stock_partner_delivery_window
@@ -1,0 +1,1 @@
+../../../../stock_partner_delivery_window

--- a/setup/stock_partner_delivery_window/setup.py
+++ b/setup/stock_partner_delivery_window/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_partner_delivery_window/__init__.py
+++ b/stock_partner_delivery_window/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_partner_delivery_window/__manifest__.py
+++ b/stock_partner_delivery_window/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "Camptocamp, ACSONE SA/NV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/stock-logistics-workflow",
-    "depends": ["base_time_window", "stock"],
+    "depends": ["base_time_window", "partner_tz", "stock"],
     "data": [
         "security/ir.model.access.csv",
         "views/res_partner.xml",

--- a/stock_partner_delivery_window/__manifest__.py
+++ b/stock_partner_delivery_window/__manifest__.py
@@ -9,12 +9,7 @@
     "license": "AGPL-3",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "depends": ["base_time_window", "partner_tz", "stock"],
-    "data": [
-        "security/ir.model.access.csv",
-        "views/res_partner.xml",
-    ],
-    "demo": [
-        "demo/delivery_time_window.xml",
-    ],
+    "data": ["security/ir.model.access.csv", "views/res_partner.xml",],
+    "demo": ["demo/delivery_time_window.xml",],
     "installable": True,
 }

--- a/stock_partner_delivery_window/__manifest__.py
+++ b/stock_partner_delivery_window/__manifest__.py
@@ -13,5 +13,8 @@
         "security/ir.model.access.csv",
         "views/res_partner.xml",
     ],
+    "demo": [
+        "demo/delivery_time_window.xml",
+    ],
     "installable": True,
 }

--- a/stock_partner_delivery_window/__manifest__.py
+++ b/stock_partner_delivery_window/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "depends": ["base_time_window", "partner_tz", "stock"],
-    "data": ["security/ir.model.access.csv", "views/res_partner.xml",],
-    "demo": ["demo/delivery_time_window.xml",],
+    "data": ["security/ir.model.access.csv", "views/res_partner.xml"],
+    "demo": ["demo/delivery_time_window.xml"],
     "installable": True,
 }

--- a/stock_partner_delivery_window/__manifest__.py
+++ b/stock_partner_delivery_window/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Partner Delivery Window",
+    "summary": "Define preferred delivery time windows for partners",
+    "version": "13.0.1.0.0",
+    "category": "Inventory",
+    "author": "Camptocamp, ACSONE SA/NV, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "depends": ["base_time_window", "stock"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/res_partner.xml",
+    ],
+    "installable": True,
+}

--- a/stock_partner_delivery_window/demo/delivery_time_window.xml
+++ b/stock_partner_delivery_window/demo/delivery_time_window.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="demo_partner_delivery_window_1" model="partner.delivery.time.window">
+        <field name="partner_id" ref="base.res_partner_1" />
+        <field name="time_window_start">10.0</field>
+        <field name="time_window_end">18.0</field>
+        <field name="time_window_weekday_ids" eval="[(4, ref('base_time_window.time_weekday_monday'))]" />
+    </record>
+    <record id="base.res_partner_1" model="res.partner">
+        <field name="delivery_time_preference">time_windows</field>
+    </record>
+</odoo>

--- a/stock_partner_delivery_window/demo/delivery_time_window.xml
+++ b/stock_partner_delivery_window/demo/delivery_time_window.xml
@@ -1,10 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="demo_partner_delivery_window_1" model="partner.delivery.time.window">
         <field name="partner_id" ref="base.res_partner_1" />
         <field name="time_window_start">10.0</field>
         <field name="time_window_end">18.0</field>
-        <field name="time_window_weekday_ids" eval="[(4, ref('base_time_window.time_weekday_monday'))]" />
+        <field
+            name="time_window_weekday_ids"
+            eval="[(4, ref('base_time_window.time_weekday_monday'))]"
+        />
     </record>
     <record id="base.res_partner_1" model="res.partner">
         <field name="delivery_time_preference">time_windows</field>

--- a/stock_partner_delivery_window/models/__init__.py
+++ b/stock_partner_delivery_window/models/__init__.py
@@ -1,0 +1,3 @@
+from . import delivery_time_window
+from . import res_partner
+from . import stock_picking

--- a/stock_partner_delivery_window/models/delivery_time_window.py
+++ b/stock_partner_delivery_window/models/delivery_time_window.py
@@ -18,9 +18,8 @@ class DeliveryTimeWindow(models.Model):
     partner_id = fields.Many2one(
         "res.partner", required=True, index=True, ondelete='cascade'
     )
-    # TODO Move to base_time_window?
     tz = fields.Selection(
-        _tz_get, string='Timezone', default=lambda p: p.env.user.company_id.partner_id.tz
+        _tz_get, related="partner_id.tz", readonly=True,
     )
 
     @api.constrains("partner_id")

--- a/stock_partner_delivery_window/models/delivery_time_window.py
+++ b/stock_partner_delivery_window/models/delivery_time_window.py
@@ -3,8 +3,9 @@
 from datetime import datetime
 import pytz
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.addons.base.models.res_partner import _tz_get
+from odoo.addons.partner_tz.tools import tz_utils
 
 
 class DeliveryTimeWindow(models.Model):
@@ -21,6 +22,22 @@ class DeliveryTimeWindow(models.Model):
     tz = fields.Selection(
         _tz_get, related="partner_id.tz", readonly=True,
     )
+    tz_display_name = fields.Char(compute="_compute_tz_display_name")
+
+    @api.depends("start", "end", "weekday_ids", "tz")
+    def _compute_tz_display_name(self):
+        for record in self:
+            start_time = tz_utils.tz_to_tz_time(
+                record.tz, self.env.user.tz, record.get_start_time()
+            )
+            end_time = tz_utils.tz_to_tz_time(
+                record.tz, self.env.user.tz, record.get_end_time()
+            )
+            record.tz_display_name = _("{days}: From {start} to {end}").format(
+                days=", ".join(record.weekday_ids.mapped("display_name")),
+                start="%02d:%02d" % (start_time.hour, start_time.minute),
+                end="%02d:%02d" % (end_time.hour, end_time.minute),
+            )
 
     @api.constrains("partner_id")
     def check_window_no_overlaps(self):

--- a/stock_partner_delivery_window/models/delivery_time_window.py
+++ b/stock_partner_delivery_window/models/delivery_time_window.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class DeliveryTimeWindow(models.Model):
+
+    _name = "partner.delivery.time.window"
+    _inherit = "time.window.mixin"
+    _description = "Preferred delivery time windows"
+
+    _overlap_check_field = 'partner_id'
+
+    partner_id = fields.Many2one("res.partner")
+
+    @api.constrains("partner_id")
+    def check_window_no_overlaps(self):
+        return super().check_window_no_overlaps()

--- a/stock_partner_delivery_window/models/delivery_time_window.py
+++ b/stock_partner_delivery_window/models/delivery_time_window.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 from odoo.addons.base.models.res_partner import _tz_get
 

--- a/stock_partner_delivery_window/models/delivery_time_window.py
+++ b/stock_partner_delivery_window/models/delivery_time_window.py
@@ -1,6 +1,10 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from datetime import datetime
+import pytz
+
 from odoo import api, fields, models
+from odoo.addons.base.models.res_partner import _tz_get
 
 
 class DeliveryTimeWindow(models.Model):
@@ -11,8 +15,27 @@ class DeliveryTimeWindow(models.Model):
 
     _overlap_check_field = 'partner_id'
 
-    partner_id = fields.Many2one("res.partner")
+    partner_id = fields.Many2one(
+        "res.partner", required=True, index=True, ondelete='cascade'
+    )
+    # TODO Move to base_time_window?
+    tz = fields.Selection(
+        _tz_get, string='Timezone', default=lambda p: p.env.user.company_id.partner_id.tz
+    )
 
     @api.constrains("partner_id")
     def check_window_no_overlaps(self):
         return super().check_window_no_overlaps()
+
+    @api.model
+    def float_to_time(self, value):
+        # TODO Move to base_time_window?
+        res = super().float_to_time(value)
+        if self.tz and self.tz != 'UTC':
+            # Convert here to naive datetime in UTC
+            tz_loc = pytz.timezone(self.tz)
+            utc_loc = pytz.timezone('UTC')
+            tz_now = datetime.now().astimezone(tz_loc)
+            tz_res = datetime.combine(tz_now, res)
+            res = tz_loc.localize(tz_res).astimezone(utc_loc).replace(tzinfo=None).time()
+        return res

--- a/stock_partner_delivery_window/models/delivery_time_window.py
+++ b/stock_partner_delivery_window/models/delivery_time_window.py
@@ -14,7 +14,7 @@ class DeliveryTimeWindow(models.Model):
     _inherit = "time.window.mixin"
     _description = "Preferred delivery time windows"
 
-    _overlap_check_field = 'partner_id'
+    _time_window_overlap_check_field = 'partner_id'
 
     partner_id = fields.Many2one(
         "res.partner", required=True, index=True, ondelete='cascade'
@@ -22,22 +22,6 @@ class DeliveryTimeWindow(models.Model):
     tz = fields.Selection(
         _tz_get, related="partner_id.tz", readonly=True,
     )
-    tz_display_name = fields.Char(compute="_compute_tz_display_name")
-
-    @api.depends("start", "end", "weekday_ids", "tz")
-    def _compute_tz_display_name(self):
-        for record in self:
-            start_time = tz_utils.tz_to_tz_time(
-                record.tz, self.env.user.tz, record.get_start_time()
-            )
-            end_time = tz_utils.tz_to_tz_time(
-                record.tz, self.env.user.tz, record.get_end_time()
-            )
-            record.tz_display_name = _("{days}: From {start} to {end}").format(
-                days=", ".join(record.weekday_ids.mapped("display_name")),
-                start="%02d:%02d" % (start_time.hour, start_time.minute),
-                end="%02d:%02d" % (end_time.hour, end_time.minute),
-            )
 
     @api.constrains("partner_id")
     def check_window_no_overlaps(self):
@@ -48,10 +32,6 @@ class DeliveryTimeWindow(models.Model):
         # TODO Move to base_time_window?
         res = super().float_to_time(value)
         if self.tz and self.tz != 'UTC':
-            # Convert here to naive datetime in UTC
-            tz_loc = pytz.timezone(self.tz)
-            utc_loc = pytz.timezone('UTC')
-            tz_now = datetime.now().astimezone(tz_loc)
-            tz_res = datetime.combine(tz_now, res)
-            res = tz_loc.localize(tz_res).astimezone(utc_loc).replace(tzinfo=None).time()
+            # Convert here to time in UTC
+            res = tz_utils.tz_to_utc_time(self.tz, res)
         return res

--- a/stock_partner_delivery_window/models/delivery_time_window.py
+++ b/stock_partner_delivery_window/models/delivery_time_window.py
@@ -1,11 +1,8 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from datetime import datetime
-import pytz
 
 from odoo import api, fields, models, _
 from odoo.addons.base.models.res_partner import _tz_get
-from odoo.addons.partner_tz.tools import tz_utils
 
 
 class DeliveryTimeWindow(models.Model):
@@ -26,12 +23,3 @@ class DeliveryTimeWindow(models.Model):
     @api.constrains("partner_id")
     def check_window_no_overlaps(self):
         return super().check_window_no_overlaps()
-
-    @api.model
-    def float_to_time(self, value):
-        # TODO Move to base_time_window?
-        res = super().float_to_time(value)
-        if self.tz and self.tz != 'UTC':
-            # Convert here to time in UTC
-            res = tz_utils.tz_to_utc_time(self.tz, res)
-        return res

--- a/stock_partner_delivery_window/models/delivery_time_window.py
+++ b/stock_partner_delivery_window/models/delivery_time_window.py
@@ -1,7 +1,8 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo import api, fields, models, _
+from odoo import _, api, fields, models
+
 from odoo.addons.base.models.res_partner import _tz_get
 
 
@@ -11,14 +12,12 @@ class DeliveryTimeWindow(models.Model):
     _inherit = "time.window.mixin"
     _description = "Preferred delivery time windows"
 
-    _time_window_overlap_check_field = 'partner_id'
+    _time_window_overlap_check_field = "partner_id"
 
     partner_id = fields.Many2one(
-        "res.partner", required=True, index=True, ondelete='cascade'
+        "res.partner", required=True, index=True, ondelete="cascade"
     )
-    tz = fields.Selection(
-        _tz_get, related="partner_id.tz", readonly=True,
-    )
+    tz = fields.Selection(_tz_get, related="partner_id.tz", readonly=True,)
 
     @api.constrains("partner_id")
     def check_window_no_overlaps(self):

--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -19,8 +20,22 @@ class ResPartner(models.Model):
     )
 
     delivery_time_window_ids = fields.One2many(
-        'partner.delivery.time.window', 'partner_id'
+        'partner.delivery.time.window',
+        'partner_id',
+        string="Delivery time windows",
     )
+
+    @api.constrains('delivery_time_preference', 'delivery_time_window_ids')
+    def _check_delivery_time_preference(self):
+        for partner in self:
+            if (
+                partner.delivery_time_preference == "time_windows" and
+                not partner.delivery_time_window_ids
+            ):
+                raise ValidationError(_(
+                    "Please define at least one delivery time window or change"
+                    " preference to Any time"
+                ))
 
     def get_delivery_windows(self, day_name=None):
         """

--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -50,7 +50,7 @@ class ResPartner(models.Model):
             week_day_id = self.env["time.weekday"]._get_id_by_name(
                 day_name
             )
-            domain.append(("weekday_ids", "in", week_day_id))
+            domain.append(("time_window_weekday_ids", "in", week_day_id))
         windows = self.env["partner.delivery.time.window"].search(
             domain
         )
@@ -65,6 +65,6 @@ class ResPartner(models.Model):
         windows = self.get_delivery_windows(date_time.weekday()).get(self.id)
         if windows:
             for w in windows:
-                if w.get_start_time() <= date_time.time() <= w.get_end_time():
+                if w.get_time_window_start_time() <= date_time.time() <= w.get_time_window_end_time():
                     return True
         return False

--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -47,7 +47,7 @@ class ResPartner(models.Model):
 
     def is_in_delivery_window(self, date_time):
         self.ensure_one()
-        windows = self.get_delivery_windows(date_time.weekday())
+        windows = self.get_delivery_windows(date_time.weekday()).get(self.id)
         for w in windows:
             if w.get_start_time() <= date_time.time() <= w.get_end_time():
                 return True

--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
 from odoo.addons.partner_tz.tools import tz_utils
 
 
@@ -21,22 +22,22 @@ class ResPartner(models.Model):
     )
 
     delivery_time_window_ids = fields.One2many(
-        'partner.delivery.time.window',
-        'partner_id',
-        string="Delivery time windows",
+        "partner.delivery.time.window", "partner_id", string="Delivery time windows",
     )
 
-    @api.constrains('delivery_time_preference', 'delivery_time_window_ids')
+    @api.constrains("delivery_time_preference", "delivery_time_window_ids")
     def _check_delivery_time_preference(self):
         for partner in self:
             if (
-                partner.delivery_time_preference == "time_windows" and
-                not partner.delivery_time_window_ids
+                partner.delivery_time_preference == "time_windows"
+                and not partner.delivery_time_window_ids
             ):
-                raise ValidationError(_(
-                    "Please define at least one delivery time window or change"
-                    " preference to Any time"
-                ))
+                raise ValidationError(
+                    _(
+                        "Please define at least one delivery time window or change"
+                        " preference to Any time"
+                    )
+                )
 
     def get_delivery_windows(self, day_name=None):
         """
@@ -48,16 +49,14 @@ class ResPartner(models.Model):
         res = {}
         domain = [("partner_id", "in", self.ids)]
         if day_name is not None:
-            week_day_id = self.env["time.weekday"]._get_id_by_name(
-                day_name
-            )
+            week_day_id = self.env["time.weekday"]._get_id_by_name(day_name)
             domain.append(("time_window_weekday_ids", "in", week_day_id))
-        windows = self.env["partner.delivery.time.window"].search(
-            domain
-        )
+        windows = self.env["partner.delivery.time.window"].search(domain)
         for window in windows:
             if not res.get(window.partner_id.id):
-                res[window.partner_id.id] = self.env["partner.delivery.time.window"].browse()
+                res[window.partner_id.id] = self.env[
+                    "partner.delivery.time.window"
+                ].browse()
             res[window.partner_id.id] |= window
         return res
 

--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -8,14 +8,14 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     delivery_time_preference = fields.Selection(
-        [("direct", "As soon as possible"), ("fix_weekdays", "Fixed week days")],
+        [("anytime", "Any time"), ("time_windows", "Fixed time windows")],
         string="Delivery time schedule preference",
-        default="direct",
+        default="anytime",
         required=True,
         help="Define the scheduling preference for delivery orders:\n\n"
-        "* As soon as possible: Do not postpone deliveries\n"
-        "* Fixed week days: Postpone deliveries to the next preferred "
-        "weekday",
+        "* Any time: Do not postpone deliveries\n"
+        "* Fixed time windows: Postpone deliveries to the next preferred "
+        "time window",
     )
 
     delivery_time_window_ids = fields.One2many(
@@ -48,7 +48,8 @@ class ResPartner(models.Model):
     def is_in_delivery_window(self, date_time):
         self.ensure_one()
         windows = self.get_delivery_windows(date_time.weekday()).get(self.id)
-        for w in windows:
-            if w.get_start_time() <= date_time.time() <= w.get_end_time():
-                return True
+        if windows:
+            for w in windows:
+                if w.get_start_time() <= date_time.time() <= w.get_end_time():
+                    return True
         return False

--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import _, api, fields, models
+
+
+class ResPartner(models.Model):
+
+    _inherit = "res.partner"
+
+    delivery_time_preference = fields.Selection(
+        [("direct", "As soon as possible"), ("fix_weekdays", "Fixed week days")],
+        string="Delivery time schedule preference",
+        default="direct",
+        required=True,
+        help="Define the scheduling preference for delivery orders:\n\n"
+        "* As soon as possible: Do not postpone deliveries\n"
+        "* Fixed week days: Postpone deliveries to the next preferred "
+        "weekday",
+    )
+
+    delivery_time_window_ids = fields.One2many(
+        'partner.delivery.time.window', 'partner_id'
+    )
+
+    def get_delivery_windows(self, day_name=None):
+        """
+        Return the list of delivery windows by partner id for the given day
+
+        :param day: The day name (see time.weekday, ex: 0,1,2,...)
+        :return: dict partner_id: delivery_window recordset
+        """
+        res = {}
+        domain = [("partner_id", "in", self.ids)]
+        if day_name is not None:
+            week_day_id = self.env["time.weekday"]._get_id_by_name(
+                day_name
+            )
+            domain.append(("weekday_ids", "in", week_day_id))
+        windows = self.env["partner.delivery.time.window"].search(
+            domain
+        )
+        for window in windows:
+            if not res.get(window.partner_id.id):
+                res[window.partner_id.id] = self.env["partner.delivery.time.window"].browse()
+            res[window.partner_id.id] |= window
+        return res
+
+    def is_in_delivery_window(self, date_time):
+        self.ensure_one()
+        windows = self.get_delivery_windows(date_time.weekday())
+        for w in windows:
+            if w.get_start_time() <= date_time.time() <= w.get_end_time():
+                return True
+        return False

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import _, api, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    @api.onchange('scheduled_date')
+    def _onchange_scheduled_date(self):
+        self.ensure_one()
+        if (
+            not self.partner_id or
+            self.partner_id.delivery_time_preference != 'fix_weekdays' or
+            self.picking_type_id.code != 'outgoing'
+        ):
+            return
+        p = self.partner_id
+        if not p.is_in_delivery_window(self.scheduled_date):
+            return {
+                "warning": {
+                    "title": _(
+                        "Scheduled date does not match partner's Delivery time"
+                        " schedule preference."
+                    ),
+                    "message": _(
+                        "The scheduled date is %s, but the partner is "
+                        "set to prefer deliveries on following time windows:\n%s"
+                        % (
+                            # FIXME handle date format + translation
+                            self.scheduled_date,
+                            '\n'.join(
+                                [
+                                    "  * %s" % w.display_name
+                                    for w
+                                    in p.get_delivery_windows().get(p.id)
+                                ]
+                            ),
+                        )
+                    ),
+                }
+            }

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -1,5 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from datetime import timedelta
+
 from odoo import _, api, models
 from odoo.tools.misc import format_datetime
 
@@ -17,26 +19,36 @@ class StockPicking(models.Model):
         ):
             return
         p = self.partner_id
-        if not p.is_in_delivery_window(self.scheduled_date):
+        sec_lead_time = self.company_id.security_lead
+        delivery_date = self.scheduled_date + timedelta(days=sec_lead_time)
+        if not p.is_in_delivery_window(delivery_date):
+            message = _(
+                "The scheduled date is %s, but the partner is "
+                "set to prefer deliveries on following time windows:\n%s"
+                % (
+                    format_datetime(self.env, self.scheduled_date),
+                    '\n'.join(
+                        [
+                            "  * %s" % w.display_name
+                            for w
+                            in p.get_delivery_windows().get(p.id)
+                        ]
+                    ),
+                )
+            )
+            if sec_lead_time:
+                message += _(
+                    "\nConsidering the security lead time of %s days defined on "
+                    "the company, the delivery will not match the partner time"
+                    "windows preference."
+                    % sec_lead_time
+                )
             return {
                 "warning": {
                     "title": _(
-                        "Scheduled date does not match partner's Delivery time"
-                        " schedule preference."
+                        "Scheduled date does not match partner's Delivery window"
+                        " preference."
                     ),
-                    "message": _(
-                        "The scheduled date is %s, but the partner is "
-                        "set to prefer deliveries on following time windows:\n%s"
-                        % (
-                            format_datetime(self.env, self.scheduled_date),
-                            '\n'.join(
-                                [
-                                    "  * %s" % w.display_name
-                                    for w
-                                    in p.get_delivery_windows().get(p.id)
-                                ]
-                            ),
-                        )
-                    ),
+                    "message": message,
                 }
             }

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -9,13 +9,13 @@ from odoo.tools.misc import format_datetime
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    @api.onchange('scheduled_date')
+    @api.onchange("scheduled_date")
     def _onchange_scheduled_date(self):
         self.ensure_one()
         if (
-            not self.partner_id or
-            self.partner_id.delivery_time_preference != 'time_windows' or
-            self.picking_type_id.code != 'outgoing'
+            not self.partner_id
+            or self.partner_id.delivery_time_preference != "time_windows"
+            or self.picking_type_id.code != "outgoing"
         ):
             return
         p = self.partner_id
@@ -27,11 +27,10 @@ class StockPicking(models.Model):
                 "set to prefer deliveries on following time windows:\n%s"
                 % (
                     format_datetime(self.env, self.scheduled_date),
-                    '\n'.join(
+                    "\n".join(
                         [
                             "  * %s" % w.display_name
-                            for w
-                            in p.get_delivery_windows().get(p.id)
+                            for w in p.get_delivery_windows().get(p.id)
                         ]
                     ),
                 )
@@ -40,8 +39,7 @@ class StockPicking(models.Model):
                 message += _(
                     "\nConsidering the security lead time of %s days defined on "
                     "the company, the delivery will not match the partner time"
-                    "windows preference."
-                    % sec_lead_time
+                    "windows preference." % sec_lead_time
                 )
             return {
                 "warning": {

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -27,7 +27,7 @@ class StockPicking(models.Model):
                         "The scheduled date is %s, but the partner is "
                         "set to prefer deliveries on following time windows:\n%s"
                         % (
-                            # FIXME handle date format + translation
+                            # TODO handle date format + tz + translation
                             self.scheduled_date,
                             '\n'.join(
                                 [

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import _, api, models
+from odoo.addons.partner_tz.tools import tz_utils
 
 
 class StockPicking(models.Model):
@@ -17,6 +18,8 @@ class StockPicking(models.Model):
             return
         p = self.partner_id
         if not p.is_in_delivery_window(self.scheduled_date):
+            user_tz = self.env.user.tz
+            tz_scheduled_date = tz_utils.utc_to_tz_naive_datetime(user_tz, self.scheduled_date)
             return {
                 "warning": {
                     "title": _(
@@ -27,11 +30,11 @@ class StockPicking(models.Model):
                         "The scheduled date is %s, but the partner is "
                         "set to prefer deliveries on following time windows:\n%s"
                         % (
-                            # TODO handle date format + tz + translation
-                            self.scheduled_date,
+                            # TODO handle date format
+                            tz_scheduled_date,
                             '\n'.join(
                                 [
-                                    "  * %s" % w.display_name
+                                    "  * %s" % w.tz_display_name
                                     for w
                                     in p.get_delivery_windows().get(p.id)
                                 ]

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -12,7 +12,7 @@ class StockPicking(models.Model):
         self.ensure_one()
         if (
             not self.partner_id or
-            self.partner_id.delivery_time_preference != 'fix_weekdays' or
+            self.partner_id.delivery_time_preference != 'time_windows' or
             self.picking_type_id.code != 'outgoing'
         ):
             return

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import _, api, models
-from odoo.addons.partner_tz.tools import tz_utils
+from odoo.tools.misc import format_datetime
 
 
 class StockPicking(models.Model):
@@ -18,8 +18,6 @@ class StockPicking(models.Model):
             return
         p = self.partner_id
         if not p.is_in_delivery_window(self.scheduled_date):
-            user_tz = self.env.user.tz
-            tz_scheduled_date = tz_utils.utc_to_tz_naive_datetime(user_tz, self.scheduled_date)
             return {
                 "warning": {
                     "title": _(
@@ -30,11 +28,10 @@ class StockPicking(models.Model):
                         "The scheduled date is %s, but the partner is "
                         "set to prefer deliveries on following time windows:\n%s"
                         % (
-                            # TODO handle date format
-                            tz_scheduled_date,
+                            format_datetime(self.env, self.scheduled_date),
                             '\n'.join(
                                 [
-                                    "  * %s" % w.tz_display_name
+                                    "  * %s" % w.display_name
                                     for w
                                     in p.get_delivery_windows().get(p.id)
                                 ]

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -1,13 +1,14 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from datetime import timedelta
-
 from odoo import _, api, models
 from odoo.tools.misc import format_datetime
 
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
+
+    def _planned_delivery_date(self):
+        return self.scheduled_date
 
     @api.onchange("scheduled_date")
     def _onchange_scheduled_date(self):
@@ -19,9 +20,7 @@ class StockPicking(models.Model):
         ):
             return
         p = self.partner_id
-        sec_lead_time = self.company_id.security_lead
-        delivery_date = self.scheduled_date + timedelta(days=sec_lead_time)
-        if not p.is_in_delivery_window(delivery_date):
+        if not p.is_in_delivery_window(self._planned_delivery_date()):
             message = _(
                 "The scheduled date is %s, but the partner is "
                 "set to prefer deliveries on following time windows:\n%s"
@@ -35,12 +34,6 @@ class StockPicking(models.Model):
                     ),
                 )
             )
-            if sec_lead_time:
-                message += _(
-                    "\nConsidering the security lead time of %s days defined on "
-                    "the company, the delivery will not match the partner time"
-                    "windows preference." % sec_lead_time
-                )
             return {
                 "warning": {
                     "title": _(

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -21,17 +21,18 @@ class StockPicking(models.Model):
             return
         p = self.partner_id
         if not p.is_in_delivery_window(self._planned_delivery_date()):
+            delivery_windows_strings = []
+            for w in p.get_delivery_windows().get(p.id):
+                delivery_windows_strings.append(
+                    "  * {} ({})".format(w.display_name, self.partner_id.tz)
+                )
             message = _(
-                "The scheduled date is %s, but the partner is "
+                "The scheduled date is %s (%s), but the partner is "
                 "set to prefer deliveries on following time windows:\n%s"
                 % (
                     format_datetime(self.env, self.scheduled_date),
-                    "\n".join(
-                        [
-                            "  * %s" % w.display_name
-                            for w in p.get_delivery_windows().get(p.id)
-                        ]
-                    ),
+                    self.env.context.get("tz"),
+                    "\n".join(delivery_windows_strings),
                 )
             )
             return {

--- a/stock_partner_delivery_window/readme/CONFIGURE.rst
+++ b/stock_partner_delivery_window/readme/CONFIGURE.rst
@@ -1,0 +1,10 @@
+On partners form view, under the "Sales & Purchases" tab, one can define a
+"Delivery schedule preference" for each partner.
+
+Possible configurations are:
+
+* Any time: Do not postpone deliveries
+* Fixed time windows: Postpone deliveries to the next preferred time window
+
+After selecting "Fixed time windows", one can define the preferred delivery
+windows in the embedded tree view below.

--- a/stock_partner_delivery_window/readme/CONTRIBUTORS.rst
+++ b/stock_partner_delivery_window/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_partner_delivery_window/readme/DESCRIPTION.rst
+++ b/stock_partner_delivery_window/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module allows to define time scheduling preference for delivery orders on
+partners, in order to raise a warning when changing a scheduled date to a time
+window that is not preferred by this customer.

--- a/stock_partner_delivery_window/security/ir.model.access.csv
+++ b/stock_partner_delivery_window/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+access_partner_delivery_time_window_user,access_partner_delivery_time_window_user,model_partner_delivery_time_window,base.group_user,1,0,0,0
+access_partner_delivery_time_window_manager,access_partner_delivery_time_window_manager,model_partner_delivery_time_window,stock.group_stock_manager,1,1,1,1

--- a/stock_partner_delivery_window/tests/__init__.py
+++ b/stock_partner_delivery_window/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)

--- a/stock_partner_delivery_window/tests/__init__.py
+++ b/stock_partner_delivery_window/tests/__init__.py
@@ -1,2 +1,1 @@
-# Copyright 2020 Camptocamp SA
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from . import test_delivery_window

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -1,187 +1,29 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 ACSONE SA/NV
+# Copyright 2020 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.exceptions import ValidationError
 from odoo.tests import SavepointCase
 
 
-class TestTimeWindow(SavepointCase):
+class TestPartnerDeliveryWindow(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # cls.partner_1 = cls.env['res.partner'].create({'name': 'partner 1'})
-        # cls.partner_2 = cls.env['res.partner'].create({'name': 'patner 2'})
-        cls.DeliveryWindow = cls.env["delivery.window"]
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner_1 = cls.env['res.partner'].create({'name': 'partner 1'})
+        cls.partner_2 = cls.env['res.partner'].create({'name': 'partner 2'})
+        cls.DeliveryWindow = cls.env["partner.delivery.time.window"]
         cls.monday = cls.env.ref(
-            "partner_delivery_window.delivery_weekday_monday"
+            "base_time_window.time_weekday_monday"
         )
         cls.sunday = cls.env.ref(
-            "partner_delivery_window.delivery_weekday_sunday"
+            "base_time_window.time_weekday_sunday"
         )
+        cls.demo_user = cls.env.ref("base.user_demo")
 
-    def test_00(self):
-        """
-        Data:
-            A partner without delivery window
-        Test Case:
-            Add a delivery window
-        Expected result:
-            A delivery window is created for the partner
-        """
+    def test_delivery_window_warning(self):
+        pass
 
-        self.assertFalse(self.partner_1.delivery_window_ids)
-        self.DeliveryWindow.create(
-            {
-                "partner_id": self.partner_1.id,
-                "start": 10.0,
-                "end": 12.0,
-                "week_day_ids": [(4, self.monday.id)],
-            }
-        )
-        self.assertTrue(self.partner_1.delivery_window_ids)
-        delivery_window = self.partner_1.delivery_window_ids
-        self.assertEqual(delivery_window.start, 10.0)
-        self.assertEqual(delivery_window.end, 12.0)
-        self.assertEqual(delivery_window.week_day_ids, self.monday)
+    def test_with_timezone(self):
+        pass
 
-    def test_01(self):
-        """
-        Data:
-            A partner without delivery window
-        Test Case:
-            1 Add a delivery window
-            2 unlink the partner
-        Expected result:
-            1 A delivery window is created for the partner
-            2 The delivery window is removed
-        """
-        partner_id = self.partner_1.id
-        self.assertFalse(self.partner_1.delivery_window_ids)
-        self.DeliveryWindow.create(
-            {
-                "partner_id": self.partner_1.id,
-                "start": 10.0,
-                "end": 12.0,
-                "week_day_ids": [(4, self.monday.id)],
-            }
-        )
-        self.assertTrue(self.partner_1.delivery_window_ids)
-        delivery_window = self.DeliveryWindow.search(
-            [("partner_id", "=", partner_id)]
-        )
-        self.assertTrue(delivery_window)
-        self.partner_1.unlink()
-        self.assertFalse(delivery_window.exists())
-
-    def test_02(self):
-        """
-        Data:
-            A partner without delivery window
-        Test Case:
-            1 Add a delivery window
-            2 Add a second delivery window that overlaps the first one (same day)
-        Expected result:
-            1 A delivery window is created for the partner
-            2 ValidationError is raised
-        """
-        self.DeliveryWindow.create(
-            {
-                "partner_id": self.partner_1.id,
-                "start": 10.0,
-                "end": 12.0,
-                "week_day_ids": [(4, self.monday.id)],
-            }
-        )
-        with self.assertRaises(ValidationError):
-            self.DeliveryWindow.create(
-                {
-                    "partner_id": self.partner_1.id,
-                    "start": 11.0,
-                    "end": 13.0,
-                    "week_day_ids": [(4, self.monday.id), (4, self.sunday.id)],
-                }
-            )
-
-    def test_03(self):
-        """
-        Data:
-            A partner without delivery window
-        Test Case:
-            1 Add a delivery window
-            2 Add a second delivery window that overlaps the first one (another day)
-        Expected result:
-            1 A delivery window is created for the partner
-            2 A second  delivery window is created for the partner
-        """
-        self.assertFalse(self.partner_1.delivery_window_ids)
-        self.DeliveryWindow.create(
-            {
-                "partner_id": self.partner_1.id,
-                "start": 10.0,
-                "end": 12.0,
-                "week_day_ids": [(4, self.monday.id)],
-            }
-        )
-        self.assertTrue(self.partner_1.delivery_window_ids)
-        self.DeliveryWindow.create(
-            {
-                "partner_id": self.partner_1.id,
-                "start": 11.0,
-                "end": 13.0,
-                "week_day_ids": [(4, self.sunday.id)],
-            }
-        )
-        self.assertEquals(len(self.partner_1.delivery_window_ids), 2)
-
-    def test_04(self):
-        """
-        Data:
-            Partner 1 without delivery window
-            Partner 2 without delivery window
-        Test Case:
-            1 Add a delivery window to partner 1
-            2 Add the same delivery window to partner 2
-        Expected result:
-            1 A delivery window is created for the partner 1
-            1 A delivery window is created for the partner 2
-        """
-        self.assertFalse(self.partner_1.delivery_window_ids)
-        self.DeliveryWindow.create(
-            {
-                "partner_id": self.partner_1.id,
-                "start": 10.0,
-                "end": 12.0,
-                "week_day_ids": [(4, self.monday.id)],
-            }
-        )
-        self.assertTrue(self.partner_1.delivery_window_ids)
-        self.assertFalse(self.partner_2.delivery_window_ids)
-        self.DeliveryWindow.create(
-            {
-                "partner_id": self.partner_2.id,
-                "start": 10.0,
-                "end": 12.0,
-                "week_day_ids": [(4, self.monday.id)],
-            }
-        )
-        self.assertTrue(self.partner_2.delivery_window_ids)
-
-    def test_05(self):
-        """""
-        Data:
-            Partner 1 without delivery window
-        Test Case:
-            Add a delivery window to partner 1 with end > start
-        Expected result:
-            ValidationError is raised
-        """
-        with self.assertRaises(ValidationError):
-            self.DeliveryWindow.create(
-                {
-                    "partner_id": self.partner_1.id,
-                    "start": 14.0,
-                    "end": 12.0,
-                    "week_day_ids": [(4, self.monday.id)],
-                }
-            )

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2020 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from freezegun import freeze_time
 
 from odoo.tests import SavepointCase
 
@@ -10,20 +11,84 @@ class TestPartnerDeliveryWindow(SavepointCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.partner_1 = cls.env['res.partner'].create({'name': 'partner 1'})
-        cls.partner_2 = cls.env['res.partner'].create({'name': 'partner 2'})
-        cls.DeliveryWindow = cls.env["partner.delivery.time.window"]
-        cls.monday = cls.env.ref(
-            "base_time_window.time_weekday_monday"
+        cls.customer = cls.env["res.partner"].create(
+            {"name": "ACME", "delivery_time_preference": "anytime"}
         )
-        cls.sunday = cls.env.ref(
-            "base_time_window.time_weekday_sunday"
+        cls.customer_shipping = cls.env["res.partner"].create(
+            {
+                "name": "Delivery address",
+                "parent_id": cls.customer.id,
+                "delivery_time_preference": "time_windows",
+                "delivery_time_window_ids": [(0, 0, {
+                    'time_window_start': 0.00,
+                    'time_window_end': 23.99,
+                    'time_window_weekday_ids': [
+                        (6, 0, [
+                            cls.env.ref('base_time_window.time_weekday_thursday').id,
+                            cls.env.ref('base_time_window.time_weekday_saturday').id
+                        ])
+                     ]
+                })]
+            }
         )
-        cls.demo_user = cls.env.ref("base.user_demo")
+        cls.product = cls.env.ref("product.product_product_9")
+        cls.picking_type_delivery = cls.env.ref("stock.picking_type_out")
+        cls.location_stock = cls.env.ref("stock.stock_location_stock")
+        cls.location_customers = cls.env.ref("stock.stock_location_customers")
 
+    def _create_delivery_picking(self, partner):
+        return self.env['stock.picking'].create(
+            {
+                "partner_id": partner.id,
+                "location_id": self.location_stock.id,
+                "location_dest_id": self.location_customers.id,
+                "picking_type_id": self.picking_type_delivery.id,
+            }
+        )
+
+    @freeze_time("2020-04-02")  # Thursday
     def test_delivery_window_warning(self):
-        pass
+        # No warning with anytime
+        cust_picking = self._create_delivery_picking(self.customer)
+        cust_picking.scheduled_date = "2020-04-03"  # Friday
+        onchange_res = cust_picking._onchange_scheduled_date()
+        self.assertIsNone(onchange_res)
+        # No warning on preferred time window
+        cust_ship_picking = self._create_delivery_picking(
+            self.customer_shipping
+        )
+        cust_ship_picking.scheduled_date = "2020-04-04"  # Saturday
+        onchange_res = cust_ship_picking._onchange_scheduled_date()
+        self.assertIsNone(onchange_res)
+        cust_ship_picking.scheduled_date = "2020-04-03"  # Friday
+        onchange_res = cust_ship_picking._onchange_scheduled_date()
+        self.assertTrue("warning" in onchange_res.keys())
 
+    @freeze_time("2020-04-02 09:00:00")  # Thursday
     def test_with_timezone(self):
-        pass
+        # Define customer to allow shipping only between 10.00am and 4.00pm
+        # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
 
+        # Frozen time is in UTC so 2020-04-02 09:00:00 == 2020-04-02 11:00:00
+        #  in Brussels which is preferred
+        self.customer_shipping.tz = 'Europe/Brussels'
+        self.customer_shipping.delivery_time_window_ids.write(
+            {
+                'time_window_start': 10.0,
+                'time_window_end': 16.0,
+            }
+        )
+        picking = self._create_delivery_picking(self.customer_shipping)
+        onchange_res = picking._onchange_scheduled_date()
+        # No warning since we're in the timeframe
+        self.assertIsNone(onchange_res)
+        # Scheduled date is in UTC so 2020-04-02 07:59:59 == 2020-04-02 09:59:59
+        #  in Brussels which is not preferred
+        picking.scheduled_date = "2020-04-02 07:59:59"
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertTrue("warning" in onchange_res.keys())
+        # Scheduled date is in UTC so 2020-04-02 07:59:59 == 2020-04-02 09:59:59
+        #  in Brussels which is not preferred
+        picking.scheduled_date = "2020-04-02 14:01:01"
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertTrue("warning" in onchange_res.keys())

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+from odoo.tests import SavepointCase
+
+
+class TestTimeWindow(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # cls.partner_1 = cls.env['res.partner'].create({'name': 'partner 1'})
+        # cls.partner_2 = cls.env['res.partner'].create({'name': 'patner 2'})
+        cls.DeliveryWindow = cls.env["delivery.window"]
+        cls.monday = cls.env.ref(
+            "partner_delivery_window.delivery_weekday_monday"
+        )
+        cls.sunday = cls.env.ref(
+            "partner_delivery_window.delivery_weekday_sunday"
+        )
+
+    def test_00(self):
+        """
+        Data:
+            A partner without delivery window
+        Test Case:
+            Add a delivery window
+        Expected result:
+            A delivery window is created for the partner
+        """
+
+        self.assertFalse(self.partner_1.delivery_window_ids)
+        self.DeliveryWindow.create(
+            {
+                "partner_id": self.partner_1.id,
+                "start": 10.0,
+                "end": 12.0,
+                "week_day_ids": [(4, self.monday.id)],
+            }
+        )
+        self.assertTrue(self.partner_1.delivery_window_ids)
+        delivery_window = self.partner_1.delivery_window_ids
+        self.assertEqual(delivery_window.start, 10.0)
+        self.assertEqual(delivery_window.end, 12.0)
+        self.assertEqual(delivery_window.week_day_ids, self.monday)
+
+    def test_01(self):
+        """
+        Data:
+            A partner without delivery window
+        Test Case:
+            1 Add a delivery window
+            2 unlink the partner
+        Expected result:
+            1 A delivery window is created for the partner
+            2 The delivery window is removed
+        """
+        partner_id = self.partner_1.id
+        self.assertFalse(self.partner_1.delivery_window_ids)
+        self.DeliveryWindow.create(
+            {
+                "partner_id": self.partner_1.id,
+                "start": 10.0,
+                "end": 12.0,
+                "week_day_ids": [(4, self.monday.id)],
+            }
+        )
+        self.assertTrue(self.partner_1.delivery_window_ids)
+        delivery_window = self.DeliveryWindow.search(
+            [("partner_id", "=", partner_id)]
+        )
+        self.assertTrue(delivery_window)
+        self.partner_1.unlink()
+        self.assertFalse(delivery_window.exists())
+
+    def test_02(self):
+        """
+        Data:
+            A partner without delivery window
+        Test Case:
+            1 Add a delivery window
+            2 Add a second delivery window that overlaps the first one (same day)
+        Expected result:
+            1 A delivery window is created for the partner
+            2 ValidationError is raised
+        """
+        self.DeliveryWindow.create(
+            {
+                "partner_id": self.partner_1.id,
+                "start": 10.0,
+                "end": 12.0,
+                "week_day_ids": [(4, self.monday.id)],
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.DeliveryWindow.create(
+                {
+                    "partner_id": self.partner_1.id,
+                    "start": 11.0,
+                    "end": 13.0,
+                    "week_day_ids": [(4, self.monday.id), (4, self.sunday.id)],
+                }
+            )
+
+    def test_03(self):
+        """
+        Data:
+            A partner without delivery window
+        Test Case:
+            1 Add a delivery window
+            2 Add a second delivery window that overlaps the first one (another day)
+        Expected result:
+            1 A delivery window is created for the partner
+            2 A second  delivery window is created for the partner
+        """
+        self.assertFalse(self.partner_1.delivery_window_ids)
+        self.DeliveryWindow.create(
+            {
+                "partner_id": self.partner_1.id,
+                "start": 10.0,
+                "end": 12.0,
+                "week_day_ids": [(4, self.monday.id)],
+            }
+        )
+        self.assertTrue(self.partner_1.delivery_window_ids)
+        self.DeliveryWindow.create(
+            {
+                "partner_id": self.partner_1.id,
+                "start": 11.0,
+                "end": 13.0,
+                "week_day_ids": [(4, self.sunday.id)],
+            }
+        )
+        self.assertEquals(len(self.partner_1.delivery_window_ids), 2)
+
+    def test_04(self):
+        """
+        Data:
+            Partner 1 without delivery window
+            Partner 2 without delivery window
+        Test Case:
+            1 Add a delivery window to partner 1
+            2 Add the same delivery window to partner 2
+        Expected result:
+            1 A delivery window is created for the partner 1
+            1 A delivery window is created for the partner 2
+        """
+        self.assertFalse(self.partner_1.delivery_window_ids)
+        self.DeliveryWindow.create(
+            {
+                "partner_id": self.partner_1.id,
+                "start": 10.0,
+                "end": 12.0,
+                "week_day_ids": [(4, self.monday.id)],
+            }
+        )
+        self.assertTrue(self.partner_1.delivery_window_ids)
+        self.assertFalse(self.partner_2.delivery_window_ids)
+        self.DeliveryWindow.create(
+            {
+                "partner_id": self.partner_2.id,
+                "start": 10.0,
+                "end": 12.0,
+                "week_day_ids": [(4, self.monday.id)],
+            }
+        )
+        self.assertTrue(self.partner_2.delivery_window_ids)
+
+    def test_05(self):
+        """""
+        Data:
+            Partner 1 without delivery window
+        Test Case:
+            Add a delivery window to partner 1 with end > start
+        Expected result:
+            ValidationError is raised
+        """
+        with self.assertRaises(ValidationError):
+            self.DeliveryWindow.create(
+                {
+                    "partner_id": self.partner_1.id,
+                    "start": 14.0,
+                    "end": 12.0,
+                    "week_day_ids": [(4, self.monday.id)],
+                }
+            )

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -65,12 +65,9 @@ class TestPartnerDeliveryWindow(SavepointCase):
         self.assertTrue("warning" in onchange_res.keys())
 
     @freeze_time("2020-04-02 09:00:00")  # Thursday
-    def test_with_timezone(self):
+    def test_with_timezone_dst(self):
         # Define customer to allow shipping only between 10.00am and 4.00pm
         # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
-
-        # Frozen time is in UTC so 2020-04-02 09:00:00 == 2020-04-02 11:00:00
-        #  in Brussels which is preferred
         self.customer_shipping.tz = 'Europe/Brussels'
         self.customer_shipping.delivery_time_window_ids.write(
             {
@@ -78,6 +75,10 @@ class TestPartnerDeliveryWindow(SavepointCase):
                 'time_window_end': 16.0,
             }
         )
+        # Test DST
+        #
+        # Frozen time is in UTC so 2020-04-02 09:00:00 == 2020-04-02 11:00:00
+        #  in Brussels which is preferred
         picking = self._create_delivery_picking(self.customer_shipping)
         onchange_res = picking._onchange_scheduled_date()
         # No warning since we're in the timeframe
@@ -87,9 +88,38 @@ class TestPartnerDeliveryWindow(SavepointCase):
         picking.scheduled_date = "2020-04-02 07:59:59"
         onchange_res = picking._onchange_scheduled_date()
         self.assertTrue("warning" in onchange_res.keys())
-        # Scheduled date is in UTC so 2020-04-02 07:59:59 == 2020-04-02 09:59:59
+        # Scheduled date is in UTC so 2020-04-02 15:01:01 == 2020-04-02 17:01:01
         #  in Brussels which is not preferred
-        picking.scheduled_date = "2020-04-02 14:01:01"
+        picking.scheduled_date = "2020-04-02 15:01:01"
         onchange_res = picking._onchange_scheduled_date()
         self.assertTrue("warning" in onchange_res.keys())
-        # TODO add test with winter time
+
+    @freeze_time("2020-03-26 09:00:00")  # Thursday
+    def test_with_timezone_no_dst(self):
+        # Define customer to allow shipping only between 10.00am and 4.00pm
+        # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
+        self.customer_shipping.tz = 'Europe/Brussels'
+        self.customer_shipping.delivery_time_window_ids.write(
+            {
+                'time_window_start': 10.0,
+                'time_window_end': 16.0,
+            }
+        )
+        # Test No-DST
+        #
+        # Frozen time is in UTC so 2020-04-02 09:00:00 == 2020-04-02 10:00:00
+        #  in Brussels which is preferred
+        picking = self._create_delivery_picking(self.customer_shipping)
+        onchange_res = picking._onchange_scheduled_date()
+        # No warning since we're in the timeframe
+        self.assertIsNone(onchange_res)
+        # Scheduled date is in UTC so 2020-04-02 07:59:59 == 2020-04-02 08:59:59
+        #  in Brussels which is not preferred
+        picking.scheduled_date = "2020-04-02 07:59:59"
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertTrue("warning" in onchange_res.keys())
+        # Scheduled date is in UTC so 2020-04-02 15:01:01 == 2020-04-02 16:01:01
+        #  in Brussels which is not preferred
+        picking.scheduled_date = "2020-04-02 15:01:01"
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertTrue("warning" in onchange_res.keys())

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -64,7 +64,7 @@ class TestPartnerDeliveryWindow(SavepointCase):
         onchange_res = cust_ship_picking._onchange_scheduled_date()
         self.assertTrue("warning" in onchange_res.keys())
 
-    @freeze_time("2020-04-02 09:00:00")  # Thursday
+    @freeze_time("2020-04-02 07:59:59")  # Thursday
     def test_with_timezone_dst(self):
         # Define customer to allow shipping only between 10.00am and 4.00pm
         # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
@@ -77,24 +77,28 @@ class TestPartnerDeliveryWindow(SavepointCase):
         )
         # Test DST
         #
-        # Frozen time is in UTC so 2020-04-02 09:00:00 == 2020-04-02 11:00:00
+        # Frozen time is in UTC so 2020-04-02 07:59:59 == 2020-04-02 09:59:59
         #  in Brussels which is preferred
         picking = self._create_delivery_picking(self.customer_shipping)
         onchange_res = picking._onchange_scheduled_date()
-        # No warning since we're in the timeframe
+        self.assertTrue(isinstance(onchange_res, dict) and "warning" in onchange_res.keys())
+        # Scheduled date is in UTC so 2020-04-02 08:00:00 == 2020-04-02 10:00:00
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-04-02 08:00:00"
+        onchange_res = picking._onchange_scheduled_date()
         self.assertIsNone(onchange_res)
-        # Scheduled date is in UTC so 2020-04-02 07:59:59 == 2020-04-02 09:59:59
-        #  in Brussels which is not preferred
-        picking.scheduled_date = "2020-04-02 07:59:59"
+        # Scheduled date is in UTC so 2020-04-02 13:59:59 == 2020-04-02 15:59:59
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-04-02 13:59:59"
         onchange_res = picking._onchange_scheduled_date()
-        self.assertTrue("warning" in onchange_res.keys())
-        # Scheduled date is in UTC so 2020-04-02 15:01:01 == 2020-04-02 17:01:01
+        self.assertIsNone(onchange_res)
+        # Scheduled date is in UTC so 2020-04-02 14:00:00 == 2020-04-02 16:00:00
         #  in Brussels which is not preferred
-        picking.scheduled_date = "2020-04-02 15:01:01"
+        picking.scheduled_date = "2020-04-02 14:00:00"
         onchange_res = picking._onchange_scheduled_date()
-        self.assertTrue("warning" in onchange_res.keys())
+        self.assertTrue(isinstance(onchange_res, dict) and "warning" in onchange_res.keys())
 
-    @freeze_time("2020-03-26 09:00:00")  # Thursday
+    @freeze_time("2020-03-26 08:59:59")  # Thursday
     def test_with_timezone_no_dst(self):
         # Define customer to allow shipping only between 10.00am and 4.00pm
         # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
@@ -107,19 +111,26 @@ class TestPartnerDeliveryWindow(SavepointCase):
         )
         # Test No-DST
         #
-        # Frozen time is in UTC so 2020-04-02 09:00:00 == 2020-04-02 10:00:00
+        # Frozen time is in UTC so 2020-03-26 08:59:59 == 2020-04-02 09:59:59
         #  in Brussels which is preferred
         picking = self._create_delivery_picking(self.customer_shipping)
+        import pdb; pdb.set_trace()
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertTrue(isinstance(onchange_res, dict) and "warning" in onchange_res.keys())
+        # Scheduled date is in UTC so 2020-03-26 09:00:00 == 2020-04-02 10:00:00
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-03-26 09:00:00"
         onchange_res = picking._onchange_scheduled_date()
         # No warning since we're in the timeframe
         self.assertIsNone(onchange_res)
-        # Scheduled date is in UTC so 2020-04-02 07:59:59 == 2020-04-02 08:59:59
-        #  in Brussels which is not preferred
-        picking.scheduled_date = "2020-04-02 07:59:59"
+        # Scheduled date is in UTC so 2020-03-26 14:59:59 == 2020-04-02 15:59:59
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-03-26 14:59:59"
         onchange_res = picking._onchange_scheduled_date()
-        self.assertTrue("warning" in onchange_res.keys())
-        # Scheduled date is in UTC so 2020-04-02 15:01:01 == 2020-04-02 16:01:01
-        #  in Brussels which is not preferred
-        picking.scheduled_date = "2020-04-02 15:01:01"
+        # No warning since we're in the timeframe
+        self.assertIsNone(onchange_res)
+        # Scheduled date is in UTC so 2020-03-26 15:00:00 == 2020-04-02 16:00:00
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-03-26 15:00:00"
         onchange_res = picking._onchange_scheduled_date()
-        self.assertTrue("warning" in onchange_res.keys())
+        self.assertTrue(isinstance(onchange_res, dict) and "warning" in onchange_res.keys())

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -81,7 +81,7 @@ class TestPartnerDeliveryWindow(SavepointCase):
         # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
         self.customer_shipping.tz = "Europe/Brussels"
         self.customer_shipping.delivery_time_window_ids.write(
-            {"time_window_start": 10.0, "time_window_end": 16.0,}
+            {"time_window_start": 10.0, "time_window_end": 16.0}
         )
         # Test DST
         #
@@ -116,7 +116,7 @@ class TestPartnerDeliveryWindow(SavepointCase):
         # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
         self.customer_shipping.tz = "Europe/Brussels"
         self.customer_shipping.delivery_time_window_ids.write(
-            {"time_window_start": 10.0, "time_window_end": 16.0,}
+            {"time_window_start": 10.0, "time_window_end": 16.0}
         )
         # Test No-DST
         #

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -92,3 +92,4 @@ class TestPartnerDeliveryWindow(SavepointCase):
         picking.scheduled_date = "2020-04-02 14:01:01"
         onchange_res = picking._onchange_scheduled_date()
         self.assertTrue("warning" in onchange_res.keys())
+        # TODO add test with winter time

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2020 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from freezegun import freeze_time
@@ -19,16 +18,30 @@ class TestPartnerDeliveryWindow(SavepointCase):
                 "name": "Delivery address",
                 "parent_id": cls.customer.id,
                 "delivery_time_preference": "time_windows",
-                "delivery_time_window_ids": [(0, 0, {
-                    'time_window_start': 0.00,
-                    'time_window_end': 23.99,
-                    'time_window_weekday_ids': [
-                        (6, 0, [
-                            cls.env.ref('base_time_window.time_weekday_thursday').id,
-                            cls.env.ref('base_time_window.time_weekday_saturday').id
-                        ])
-                     ]
-                })]
+                "delivery_time_window_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "time_window_start": 0.00,
+                            "time_window_end": 23.99,
+                            "time_window_weekday_ids": [
+                                (
+                                    6,
+                                    0,
+                                    [
+                                        cls.env.ref(
+                                            "base_time_window.time_weekday_thursday"
+                                        ).id,
+                                        cls.env.ref(
+                                            "base_time_window.time_weekday_saturday"
+                                        ).id,
+                                    ],
+                                )
+                            ],
+                        },
+                    )
+                ],
             }
         )
         cls.product = cls.env.ref("product.product_product_9")
@@ -37,7 +50,7 @@ class TestPartnerDeliveryWindow(SavepointCase):
         cls.location_customers = cls.env.ref("stock.stock_location_customers")
 
     def _create_delivery_picking(self, partner):
-        return self.env['stock.picking'].create(
+        return self.env["stock.picking"].create(
             {
                 "partner_id": partner.id,
                 "location_id": self.location_stock.id,
@@ -54,9 +67,7 @@ class TestPartnerDeliveryWindow(SavepointCase):
         onchange_res = cust_picking._onchange_scheduled_date()
         self.assertIsNone(onchange_res)
         # No warning on preferred time window
-        cust_ship_picking = self._create_delivery_picking(
-            self.customer_shipping
-        )
+        cust_ship_picking = self._create_delivery_picking(self.customer_shipping)
         cust_ship_picking.scheduled_date = "2020-04-04"  # Saturday
         onchange_res = cust_ship_picking._onchange_scheduled_date()
         self.assertIsNone(onchange_res)
@@ -68,12 +79,9 @@ class TestPartnerDeliveryWindow(SavepointCase):
     def test_with_timezone_dst(self):
         # Define customer to allow shipping only between 10.00am and 4.00pm
         # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
-        self.customer_shipping.tz = 'Europe/Brussels'
+        self.customer_shipping.tz = "Europe/Brussels"
         self.customer_shipping.delivery_time_window_ids.write(
-            {
-                'time_window_start': 10.0,
-                'time_window_end': 16.0,
-            }
+            {"time_window_start": 10.0, "time_window_end": 16.0,}
         )
         # Test DST
         #
@@ -81,7 +89,9 @@ class TestPartnerDeliveryWindow(SavepointCase):
         #  in Brussels which is preferred
         picking = self._create_delivery_picking(self.customer_shipping)
         onchange_res = picking._onchange_scheduled_date()
-        self.assertTrue(isinstance(onchange_res, dict) and "warning" in onchange_res.keys())
+        self.assertTrue(
+            isinstance(onchange_res, dict) and "warning" in onchange_res.keys()
+        )
         # Scheduled date is in UTC so 2020-04-02 08:00:00 == 2020-04-02 10:00:00
         #  in Brussels which is preferred
         picking.scheduled_date = "2020-04-02 08:00:00"
@@ -96,27 +106,27 @@ class TestPartnerDeliveryWindow(SavepointCase):
         #  in Brussels which is not preferred
         picking.scheduled_date = "2020-04-02 14:00:00"
         onchange_res = picking._onchange_scheduled_date()
-        self.assertTrue(isinstance(onchange_res, dict) and "warning" in onchange_res.keys())
+        self.assertTrue(
+            isinstance(onchange_res, dict) and "warning" in onchange_res.keys()
+        )
 
     @freeze_time("2020-03-26 08:59:59")  # Thursday
     def test_with_timezone_no_dst(self):
         # Define customer to allow shipping only between 10.00am and 4.00pm
         # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
-        self.customer_shipping.tz = 'Europe/Brussels'
+        self.customer_shipping.tz = "Europe/Brussels"
         self.customer_shipping.delivery_time_window_ids.write(
-            {
-                'time_window_start': 10.0,
-                'time_window_end': 16.0,
-            }
+            {"time_window_start": 10.0, "time_window_end": 16.0,}
         )
         # Test No-DST
         #
         # Frozen time is in UTC so 2020-03-26 08:59:59 == 2020-04-02 09:59:59
         #  in Brussels which is preferred
         picking = self._create_delivery_picking(self.customer_shipping)
-        import pdb; pdb.set_trace()
         onchange_res = picking._onchange_scheduled_date()
-        self.assertTrue(isinstance(onchange_res, dict) and "warning" in onchange_res.keys())
+        self.assertTrue(
+            isinstance(onchange_res, dict) and "warning" in onchange_res.keys()
+        )
         # Scheduled date is in UTC so 2020-03-26 09:00:00 == 2020-04-02 10:00:00
         #  in Brussels which is preferred
         picking.scheduled_date = "2020-03-26 09:00:00"
@@ -133,4 +143,6 @@ class TestPartnerDeliveryWindow(SavepointCase):
         #  in Brussels which is preferred
         picking.scheduled_date = "2020-03-26 15:00:00"
         onchange_res = picking._onchange_scheduled_date()
-        self.assertTrue(isinstance(onchange_res, dict) and "warning" in onchange_res.keys())
+        self.assertTrue(
+            isinstance(onchange_res, dict) and "warning" in onchange_res.keys()
+        )

--- a/stock_partner_delivery_window/views/res_partner.xml
+++ b/stock_partner_delivery_window/views/res_partner.xml
@@ -14,9 +14,9 @@
                     <label for="delivery_time_window_ids" />
                     <field name="delivery_time_window_ids" >
                         <tree editable="bottom">
-                            <field name="start" widget="float_time"/>
-                            <field name="end" widget="float_time"/>
-                            <field name="weekday_ids" widget="many2many_tags" />
+                            <field name="time_window_start" widget="float_time"/>
+                            <field name="time_window_end" widget="float_time"/>
+                            <field name="time_window_weekday_ids" widget="many2many_tags" />
                         </tree>
                     </field>
                 </div>

--- a/stock_partner_delivery_window/views/res_partner.xml
+++ b/stock_partner_delivery_window/views/res_partner.xml
@@ -10,17 +10,22 @@
                 position="inside"
             >
                 <field name="delivery_time_preference" />
-                <div attrs="{'invisible': [('delivery_time_preference', '!=', 'time_windows')]}" colspan="2">
+                <div
+                    attrs="{'invisible': [('delivery_time_preference', '!=', 'time_windows')]}"
+                    colspan="2"
+                >
                     <label for="delivery_time_window_ids" />
-                    <field name="delivery_time_window_ids" >
+                    <field name="delivery_time_window_ids">
                         <tree editable="bottom">
-                            <field name="time_window_start" widget="float_time"/>
-                            <field name="time_window_end" widget="float_time"/>
-                            <field name="time_window_weekday_ids" widget="many2many_tags" />
+                            <field name="time_window_start" widget="float_time" />
+                            <field name="time_window_end" widget="float_time" />
+                            <field
+                                name="time_window_weekday_ids"
+                                widget="many2many_tags"
+                            />
                         </tree>
                     </field>
                 </div>
-
             </xpath>
         </field>
     </record>

--- a/stock_partner_delivery_window/views/res_partner.xml
+++ b/stock_partner_delivery_window/views/res_partner.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_partner_form_inherit" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='sales_purchases']//group[@name='sale']"
+                position="inside"
+            >
+                <field name="delivery_time_preference" />
+                <field name="delivery_time_window_ids" attrs="{'invisible': [('delivery_time_preference', '!=', 'fix_weekdays')]}">
+                    <tree editable="bottom">
+                        <field name="start" />
+                        <field name="end" />
+                        <field name="weekday_ids" widget="many2many_tags" />
+                    </tree>
+                </field>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_partner_delivery_window/views/res_partner.xml
+++ b/stock_partner_delivery_window/views/res_partner.xml
@@ -10,14 +10,17 @@
                 position="inside"
             >
                 <field name="delivery_time_preference" />
-                <field name="delivery_time_window_ids" attrs="{'invisible': [('delivery_time_preference', '!=', 'fix_weekdays')]}">
-                    <tree editable="bottom">
-                        <field name="start" />
-                        <field name="end" />
-                        <field name="weekday_ids" widget="many2many_tags" />
-                        <field name="tz" />
-                    </tree>
-                </field>
+                <div attrs="{'invisible': [('delivery_time_preference', '!=', 'time_windows')]}" colspan="2">
+                    <label for="delivery_time_window_ids" />
+                    <field name="delivery_time_window_ids" >
+                        <tree editable="bottom">
+                            <field name="start" widget="float_time"/>
+                            <field name="end" widget="float_time"/>
+                            <field name="weekday_ids" widget="many2many_tags" />
+                        </tree>
+                    </field>
+                </div>
+
             </xpath>
         </field>
     </record>

--- a/stock_partner_delivery_window/views/res_partner.xml
+++ b/stock_partner_delivery_window/views/res_partner.xml
@@ -15,6 +15,7 @@
                         <field name="start" />
                         <field name="end" />
                         <field name="weekday_ids" widget="many2many_tags" />
+                        <field name="tz" />
                     </tree>
                 </field>
             </xpath>


### PR DESCRIPTION
Depends on:
 - [x] https://github.com/OCA/server-tools/pull/1798
 - [x] https://github.com/OCA/partner-contact/pull/876

This module allows to define time scheduling preference for delivery orders on
partners, in order to raise a warning when changing a scheduled date to a time
window that is not preferred by this customer.
