### PR TITLE
Revert "[FIX] stock: When a transfer is packaged and unpacked, it creates a"

### DIFF
--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -22,9 +22,7 @@ class StockQuant(models.Model):
         )
         if not check_negative_qty:
             return
-        # Execute generic merge method before doing comparisons for avoiding
-        # existing negative quants not merged with their counterparts
-        self._merge_quants()
+
         for quant in self:
             disallowed_by_product = \
                 not quant.product_id.allow_negative_stock \


### PR DESCRIPTION
This reverts commit c3ff0950f343a3360b1fff1e75676f3b2d3c0b54 from https://github.com/OCA/stock-logistics-workflow/pull/675.

With that commit, we started having performance bottlenecks. Rolling back until a better solution is found.

Problem STR:

1. Create a `stock.picking` with quite a few operations.
1. Validate it.

Here you have the speedscope profile to check what was happening: [profiling.zip](https://github.com/OCA/stock-logistics-workflow/files/5371353/profiling.zip)
Just open it with https://www.speedscope.app/ and browse.

As you can see, the method `check_negative_qty` is called each time `_update_available_qty` is called. This is roughly twice per record in `Model(stock.move.line)._action_done()`, specifically these lines:

1. https://github.com/odoo/odoo/blob/12.0/addons/stock/models/stock_move_line.py#L451
1. https://github.com/odoo/odoo/blob/12.0/addons/stock/models/stock_move_line.py#L459

The query that `_merge_quants()` executes is highly suboptimal. Check [these explain analyze results](https://explain.depesz.com/s/B6nq). That's 3.3s * 2 * line. **A lot.** Notice that this database has ~1.25M quants.

@Tecnativa TT26171 @deivislaya @moylop260 