### PR TITLE
[13.0] Add stock_putaway_by_route

### DIFF
--- a/setup/stock_putaway_by_route/odoo/addons/stock_putaway_by_route
+++ b/setup/stock_putaway_by_route/odoo/addons/stock_putaway_by_route
@@ -1,0 +1,1 @@
+../../../../stock_putaway_by_route

--- a/setup/stock_putaway_by_route/setup.py
+++ b/setup/stock_putaway_by_route/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/stock_putaway_hook/odoo/addons/stock_putaway_hook
+++ b/setup/stock_putaway_hook/odoo/addons/stock_putaway_hook
@@ -1,0 +1,1 @@
+../../../../stock_putaway_hook

--- a/setup/stock_putaway_hook/setup.py
+++ b/setup/stock_putaway_hook/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_putaway_by_route/__init__.py
+++ b/stock_putaway_by_route/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_putaway_by_route/__manifest__.py
+++ b/stock_putaway_by_route/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Stock Putaway By Route",
+    "summary": "Add a match by route on putaway, after product and categories",
+    "version": "13.0.1.0.0",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": True,
+    "depends": ["stock_putaway_hook"],
+    "data": ["views/stock_putaway_rule_views.xml"],
+}

--- a/stock_putaway_by_route/models/__init__.py
+++ b/stock_putaway_by_route/models/__init__.py
@@ -1,0 +1,4 @@
+from . import stock_move
+from . import stock_move_line
+from . import stock_location
+from . import stock_putaway_rule

--- a/stock_putaway_by_route/models/stock_location.py
+++ b/stock_putaway_by_route/models/stock_location.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    @property
+    def _putaway_strategies(self):
+        strategies = super()._putaway_strategies
+        return strategies + ["route_id"]

--- a/stock_putaway_by_route/models/stock_move.py
+++ b/stock_putaway_by_route/models/stock_move.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _generate_serial_move_line_commands(self, lot_names, origin_move_line=None):
+        if self.rule_id.route_id:
+            self = self.with_context(_putaway_route_id=self.rule_id.route_id)
+        return super()._generate_serial_move_line_commands(
+            lot_names, origin_move_line=origin_move_line
+        )
+
+    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
+        if self.rule_id.route_id:
+            self = self.with_context(_putaway_route_id=self.rule_id.route_id)
+        return super()._prepare_move_line_vals(
+            quantity=quantity, reserved_quant=reserved_quant
+        )

--- a/stock_putaway_by_route/models/stock_move_line.py
+++ b/stock_putaway_by_route/models/stock_move_line.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    @api.onchange("product_id", "product_uom_id")
+    def onchange_product_id(self):
+        if self.rule_id.route_id:
+            self = self.with_context(_putaway_route_id=self.rule_id.route_id)
+        return super().onchange_product_id()

--- a/stock_putaway_by_route/models/stock_putaway_rule.py
+++ b/stock_putaway_by_route/models/stock_putaway_rule.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class StockPutawayRule(models.Model):
+    _inherit = "stock.putaway.rule"
+
+    route_id = fields.Many2one(
+        comodel_name="stock.location.route",
+        string="Route",
+        check_company=True,
+        ondelete="cascade",
+    )

--- a/stock_putaway_by_route/readme/CONFIGURATION.rst
+++ b/stock_putaway_by_route/readme/CONFIGURATION.rst
@@ -1,0 +1,2 @@
+Go to Inventory > Configuration > Putaway Rules (the "Storage Locations" setting must be active).
+Create a new rule, a route can be selected.

--- a/stock_putaway_by_route/readme/CONTRIBUTORS.rst
+++ b/stock_putaway_by_route/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/stock_putaway_by_route/readme/DESCRIPTION.rst
+++ b/stock_putaway_by_route/readme/DESCRIPTION.rst
@@ -1,0 +1,16 @@
+Add putaway rules based on a Stock Route.
+
+The core putaway rules allow to select a putaway rule for: products, product categories.
+This module adds the route.
+
+For instance, a move generated for a replenishment (e.g. using the module
+``Stock Orderpoint Route`` or ``Stock Buffer Route``) will be related to the
+rule (so the route) that generated it. When the putaway rules are applied, if a
+rule is defined on the replenishment route, the destination move will be changed
+to the one of the rule.
+
+The rules for the route are applied when no rule for product and categories have
+been found.
+
+Note: it is based on the Stock Rule stored on a move, so it cannot be applied
+on a route without rule.

