### PR TITLE
[13.0][FIX] stock_move_line_auto_fill: Qty done not fully updated in case of update stock move line

### DIFF
--- a/stock_move_line_auto_fill/models/stock_move.py
+++ b/stock_move_line_auto_fill/models/stock_move.py
@@ -1,5 +1,6 @@
 # Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2018 David Vidal <david.vidal@tecnativa.com>
+# Copyright 2020 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models
@@ -9,12 +10,42 @@ class StockMove(models.Model):
     _inherit = "stock.move"
 
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
-        """Auto-assign as done the quantity proposed for the lots"""
+        """
+        Auto-assign as done the quantity proposed for the lots.
+        Keep this method to avoid extra write after picking _action_assign
+        """
         self.ensure_one()
         res = super()._prepare_move_line_vals(quantity, reserved_quant)
         if not self.picking_id.auto_fill_operation:
             return res
         elif self.picking_id.picking_type_id.avoid_lot_assignment and res.get("lot_id"):
             return res
-        res.update({"qty_done": res.get("product_uom_qty", 0.0)})
+        if self.quantity_done != self.product_uom_qty:
+            # Not assign qty_done for extra moves in over processed quantities
+            res.update({"qty_done": res.get("product_uom_qty", 0.0)})
+        return res
+
+    def _action_assign(self):
+        """
+        Update stock move line quantity done field with reserved quantity.
+        This method take into account incoming and outgoing moves.
+        We can not use _prepare_move_line_vals method because this method only
+        is called for a new lines.
+        """
+        res = super()._action_assign()
+        for line in self:
+            if (
+                line._should_bypass_reservation()
+                or not line.picking_id.auto_fill_operation
+            ):
+                return res
+            lines_to_update = line.move_line_ids.filtered(
+                lambda l: l.qty_done != l.product_uom_qty
+            )
+            for move_line in lines_to_update:
+                if (
+                    not line.picking_id.picking_type_id.avoid_lot_assignment
+                    or not move_line.lot_id
+                ):
+                    move_line.qty_done = move_line.product_uom_qty
         return res

--- a/stock_move_line_auto_fill/tests/test_stock_picking_auto_fill.py
+++ b/stock_move_line_auto_fill/tests/test_stock_picking_auto_fill.py
@@ -380,3 +380,40 @@ class TestStockPicking(TransactionCase):
         # The expected result is only opertions with product_id set and
         self.assertFalse(product_8_op.qty_done)
         self.assertTrue(product_9_op.qty_done)
+
+    def test_action_assign_replenish_stock(self):
+        # Covered case:
+        # For a product with less stock than initial demand, check after
+        # replenish stock that quantity done is written with initial demand
+        # after check availability
+        self.picking_type_in.auto_fill_operation = True
+        product = self.env["product.product"].create(
+            {"name": "Test auto fill", "type": "product"}
+        )
+        product_quant = self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "location_id": self.picking_type_out.default_location_src_id.id,
+                "quantity": 1000.00,
+            }
+        )
+        self.move_model.create(
+            dict(
+                product_id=product.id,
+                picking_id=self.picking.id,
+                name=product.display_name,
+                picking_type_id=self.picking_type_out.id,
+                product_uom_qty=1500.00,
+                location_id=self.picking_type_out.default_location_src_id.id,
+                location_dest_id=self.customer_location.id,
+                product_uom=product.uom_id.id,
+            )
+        )
+        self.picking.action_assign()
+        self.assertEqual(self.picking.state, "assigned")
+        self.assertEqual(len(self.picking.move_line_ids), 1)
+        # Try to fill all the operation automatically.
+        self.assertEqual(self.picking.move_line_ids.qty_done, 1000.00)
+        product_quant.quantity = 1500.00
+        self.picking.action_assign()
+        self.assertEqual(self.picking.move_line_ids.qty_done, 1500.00)


### PR DESCRIPTION
@Tecnativa TT25820
Before this PR:

- Create a product and update stock on hand to 1000
- Make a sale of 1500 units of this product 
- Go to picking, the qty_done in detail operations is 1000
- Go to product and update stock on hand to 1500
- Got to picking and click in "check availavility"
- qty_done in datailed operation is **1000** 

After this PR:
- Create a product and update stock on hand to 1000
- Make a sale of 1500 units of this product 
- Go to picking, the qty_done in detail operations is 1000
- Go to product and update stock on hand to 1500
- Got to picking and click in "check availavility"
- qty_done in datailed operation is **1500**

ping @carlosdauden ping @chienandalu 