### PR TITLE
[13.0] Fix groups of transfers on sales

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/__manifest__.py
+++ b/stock_picking_group_by_partner_by_carrier/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Picking: group by partner and carrier",
     "Summary": "Group sales deliveries moves in 1 picking per partner and carrier",
-    "version": "13.0.1.3.0",
+    "version": "13.0.1.4.0",
     "development_status": "alpha",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",

--- a/stock_picking_group_by_partner_by_carrier/migrations/13.0.1.4.0/post-migration.py
+++ b/stock_picking_group_by_partner_by_carrier/migrations/13.0.1.4.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    groups = env["procurement.group"].search([])
+    for group in groups:
+        pickings = group.picking_ids
+        all_sales = pickings.move_lines.sale_line_id.order_id
+        # approximation, only new orders will have the correct
+        # links
+        group.sale_ids |= all_sales

--- a/stock_picking_group_by_partner_by_carrier/models/__init__.py
+++ b/stock_picking_group_by_partner_by_carrier/models/__init__.py
@@ -3,4 +3,5 @@ from . import sale_order
 from . import stock_move
 from . import stock_picking
 from . import stock_picking_type
+from . import stock_rule
 from . import stock_warehouse

--- a/stock_picking_group_by_partner_by_carrier/models/procurement_group.py
+++ b/stock_picking_group_by_partner_by_carrier/models/procurement_group.py
@@ -5,3 +5,7 @@ class ProcurementGroup(models.Model):
     _inherit = "procurement.group"
 
     carrier_id = fields.Many2one("delivery.carrier", string="Delivery Method")
+    sale_ids = fields.Many2many(comodel_name="sale.order", copy=True)
+    picking_ids = fields.One2many(
+        comodel_name="stock.picking", inverse_name="group_id", readonly=True,
+    )

--- a/stock_picking_group_by_partner_by_carrier/models/sale_order.py
+++ b/stock_picking_group_by_partner_by_carrier/models/sale_order.py
@@ -27,5 +27,7 @@ class SaleOrderLine(models.Model):
 
     def _prepare_procurement_group_vals(self):
         vals = super()._prepare_procurement_group_vals()
+        if not vals.get("sale_ids") and vals.get("sale_id"):
+            vals["sale_ids"] = [(6, 0, [vals["sale_id"]])]
         vals["carrier_id"] = self.order_id.carrier_id.id
         return vals

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -42,7 +42,10 @@ class StockMove(models.Model):
                 return
             base_group = picking.group_id
             base_sales = base_group.sale_ids
-            line_sales = moves.sale_line_id.order_id
+            # If we have different sales in the line's group, it means moves
+            # have been merged in the same picking/group but they come from a
+            # different sale.
+            line_sales = moves.group_id.sale_id
             all_sales = base_sales | line_sales
             # if we have different sales, it means "_assign_picking" added
             # moves from another SO in the picking

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -12,10 +12,10 @@ class StockPicking(models.Model):
     # printed picking becomes printed
     printed = fields.Boolean(copy=False)
 
-    @api.depends("move_lines.group_id.sale_id")
+    @api.depends("move_lines.group_id.sale_ids")
     def _compute_sale_ids(self):
         for rec in self:
-            rec.sale_ids = rec.mapped("move_lines.group_id.sale_id")
+            rec.sale_ids = rec.mapped("move_lines.group_id.sale_ids")
 
     def write(self, values):
         if self.env.context.get("picking_no_overwrite_partner_origin"):
@@ -27,8 +27,8 @@ class StockPicking(models.Model):
     def action_cancel(self):
         cancel_sale_id = self.env.context.get("cancel_sale_id")
         if cancel_sale_id:
-            moves = self.mapped("move_lines").filtered(
-                lambda m: m.group_id.sale_id.id == cancel_sale_id
+            moves = self.move_lines.filtered(
+                lambda m: m.original_group_id.sale_id.id == cancel_sale_id
                 and m.state not in ("done", "cancel")
             )
             moves.with_context(cancel_sale_id=False)._action_cancel()

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -37,9 +37,10 @@ class StockPicking(models.Model):
             return super().action_cancel()
 
     def _create_backorder(self):
-        return super(
-            StockPicking, self.with_context(picking_no_copy_if_can_group=1)
-        )._create_backorder()
+        self = self.with_context(picking_no_copy_if_can_group=1)
+        backorders = super()._create_backorder()
+        backorders.move_lines._on_assign_picking_merge_group()
+        return backorders
 
     def copy(self, defaults=None):
         if self.env.context.get("picking_no_copy_if_can_group") and self.move_lines:

--- a/stock_picking_group_by_partner_by_carrier/models/stock_rule.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_rule.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _get_stock_move_values(
+        self,
+        product_id,
+        product_qty,
+        product_uom,
+        location_id,
+        name,
+        origin,
+        company_id,
+        values,
+    ):
+        move_values = super()._get_stock_move_values(
+            product_id,
+            product_qty,
+            product_uom,
+            location_id,
+            name,
+            origin,
+            company_id,
+            values,
+        )
+        move_values["original_group_id"] = move_values.get("group_id")
+        return move_values


### PR DESCRIPTION
When grouping transfers of different sales orders in the same
procurement.group, we have an issue with only the first sales order
showing the "Transfers" button on the SO view, because
"sale.picking_ids" returns an empty recordset on the other sales orders.

This is because the link between sales and pickings is done through the
"group_id.sale_id" field of the stock moves. When we group transfers of
different sales, we end up with several group_id in the moves of the
same picking, which is a bit unexpected, and when new transfers are
created (dynamic routing, backorders, ...), they'll only get the first
group_id and be attached only to the first sale order.

The solution implemented here is the following:

* Add a M2m "sale_ids" field on the procurement group
* When several moves with different groups are merged into the same
  group, clone the group, update its "sale_ids" field to contain all the
  sales (sale_id will keep the first one though) and set in on the moves
* Update the computed fields for the relation between the sales and
  pickings to use this M2M field
* Keep the original group in the stock move as "original_group_id": used
  when a sales order is cancelled