### PR TITLE
[ADD] stock_split_picking: Mode selection to split in different ways

### DIFF
--- a/stock_split_picking/__init__.py
+++ b/stock_split_picking/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizards

--- a/stock_split_picking/__manifest__.py
+++ b/stock_split_picking/__manifest__.py
@@ -17,6 +17,7 @@
         'stock',
     ],
     'data': [
+        'wizards/stock_split_picking.xml',
         'views/stock_partial_picking.xml',
     ],
 }

--- a/stock_split_picking/readme/CONTRIBUTORS.rst
+++ b/stock_split_picking/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Vicent Cubells <vicent.cubells@tecnativa.com>
 * Julien Coux <julien.coux@camptocamp.com>
 * Andrius Preimantas <andrius@versada.eu>
+* Holger Brunn <mail@hunki-enterprises.com>

--- a/stock_split_picking/readme/DESCRIPTION.rst
+++ b/stock_split_picking/readme/DESCRIPTION.rst
@@ -2,3 +2,6 @@ This module adds a "Split" button on the outgoing pickings form.
 
 It works like the classical picking Transfer but it leaves both pickings
 (picking and its backorder) as confirmed without processing the transfer.
+
+You can also choose to put all moves into separate pickings, or select moves
+to be put into a new picking.

--- a/stock_split_picking/views/stock_partial_picking.xml
+++ b/stock_split_picking/views/stock_partial_picking.xml
@@ -7,12 +7,11 @@
     <field name="inherit_id" ref="stock.view_picking_form" />
     <field name="arch" type="xml">
         <field name ="state" position="before">
-            <button name="split_process"
+            <button name="%(stock_split_picking.action_stock_split_picking)s"
                     states="draft,confirmed,assigned"
                     string="Split"
-                    confirm="Are you sure you want to split current picking?"
                     groups="stock.group_stock_user"
-                    type="object"/>
+                    type="action"/>
         </field>
     </field>
 </record>

--- a/stock_split_picking/wizards/__init__.py
+++ b/stock_split_picking/wizards/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 Hunki Enterprises BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import stock_split_picking

--- a/stock_split_picking/wizards/stock_split_picking.py
+++ b/stock_split_picking/wizards/stock_split_picking.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Hunki Enterprises BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+
+
+class StockSplitPicking(models.TransientModel):
+    _name = 'stock.split.picking'
+    _description = 'Split a picking'
+
+    mode = fields.Selection([
+        ('done', 'Done quantities'),
+        ('move', 'One picking per move'),
+        ('selection', 'Select move lines to split off'),
+    ], required=True, default='done')
+
+    picking_ids = fields.Many2many(
+        'stock.picking', default=lambda self: self._default_picking_ids(),
+    )
+    move_ids = fields.Many2many('stock.move')
+
+    def _default_picking_ids(self):
+        return self.env['stock.picking'].browse(
+            self.env.context.get('active_ids', [])
+        )
+
+    def action_apply(self):
+        return getattr(self, '_apply_%s' % self[:1].mode)()
+
+    def _apply_done(self):
+        return self.mapped('picking_ids').split_process()
+
+    def _apply_move(self):
+        """Create new pickings for every move line, keep first
+        move line in original picking
+        """
+        new_pickings = self.env['stock.picking']
+        for picking in self.mapped('picking_ids'):
+            for move in picking.move_lines[1:]:
+                new_pickings += picking._split_off_moves(move)
+        return self._picking_action(new_pickings)
+
+    def _apply_selection(self):
+        """Create one picking for all selected moves"""
+        moves = self.mapped('move_ids')
+        new_picking = moves.mapped('picking_id')._split_off_moves(moves)
+        return self._picking_action(new_picking)
+
+    def _picking_action(self, pickings):
+        action = self.env['ir.actions.act_window'].for_xml_id(
+            'stock', 'action_picking_tree_all',
+        )
+        action['domain'] = [('id', 'in', pickings.ids)]
+        return action

--- a/stock_split_picking/wizards/stock_split_picking.xml
+++ b/stock_split_picking/wizards/stock_split_picking.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<record id="view_stock_split_picking" model="ir.ui.view">
+    <field name="model">stock.split.picking</field>
+    <field name="arch" type="xml">
+        <form>
+            <group>
+                <field name="mode" />
+                <field name="picking_ids" invisible="True" />
+                <field name="move_ids" attrs="{'invisible': [('mode', '!=', 'selection')], 'required': [('mode', '=', 'selection')]}" domain="[('picking_id', 'in', picking_ids)]" />
+            </group>
+            <footer>
+                <button name="action_apply" class="btn btn-primary" string="Split" type="object" />
+                or
+                <button special="cancel" class="btn btn-secondary" string="Cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+<act_window
+    id="action_stock_split_picking"
+    res_model="stock.split.picking"
+    src_model="stock.picking"
+    multi="True"
+    target="new"
+    name="Split pickings"
+    view_id="view_stock_split_picking"
+/>
+
+</odoo>


### PR DESCRIPTION
this adds two additional modes of splitting, either every move in its own picking, or some selected moves into a new picking.

As the original is the default choice, we end up with the same amount of clicks for splitting by done quantity as we had before.