--- a/stock_putaway_by_route/tests/__init__.py
+++ b/stock_putaway_by_route/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_view
+from . import test_route_putaway

--- a/stock_putaway_by_route/tests/test_route_putaway.py
+++ b/stock_putaway_by_route/tests/test_route_putaway.py
@@ -1,0 +1,78 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestRoutePutaway(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.input_location = cls.env.ref("stock.stock_location_company")
+        cls.input_gate_a_location = cls.env.ref("stock.location_gate_a")
+        cls.shelf_location = cls.env.ref("stock.stock_location_components")
+
+        cls.product = cls.env["product.product"].create(
+            {"name": "Product", "type": "product"}
+        )
+
+        cls.route = cls.env["stock.location.route"].create(
+            {
+                "name": "Transfer",
+                "product_categ_selectable": False,
+                "product_selectable": True,
+                "company_id": cls.env.ref("base.main_company").id,
+                "sequence": 10,
+            }
+        )
+        cls.rule = cls.env["stock.rule"].create(
+            {
+                "name": "Transfer",
+                "route_id": cls.route.id,
+                "location_src_id": cls.input_location.id,
+                "location_id": cls.warehouse.lot_stock_id.id,
+                "action": "pull",
+                "picking_type_id": cls.warehouse.int_type_id.id,
+                "procure_method": "make_to_stock",
+                "warehouse_id": cls.warehouse.id,
+                "company_id": cls.env.ref("base.main_company").id,
+            }
+        )
+
+    def _create_single_move(self, product, rule=None):
+        picking_type = self.warehouse.int_type_id
+        move_vals = {
+            "name": product.name,
+            "picking_type_id": picking_type.id,
+            "product_id": product.id,
+            "product_uom_qty": 2.0,
+            "product_uom": product.uom_id.id,
+            "location_id": self.input_location.id,
+            "location_dest_id": picking_type.default_location_dest_id.id,
+            "state": "confirmed",
+            "procure_method": "make_to_stock",
+            "rule_id": rule.id if rule else None,
+        }
+        return self.env["stock.move"].create(move_vals)
+
+    def _update_product_qty_in_location(self, location, product, quantity):
+        self.env["stock.quant"]._update_available_quantity(product, location, quantity)
+
+    def test_route_putaway(self):
+        self.env["stock.putaway.rule"].create(
+            {
+                "route_id": self.route.id,
+                "location_in_id": self.warehouse.lot_stock_id.id,
+                "location_out_id": self.shelf_location.id,
+            }
+        )
+
+        move = self._create_single_move(self.product, rule=self.rule)
+        self._update_product_qty_in_location(
+            self.input_gate_a_location, self.product, move.product_uom_qty
+        )
+        move._assign_picking()
+        move._action_assign()
+        self.assertEqual(move.move_line_ids.location_dest_id, self.shelf_location)

--- a/stock_putaway_by_route/tests/test_view.py
+++ b/stock_putaway_by_route/tests/test_view.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import Form, SavepointCase
+
+
+class TestPutawayView(SavepointCase):
+    def test_view_attrs(self):
+        tree = Form(
+            self.env["stock.putaway.rule"],
+            view=self.env.ref("stock.stock_putaway_list"),
+        )
+        self.assertFalse(tree._get_modifier("product_id", "readonly"))
+        self.assertTrue(tree._get_modifier("product_id", "required"))
+        self.assertFalse(tree._get_modifier("category_id", "readonly"))
+        self.assertTrue(tree._get_modifier("category_id", "required"))
+        self.assertFalse(tree._get_modifier("route_id", "readonly"))
+        self.assertTrue(tree._get_modifier("route_id", "required"))
+
+        tree.product_id = self.env["product.product"].search([], limit=1)
+        self.assertFalse(tree._get_modifier("product_id", "readonly"))
+        self.assertTrue(tree._get_modifier("product_id", "required"))
+        self.assertTrue(tree._get_modifier("category_id", "readonly"))
+        self.assertFalse(tree._get_modifier("category_id", "required"))
+        self.assertTrue(tree._get_modifier("route_id", "readonly"))
+        self.assertFalse(tree._get_modifier("route_id", "required"))
+        tree.product_id = self.env["product.product"]
+
+        tree.category_id = self.env["product.category"].search([], limit=1)
+        self.assertTrue(tree._get_modifier("product_id", "readonly"))
+        self.assertFalse(tree._get_modifier("product_id", "required"))
+        self.assertFalse(tree._get_modifier("category_id", "readonly"))
+        self.assertTrue(tree._get_modifier("category_id", "required"))
+        self.assertTrue(tree._get_modifier("route_id", "readonly"))
+        self.assertFalse(tree._get_modifier("route_id", "required"))
+        tree.category_id = self.env["product.category"]
+
+        tree.route_id = self.env["stock.location.route"].search([], limit=1)
+        self.assertTrue(tree._get_modifier("product_id", "readonly"))
+        self.assertFalse(tree._get_modifier("product_id", "required"))
+        self.assertTrue(tree._get_modifier("category_id", "readonly"))
+        self.assertFalse(tree._get_modifier("category_id", "required"))
+        self.assertFalse(tree._get_modifier("route_id", "readonly"))
+        self.assertTrue(tree._get_modifier("route_id", "required"))

--- a/stock_putaway_by_route/views/stock_putaway_rule_views.xml
+++ b/stock_putaway_by_route/views/stock_putaway_rule_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="stock_putaway_list" model="ir.ui.view">
+        <field name="name">stock.putaway.rule.tree</field>
+        <field name="model">stock.putaway.rule</field>
+        <field name="inherit_id" ref="stock.stock_putaway_list" />
+        <field name="arch" type="xml">
+            <field name="category_id" position="after">
+                <field
+                    name="route_id"
+                    options="{'no_create': True, 'no_open': True, 'exclusive_selection': True}"
+                    readonly="context.get('putaway_route', False)"
+                    force_save="1"
+                />
+            </field>
+        </field>
+    </record>
+    <record id="view_putaway_search" model="ir.ui.view">
+        <field name="name">stock.putaway.rule.search</field>
+        <field name="model">stock.putaway.rule</field>
+        <field name="inherit_id" ref="stock.view_putaway_search" />
+        <field name="arch" type="xml">
+            <field name="category_id" position="after">
+                <field name="route_id" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/stock_putaway_hook/__init__.py
+++ b/stock_putaway_hook/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_putaway_hook/__manifest__.py
+++ b/stock_putaway_hook/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Stock Putaway Hooks",
+    "summary": "Add hooks allowing modules to add more putaway strategies",
+    "version": "13.0.1.0.0",
+    "category": "Hidden",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": True,
+    "depends": ["stock"],
+    "data": [],
+}

