### PR TITLE
[11.0] Fix StockPickingOperationWizard picking move_line_ids

### DIFF
--- a/stock_picking_operation_quick_change/wizards/stock_picking_wizard.py
+++ b/stock_picking_operation_quick_change/wizards/stock_picking_wizard.py
@@ -23,7 +23,7 @@ class StockPickingOperationWizard(models.TransientModel):
     def _default_old_dest_location_id(self):
         stock_picking_obj = self.env['stock.picking']
         pickings = stock_picking_obj.browse(self.env.context['active_ids'])
-        first_move_line = pickings.mapped('move_line_ids')[:1]
+        first_move_line = pickings.mapped('move_lines')[:1]
         return first_move_line.location_dest_id.id
 
     def _get_allowed_locations(self):
@@ -78,7 +78,7 @@ class StockPickingOperationWizard(models.TransientModel):
         stock_picking_obj = self.env['stock.picking']
         pickings = stock_picking_obj.browse(self.env.context['active_ids'])
         self.check_allowed_pickings(pickings)
-        move_lines = pickings.mapped('move_line_ids')
+        move_lines = pickings.mapped('move_lines')
 
         vals = {'location_dest_id': self.new_location_dest_id.id}
         if self.change_all:


### PR DESCRIPTION
The wizard `stock.picking.operation.wizard` is used to update Picking -> Move Destination.

When trying to do the stock.move updates, the field `move_line_ids` does not exist in `stock.picking` model. The field must be rename to `move_lines`