### PR TITLE
[12.0][FIX] stock_no_negative: Use product display_name instead of name

### DIFF
--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -42,5 +42,5 @@ class StockQuant(models.Model):
                     "stock level of the product '%s'%s would become negative "
                     "(%s) on the stock location '%s' and negative stock is "
                     "not allowed for this product and/or location.") % (
-                        quant.product_id.name, msg_add, quant.quantity,
+                        quant.product_id.display_name, msg_add, quant.quantity,
                         quant.location_id.complete_name))


### PR DESCRIPTION
Use `product.display_name` instead of `product.name`