### PR TITLE
[13.0][IMP] stock_picking_group_by_partner_by_carrier

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -139,6 +139,15 @@ class StockPicking(models.Model):
             else:
                 return self.move_line_ids
 
+    def get_customer_refs(self):
+        """Returns all unique sales order customer references."""
+        if self.state != "done":
+            move_lines = self.move_lines.filtered("product_uom_qty")
+        else:
+            move_lines = self.move_lines
+        references = move_lines.mapped("sale_line_id.order_id.client_order_ref")
+        return set(filter(None, references))
+
 
 MockedMove = namedtuple(
     "MockedMove",

--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -89,6 +89,10 @@
         >
             <attribute name="t-if">move_line.product_id</attribute>
         </xpath>
+        <!-- Remove "All items could not be shipped..." sentence -->
+        <xpath expr='//div[hasclass("page")]/p[last()]' position="attributes">
+            <attribute name="t-if">False</attribute>
+        </xpath>
     </template>
     <template
         id="report_delivery_document_inherit_sale_stock"

--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -90,4 +90,25 @@
             <attribute name="t-if">move_line.product_id</attribute>
         </xpath>
     </template>
+    <template
+        id="report_delivery_document_inherit_sale_stock"
+        inherit_id="sale_stock.report_delivery_document_inherit_sale_stock"
+    >
+        <!-- Remove the customer reference in the header if there is more than one -->
+        <xpath
+            expr='//div[@t-if="o.sudo().sale_id.client_order_ref"]'
+            position="attributes"
+        >
+            <attribute name="t-if">len(o.get_customer_refs())==1</attribute>
+        </xpath>
+        <!-- Replace the customer refs with the one based on the move line displayed -->
+        <xpath
+            expr='//p[@t-field="o.sudo().sale_id.client_order_ref"]'
+            position="replace"
+        >
+            <p>
+                <t t-esc="o.get_customer_refs().pop()" />
+            </p>
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
The delivery slip can reference more than one sale order with different
customer references. If there is more than one of those references they
will be displayed in the lines.
But only one in the header!
So better not to display the customer reference in the header when
this is the case.