### PR TITLE
[FIX] 12.0 picking_quick search view

### DIFF
--- a/stock_picking_quick/__manifest__.py
+++ b/stock_picking_quick/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Quick Stock Picking",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "license": "AGPL-3",
@@ -12,4 +12,5 @@
     "depends": ["base_product_mass_addition", "stock"],
     "data": ["views/picking_view.xml", "views/product_view.xml"],
     "installable": True,
+    "maintainers": ["PierrickBrun", "bealdav"],
 }

--- a/stock_picking_quick/models/stock_picking.py
+++ b/stock_picking_quick/models/stock_picking.py
@@ -25,6 +25,9 @@ class StockPicking(models.Model):
         res["view_id"] = (
             self.env.ref("stock_picking_quick.product_tree_view4picking").id,
         )
+        res["search_view_id"] = (
+            self.env.ref("stock_picking_quick.product_search_view4picking").id,
+        )
         return res
 
     def _prepare_quick_line(self, product):

--- a/stock_picking_quick/views/product_view.xml
+++ b/stock_picking_quick/views/product_view.xml
@@ -17,9 +17,10 @@
        </field>
     </record>
 
-    <record id="product_search_form_view" model="ir.ui.view">
+    <record id="product_search_view4picking" model="ir.ui.view">
         <field name="model">product.product</field>
         <field name="inherit_id" ref="base_product_mass_addition.product_search_form_view"/>
+        <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//filter[last()]" position="after">
                 <filter name="use_only_available_products"


### PR DESCRIPTION
Search view was not primary and the filter added is not useful if not in this context.

Also search_view_id must be forced from the action