### PR TITLE
[13.0] Add match by product's route in putaway by routes

### DIFF
--- a/stock_putaway_by_route/models/stock_move.py
+++ b/stock_putaway_by_route/models/stock_move.py
@@ -10,6 +10,8 @@ class StockMove(models.Model):
     def _generate_serial_move_line_commands(self, lot_names, origin_move_line=None):
         if self.rule_id.route_id:
             self = self.with_context(_putaway_route_id=self.rule_id.route_id)
+        elif self.product_id.route_ids:
+            self = self.with_context(_putaway_route_id=self.product_id.route_ids)
         return super()._generate_serial_move_line_commands(
             lot_names, origin_move_line=origin_move_line
         )
@@ -17,6 +19,8 @@ class StockMove(models.Model):
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
         if self.rule_id.route_id:
             self = self.with_context(_putaway_route_id=self.rule_id.route_id)
+        elif self.product_id.route_ids:
+            self = self.with_context(_putaway_route_id=self.product_id.route_ids)
         return super()._prepare_move_line_vals(
             quantity=quantity, reserved_quant=reserved_quant
         )

--- a/stock_putaway_by_route/models/stock_move_line.py
+++ b/stock_putaway_by_route/models/stock_move_line.py
@@ -9,6 +9,6 @@ class StockMoveLine(models.Model):
 
     @api.onchange("product_id", "product_uom_id")
     def onchange_product_id(self):
-        if self.move_id.rule_id.route_id:
-            self = self.with_context(_putaway_route_id=self.rule_id.route_id)
+        if self.product_id.route_ids:
+            self = self.with_context(_putaway_route_id=self.product_id.route_ids)
         return super().onchange_product_id()

--- a/stock_putaway_by_route/readme/DESCRIPTION.rst
+++ b/stock_putaway_by_route/readme/DESCRIPTION.rst
@@ -12,5 +12,9 @@ to the one of the rule.
 The rules for the route are applied when no rule for product and categories have
 been found.
 
-Note: it is based on the Stock Rule stored on a move, so it cannot be applied
-on a route without rule.
+When the put-away strategy by route is applied it looks:
+
+1. If the move has a Stock Rule, it searches a put-away rule which has the
+   same Rule's Route
+2. Otherwise, if the Product has Route(s), it searches a put-away rule which
+   has any Route of the product set (it takes the first found)

--- a/stock_putaway_by_route/tests/test_route_putaway.py
+++ b/stock_putaway_by_route/tests/test_route_putaway.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import Form, SavepointCase
 
 
 class TestRoutePutaway(SavepointCase):
@@ -40,6 +40,13 @@ class TestRoutePutaway(SavepointCase):
                 "company_id": cls.env.ref("base.main_company").id,
             }
         )
+        cls.env["stock.putaway.rule"].create(
+            {
+                "route_id": cls.route.id,
+                "location_in_id": cls.warehouse.lot_stock_id.id,
+                "location_out_id": cls.shelf_location.id,
+            }
+        )
 
     def _create_single_move(self, product, rule=None):
         picking_type = self.warehouse.int_type_id
@@ -60,15 +67,7 @@ class TestRoutePutaway(SavepointCase):
     def _update_product_qty_in_location(self, location, product, quantity):
         self.env["stock.quant"]._update_available_quantity(product, location, quantity)
 
