### PR TITLE
[13.0] stock_picking_group_by_partner_by_carrier: Fix cancelation of SO when multiple SO are grouped in a same delivery.

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/README.rst
+++ b/stock_picking_group_by_partner_by_carrier/README.rst
@@ -85,6 +85,8 @@ Contributors
 
 * Camptocamp:
   * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+* BCIM:
+  * Jacques-Etienne Baudoux <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_group_by_partner_by_carrier/__manifest__.py
+++ b/stock_picking_group_by_partner_by_carrier/__manifest__.py
@@ -6,7 +6,7 @@
     "Summary": "Group sales deliveries moves in 1 picking per partner and carrier",
     "version": "13.0.1.4.1",
     "development_status": "Alpha",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "category": "Warehouse Management",
     "depends": ["sale_stock", "delivery"],

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -1,7 +1,7 @@
 import re
 from collections import namedtuple
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockMove(models.Model):
@@ -12,8 +12,16 @@ class StockMove(models.Model):
     # and for cancellation of a sales order (to cancel only the moves related
     # to it)
     original_group_id = fields.Many2one(
-        comodel_name="procurement.group", string="Original Procurement Group",
+        comodel_name="procurement.group",
+        string="Original Procurement Group",
     )
+
+    @api.model
+    def _prepare_merge_moves_distinct_fields(self):
+        # Prevent merging pulled moves. This allows to cancel a SO without
+        # canceling pulled moves from other SO as we ensure they are not
+        # merged.
+        return super()._prepare_merge_moves_distinct_fields() + ["original_group_id"]
 
     def _assign_picking(self):
         result = super(

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -1,3 +1,7 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 import re
 from collections import namedtuple
 
@@ -12,8 +16,7 @@ class StockMove(models.Model):
     # and for cancellation of a sales order (to cancel only the moves related
     # to it)
     original_group_id = fields.Many2one(
-        comodel_name="procurement.group",
-        string="Original Procurement Group",
+        comodel_name="procurement.group", string="Original Procurement Group",
     )
 
     @api.model

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -1,3 +1,7 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from collections import namedtuple
 from itertools import groupby
 

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -28,7 +28,7 @@ class StockPicking(models.Model):
         cancel_sale_id = self.env.context.get("cancel_sale_id")
         if cancel_sale_id:
             moves = self.move_lines.filtered(
-                lambda m: m.original_group_id.sale_id.id == cancel_sale_id
+                lambda m: cancel_sale_id in m.original_group_id.sale_ids.ids
                 and m.state not in ("done", "cancel")
             )
             moves.with_context(cancel_sale_id=False)._action_cancel()

--- a/stock_picking_group_by_partner_by_carrier/models/stock_rule.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_rule.py
@@ -27,5 +27,11 @@ class StockRule(models.Model):
             company_id,
             values,
         )
-        move_values["original_group_id"] = move_values.get("group_id")
+        # We propagate the original_group_id on pull moves to allow to prevent
+        # merging pulled moves. This allows to cancel a SO without canceling
+        # pulled moves from other SO (as we ensure they are not merged).
+        move_values["original_group_id"] = (
+            values.get("move_dest_ids", self.env["stock.move"]).original_group_id.id
+            or move_values["group_id"]
+        )
         return move_values

--- a/stock_picking_group_by_partner_by_carrier/models/stock_rule.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_rule.py
@@ -1,5 +1,7 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from odoo import models
 
 

--- a/stock_picking_group_by_partner_by_carrier/readme/CONTRIBUTORS.rst
+++ b/stock_picking_group_by_partner_by_carrier/readme/CONTRIBUTORS.rst
@@ -1,2 +1,4 @@
 * Camptocamp:
   * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+* BCIM:
+  * Jacques-Etienne Baudoux <je@bcim.be>


### PR DESCRIPTION
Propagate the original_group_id on pull moves to allow to prevent
merging pulled moves. This allows to cancel a SO without canceling
pulled moves from other SO, as we ensure they are not merged.