### PR TITLE
[13.0] Fix "record does not exist" when validating move line

### DIFF
--- a/stock_quant_package_product_packaging/models/stock_move_line.py
+++ b/stock_quant_package_product_packaging/models/stock_move_line.py
@@ -8,6 +8,8 @@ class StockMoveLine(models.Model):
 
     def _action_done(self):
         res = super()._action_done()
-        for line in self.filtered(lambda l: l.result_package_id):
+        # _action_done in stock module sometimes delete a move line, we
+        # have to check if it still exists before reading/writing on it
+        for line in self.exists().filtered(lambda l: l.result_package_id):
             line.result_package_id.auto_assign_packaging()
         return res


### PR DESCRIPTION
When _action_done is called on a transfer, it may delete a part of
the move lines. The extension of `_action_done()` that assigns
a packaging fails with "Record does not exist or has been deleted".

Check if the if lines still exist before writing on them.