-    def test_route_putaway(self):
-        self.env["stock.putaway.rule"].create(
-            {
-                "route_id": self.route.id,
-                "location_in_id": self.warehouse.lot_stock_id.id,
-                "location_out_id": self.shelf_location.id,
-            }
-        )
-
+    def test_route_putaway_move_route(self):
         move = self._create_single_move(self.product, rule=self.rule)
         self._update_product_qty_in_location(
             self.input_gate_a_location, self.product, move.product_uom_qty
@@ -76,3 +75,47 @@ class TestRoutePutaway(SavepointCase):
         move._assign_picking()
         move._action_assign()
         self.assertEqual(move.move_line_ids.location_dest_id, self.shelf_location)
+
+    def test_route_putaway_product(self):
+        self.product.route_ids = self.route
+        move = self._create_single_move(self.product)
+        self._update_product_qty_in_location(
+            self.input_gate_a_location, self.product, move.product_uom_qty
+        )
+        move._assign_picking()
+        move._action_assign()
+        self.assertEqual(move.move_line_ids.location_dest_id, self.shelf_location)
+
+    def test_route_putaway_onchange_move_line(self):
+        # the group is necessary to have the put-away rule applied on
+        # StockMoveLine.onchange_product_id
+        self.env.user.groups_id |= self.env.ref("stock.group_stock_multi_locations")
+
+        picking_type = self.warehouse.int_type_id
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.input_location.id,
+                "location_dest_id": picking_type.default_location_dest_id.id,
+            }
+        )
+
+        # the onchange is applied on move line only for NewID records
+        # otherwise we are not even allowed to change the product
+        view_move_line = Form(self.env["stock.move.line"])
+        view_move_line.product_uom_qty = 2.0
+        view_move_line.picking_id = picking
+        view_move_line.location_id = self.input_location
+        view_move_line.location_dest_id = picking.location_dest_id
+        view_move_line.product_id = self.product
+
+        self.assertEqual(view_move_line.location_dest_id, picking.location_dest_id)
+
+        # trigger StockMoveLine.onchange_product_id
+        route_product = self.env["product.product"].create(
+            {"name": "Product with route", "type": "product"}
+        )
+        route_product.route_ids |= self.route
+        view_move_line.product_id = route_product
+
+        self.assertEqual(view_move_line.location_dest_id, self.shelf_location)

--- a/stock_putaway_hook/models/stock_location.py
+++ b/stock_putaway_hook/models/stock_location.py
@@ -15,7 +15,6 @@ class StockLocation(models.Model):
         strategy is found for the product and the category (default ones), the
         method ``_alternative_putaway_strategy`` will loop over these keys.
 
-
         The key of a strategy must be the name of the field added on
         ``stock.putaway.rule``.
 
@@ -48,7 +47,9 @@ class StockLocation(models.Model):
         The methods that calls ``StockLocation._get_putaway_strategy have to
         pass in the context a key with the name ``_putaway_<KEY>``, where KEY
         is the name of the strategy. The value must be the value to match with
-        the putaway rule.
+        the putaway rule. The value can be a unit, a recordset of any length or
+        a list/tuple. In latter cases, the putaway rule is selected if its
+        field match any value in the list/recordset.
         """
         current_location = self
         putaway_location = self.browse()
@@ -76,7 +77,9 @@ class StockLocation(models.Model):
                 value = strategy_values[strategy]
                 # Looking for a putaway from the strategy
                 putaway_rules = current_location.putaway_rule_ids.filtered(
-                    lambda x: x[strategy] == value
+                    lambda x: x[strategy] in value
+                    if isinstance(value, (models.BaseModel, list, tuple))
+                    else x[strategy] == value
                 )
                 if putaway_rules:
                     putaway_location = putaway_rules[0].location_out_id

--- a/stock_putaway_hook/readme/USAGE.rst
+++ b/stock_putaway_hook/readme/USAGE.rst
@@ -21,4 +21,6 @@ Add the strategy key, named after the new field name, in ``StockLocation._putawa
 Pass the value to match with the putaway rule field in the context, in every
 method calling ``StockLocation._get_putaway_strategy``. The name of the key in
 the context is:``_putaway_<KEY>``, where KEY is the name of the new field on the
-putaway rule.
+putaway rule. The value can be a unit, a recordset of any length or a
+list/tuple. In latter cases, the putaway rule is selected if its field match any
+value in the list/recordset.


### PR DESCRIPTION
The module matching a putaway rule by a route can now:

* find a putaway rule by the route related to a stock move
* or a route related to the product on the move

The changes required to enable this feature:

* In stock_putaway_hook: in the part that match the value, support "in"
  when the value is a container (recordset, list, tuple), so we can pass
  product.route_ids (and match any route set on a put-away rule)
* In stock_putaway_by_route, in the various parts where
  `StockLocation._get_putaway_strategy()` is called, propagate the
  product's routes as well
* In StockMoveLine.onchange_product_id, remove the computation based on
  self.move_id: it cannot change.