--- a/stock_putaway_hook/models/__init__.py
+++ b/stock_putaway_hook/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_location
+from . import stock_putaway_rule

--- a/stock_putaway_hook/models/stock_location.py
+++ b/stock_putaway_hook/models/stock_location.py
@@ -1,0 +1,89 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    @property
+    def _putaway_strategies(self):
+        """List of plugged put-away strategies
+
+        Each item is the key of the strategy. When applying the putaway, if no
+        strategy is found for the product and the category (default ones), the
+        method ``_alternative_putaway_strategy`` will loop over these keys.
+
+
+        The key of a strategy must be the name of the field added on
+        ``stock.putaway.rule``.
+
+        For instance if the strategies are ["route_id", "foo"], the putaway will:
+
+        * search a putaway for the product (core module)
+        * if not found, search for the product category (core module)
+
+        If None is found, the alternatives strategies are looked for:
+
+        * if not found, search for route_id
+        * if not found, search for foo
+        """
+        return []
+
+    def _get_putaway_strategy(self, product):
+        """Extend the code method to add hooks
+
+        * Call the alternative strategies lookups
+        * Call a hook ``_putaway_strategy_finalizer`` after all the strategies
+        """
+        putaway_location = super()._get_putaway_strategy(product)
+        if not putaway_location:
+            putaway_location = self._alternative_putaway_strategy()
+        return self._putaway_strategy_finalizer(putaway_location, product)
+
+    def _alternative_putaway_strategy(self):
+        """Find a putaway according to the ``_putaway_strategies`` keys
+
+        The methods that calls ``StockLocation._get_putaway_strategy have to
+        pass in the context a key with the name ``_putaway_<KEY>``, where KEY
+        is the name of the strategy. The value must be the value to match with
+        the putaway rule.
+        """
+        current_location = self
+        putaway_location = self.browse()
+
+        strategy_values = {
+            field: self.env.context.get("_putaway_{}".format(field))
+            for field in self._putaway_strategies
+        }
+
+        # retain only the strategies for which we have a value provided in context
+        available_strategies = [
+            strategy
+            for strategy in self._putaway_strategies
+            if strategy_values.get(strategy)
+        ]
+
+        if not available_strategies:
+            return putaway_location
+
+        while current_location and not putaway_location:
+            # copy and reverse the strategies, so we pop them in their order
+            strategies = available_strategies[::-1]
+            while not putaway_location and strategies:
+                strategy = strategies.pop()
+                value = strategy_values[strategy]
+                # Looking for a putaway from the strategy
+                putaway_rules = current_location.putaway_rule_ids.filtered(
+                    lambda x: x[strategy] == value
+                )
+                if putaway_rules:
+                    putaway_location = putaway_rules[0].location_out_id
+            current_location = current_location.location_id
+        return putaway_location
+
+    def _putaway_strategy_finalizer(self, putaway_location, product):
+        """Hook for putaway called after the strategy lookup"""
+        # by default, do nothing
+        return putaway_location

