### PR TITLE
[12.0][FIX] stock_no_negative: When a transfer is packaged and unpacked, it creates a separate quant

### DIFF
--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -22,7 +22,9 @@ class StockQuant(models.Model):
         )
         if not check_negative_qty:
             return
-
+        # Execute generic merge method before doing comparisons for avoiding
+        # existing negative quants not merged with their counterparts
+        self._merge_quants()
         for quant in self:
             disallowed_by_product = \
                 not quant.product_id.allow_negative_stock \


### PR DESCRIPTION
This causes that when making a transfer, take only one quant and leave
it negative instead of taking it from the other quants of the same
product

Issue related https://github.com/odoo/odoo/issues/53535