--- a/stock_putaway_hook/models/stock_putaway_rule.py
+++ b/stock_putaway_hook/models/stock_putaway_rule.py
@@ -1,0 +1,113 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from lxml import etree
+
+from odoo import models
+from odoo.osv.expression import AND, OR
+from odoo.tools.safe_eval import safe_eval
+
+from odoo.addons.base.models.ir_ui_view import (
+    transfer_modifiers_to_node,
+    transfer_node_to_modifiers,
+)
+
+
+class StockPutawayRule(models.Model):
+    _inherit = "stock.putaway.rule"
+
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        result = super().fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
+        )
+        if result["name"] == "stock.putaway.rule.tree":
+            result["arch"] = self._fields_view_get_adapt_attrs(result["arch"])
+        return result
+
+    def _fields_view_get_add_exclusive_selection_attrs(self, doc):
+        """Make the readonly and required attrs dynamic for putaway rules
+
+        By default, product_id and category_id fields have static domains
+        such as they are mutually exclusive: both fields are required,
+        as soon as we select a product, the category becomes readonly and
+        not required, if we select a category, the product becomes readonly
+        and not required.
+
+        If we add a third field, such as "route_id", the domains for the
+        readonly and required attrs should now include "route_id" as well,
+        and if we add a fourth field, again. We can't extend them this way
+        from XML, so this method dynamically generate these domains and
+        set it on the fields attrs.
+
+        The only requirement is to have exclusive_selection set in the options
+        of the field:
+
+        ::
+
+            <field name="route_id"
+                options="{'no_create': True, 'no_open': True,
+                          'exclusive_selection': True}"
+                readonly="context.get('putaway_route', False)"
+                force_save="1"
+            />
+
+        Look in module stock_putaway_by_route (where this is tested as well).
+        """
+        exclusive_fields = set()
+        nodes = doc.xpath("//field[@options]")
+        for field in nodes:
+            options = safe_eval(field.attrib.get("options", "{}"))
+            if options.get("exclusive_selection"):
+                exclusive_fields.add(field)
+
+        for field in exclusive_fields:
+            readonly_domain = OR(
+                [
+                    [(other.attrib["name"], "!=", False)]
+                    for other in exclusive_fields
+                    if other != field
+                ]
+            )
+            required_domain = AND(
+                [
+                    [(other.attrib["name"], "=", False)]
+                    for other in exclusive_fields
+                    if other != field
+                ]
+            )
+
+            if field.attrib.get("attrs"):
+                attrs = safe_eval(field.attrib["attrs"])
+            else:
+                attrs = {}
+            attrs["readonly"] = readonly_domain
+            attrs["required"] = required_domain
+
+            field.set("attrs", str(attrs))
+            modifiers = {}
+            transfer_node_to_modifiers(
+                field, modifiers, self.env.context, in_tree_view=True
+            )
+            transfer_modifiers_to_node(modifiers, field)
+
+    def _add_exclusive_selection(self, doc, field_name):
+        nodes = doc.xpath("//field[@name='{}']".format(field_name))
+        for field in nodes:
+            options = safe_eval(field.attrib.get("options", "{}"))
+            options["exclusive_selection"] = True
+            field.set("options", str(options))
+
+    def _fields_view_get_adapt_attrs(self, view_arch):
+        doc = etree.XML(view_arch)
+        # Add the "exclusive_selection" option on product_id and category_id
+        # fields from core, so they are treated by
+        # _fields_view_get_add_exclusive_selection_attrs
+        self._add_exclusive_selection(doc, "product_id")
+        self._add_exclusive_selection(doc, "category_id")
+
+        self._fields_view_get_add_exclusive_selection_attrs(doc)
+
+        new_view = etree.tostring(doc, encoding="unicode")
+        return new_view

--- a/stock_putaway_hook/readme/CONTRIBUTORS.rst
+++ b/stock_putaway_hook/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/stock_putaway_hook/readme/DESCRIPTION.rst
+++ b/stock_putaway_hook/readme/DESCRIPTION.rst
@@ -1,0 +1,6 @@
+Technical module. It adds hooks to the core putaway method
+``StockLocation._get_putaway_strategy()`` allowing to plug other strategies and
+makes the selector fields in the tree views dynamic (required/readonly). See the
+usage section for details.
+
+An example of implementation is the module ``stock_putaway_by_route``.

--- a/stock_putaway_hook/readme/USAGE.rst
+++ b/stock_putaway_hook/readme/USAGE.rst
@@ -1,0 +1,24 @@
+The modules that implement a new strategy have to follow the following steps.
+The module ``stock_putaway_by_route`` should be used as reference.
+
+Add the field to match on ``stock.putaway.rule`` in the model and in the view.
+In the view, the field must have ``options="{'exclusive_selection': True}"``,
+which will allow this module to dynamically build dynamic attrs, restricting the
+selection of more than one field. (defining the readonly and required attrs in the view is therefore useless).
+
+Add the strategy key, named after the new field name, in ``StockLocation._putaway_strategies``. Example:
+
+::
+
+  class StockLocation(models.Model):
+      _inherit = "stock.location"
+
+      @property
+      def _putaway_strategies(self):
+          strategies = super()._putaway_strategies
+          return strategies + ["route_id"]
+
+Pass the value to match with the putaway rule field in the context, in every
+method calling ``StockLocation._get_putaway_strategy``. The name of the key in
+the context is:``_putaway_<KEY>``, where KEY is the name of the new field on the
+putaway rule.


### PR DESCRIPTION
# Stock Putaway Hook

Add hooks allowing modules to add more putaway strategies.
It adds hooks to the core putaway method
``StockLocation._get_putaway_strategy()`` allowing to plug other
strategies and makes the selector fields in the tree views dynamic
(required/readonly).

# Stock Putaway By Route

Based on stock_putaway_hook.

Add the possibility to apply a putaway rule based on a route.

For instance, a move generated for a replenishment (e.g. using the module
``Stock Orderpoint Route`` or ``Stock Buffer Route``) will be related to the
rule (so the route) that generated it. When the putaway rules are applied, if a
rule is defined on the replenishment route, the destination move will be changed
to the one of the rule.