### PR TITLE
[13.0][IMP] stock_picking_auto_create_lot: Improve performances and UX

### DIFF
--- a/stock_picking_auto_create_lot/__manifest__.py
+++ b/stock_picking_auto_create_lot/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
+# Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Stock Picking Auto Create Lot",
@@ -7,7 +8,7 @@
     "development_status": "Production/Stable",
     "category": "stock",
     "website": "https://github.com/OCA/stock-logistics-workflow",
-    "author": "Tecnativa, Odoo Community Association (OCA)",
+    "author": "ACSONE SA/NV, Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
     "depends": ["stock"],

--- a/stock_picking_auto_create_lot/models/__init__.py
+++ b/stock_picking_auto_create_lot/models/__init__.py
@@ -1,3 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import product
 from . import stock_picking
+from . import stock_picking_type
+from . import stock_move_line
+from . import stock_move

--- a/stock_picking_auto_create_lot/models/stock_move.py
+++ b/stock_picking_auto_create_lot/models/stock_move.py
@@ -1,0 +1,23 @@
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, models
+
+
+class StockMove(models.Model):
+
+    _inherit = "stock.move"
+
+    @api.depends(
+        "has_tracking",
+        "picking_type_id.auto_create_lot",
+        "product_id.auto_create_lot",
+        "picking_type_id.use_existing_lots",
+        "state",
+    )
+    def _compute_display_assign_serial(self):
+        super()._compute_display_assign_serial()
+        moves_not_display = self.filtered(
+            lambda m: m.picking_type_id.auto_create_lot and m.product_id.auto_create_lot
+        )
+        for move in moves_not_display:
+            move.display_assign_serial = False

--- a/stock_picking_auto_create_lot/models/stock_move_line.py
+++ b/stock_picking_auto_create_lot/models/stock_move_line.py
@@ -1,7 +1,6 @@
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
-from odoo.fields import first
 
 
 class StockMoveLine(models.Model):
@@ -22,12 +21,15 @@ class StockMoveLine(models.Model):
             products, we apply the lot with both different approaches.
         """
         values = []
+        lot_by_product = {}
         production_lot_obj = self.env["stock.production.lot"]
         for line in self:
             values.append(line._prepare_auto_lot_values())
         lots = production_lot_obj.create(values)
+        for lot in lots:
+            lot_by_product[lot.product_id.id] = lot
         for line in self:
-            lot = first(lots.filtered(lambda l: l.product_id == line.product_id))
+            lot = lot_by_product[line.product_id.id]
             line.lot_id = lot
             if lot.product_id.tracking == "serial":
                 lots -= lot

--- a/stock_picking_auto_create_lot/models/stock_move_line.py
+++ b/stock_picking_auto_create_lot/models/stock_move_line.py
@@ -1,6 +1,7 @@
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
+from odoo.fields import first
 
 
 class StockMoveLine(models.Model):
@@ -21,15 +22,18 @@ class StockMoveLine(models.Model):
             products, we apply the lot with both different approaches.
         """
         values = []
-        lot_by_product = {}
         production_lot_obj = self.env["stock.production.lot"]
+        lots_by_product = dict()
         for line in self:
             values.append(line._prepare_auto_lot_values())
         lots = production_lot_obj.create(values)
         for lot in lots:
-            lot_by_product[lot.product_id.id] = lot
+            if lot.product_id.id not in lots_by_product:
+                lots_by_product[lot.product_id.id] = lot
+            else:
+                lots_by_product[lot.product_id.id] += lot
         for line in self:
-            lot = lot_by_product[line.product_id.id]
+            lot = first(lots_by_product[line.product_id.id])
             line.lot_id = lot
             if lot.product_id.tracking == "serial":
-                lots -= lot
+                lots_by_product[line.product_id.id] -= lot

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -1,12 +1,7 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
+# Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
-
-
-class StockPickingType(models.Model):
-    _inherit = "stock.picking.type"
-
-    auto_create_lot = fields.Boolean(string="Auto Create Lot")
+from odoo import models
 
 
 class StockPicking(models.Model):
@@ -14,15 +9,14 @@ class StockPicking(models.Model):
 
     def button_validate(self):
         if self.picking_type_id.auto_create_lot:
-            for line in self.move_line_ids.filtered(
+            lines = self.move_line_ids.filtered(
                 lambda x: (
                     not x.lot_id
                     and not x.lot_name
                     and x.product_id.tracking != "none"
                     and x.product_id.auto_create_lot
                 )
-            ):
-                line.lot_id = self.env["stock.production.lot"].create(
-                    {"product_id": line.product_id.id, "company_id": line.company_id.id}
-                )
+            )
+            lines.set_lot_auto()
+
         return super().button_validate()

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -7,7 +7,7 @@ from odoo import models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    def button_validate(self):
+    def _set_auto_lot(self):
         if self.picking_type_id.auto_create_lot:
             lines = self.move_line_ids.filtered(
                 lambda x: (
@@ -19,4 +19,10 @@ class StockPicking(models.Model):
             )
             lines.set_lot_auto()
 
-        return super().button_validate()
+    def action_done(self):
+        self._set_auto_lot()
+        return super().action_done()
+
+    def button_validate(self):
+        self._set_auto_lot()
+        return super().action_done()

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -8,16 +8,19 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     def _set_auto_lot(self):
-        if self.picking_type_id.auto_create_lot:
-            lines = self.move_line_ids.filtered(
-                lambda x: (
-                    not x.lot_id
-                    and not x.lot_name
-                    and x.product_id.tracking != "none"
-                    and x.product_id.auto_create_lot
-                )
+        """
+            Allows to be called either by button or through code
+        """
+        pickings = self.filtered(lambda p: p.picking_type_id.auto_create_lot)
+        lines = pickings.mapped("move_line_ids").filtered(
+            lambda x: (
+                not x.lot_id
+                and not x.lot_name
+                and x.product_id.tracking != "none"
+                and x.product_id.auto_create_lot
             )
-            lines.set_lot_auto()
+        )
+        lines.set_lot_auto()
 
     def action_done(self):
         self._set_auto_lot()
@@ -25,4 +28,4 @@ class StockPicking(models.Model):
 
     def button_validate(self):
         self._set_auto_lot()
-        return super().action_done()
+        return super().button_validate()

--- a/stock_picking_auto_create_lot/models/stock_picking_type.py
+++ b/stock_picking_auto_create_lot/models/stock_picking_type.py
@@ -1,0 +1,9 @@
+# Copyright 2018 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    auto_create_lot = fields.Boolean(string="Auto Create Lot")

--- a/stock_picking_auto_create_lot/readme/CONFIGURE.rst
+++ b/stock_picking_auto_create_lot/readme/CONFIGURE.rst
@@ -2,3 +2,6 @@ To configure this module, you need to:
 
 #. Go to a *Inventory > Configuration > Operation Types*.
 #. Set 'auto create lot' option for this operation type.
+
+#. Go to a *Inventory > Master Data > Products*.
+#. Set 'auto create lot' option for the products you need.

--- a/stock_picking_auto_create_lot/readme/CONTRIBUTORS.rst
+++ b/stock_picking_auto_create_lot/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Carlos Dauden <carlos.dauden@tecnativa.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* Denis Roussel <denis.roussel@acsone.eu>

--- a/stock_picking_auto_create_lot/tests/__init__.py
+++ b/stock_picking_auto_create_lot/tests/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import common
 from . import test_stock_picking_auto_create_lot

--- a/stock_picking_auto_create_lot/tests/common.py
+++ b/stock_picking_auto_create_lot/tests/common.py
@@ -4,6 +4,13 @@
 
 
 class CommonStockPickingAutoCreateLot(object):
+    def assertUniqueIn(self, element_list):
+        elements = []
+        for element in element_list:
+            if element in elements:
+                raise Exception("Element %s is not unique in list" % element)
+            elements.append(element)
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/stock_picking_auto_create_lot/tests/common.py
+++ b/stock_picking_auto_create_lot/tests/common.py
@@ -1,0 +1,57 @@
+# Copyright 2018 Tecnativa - Sergio Teruel
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+class CommonStockPickingAutoCreateLot(object):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.lot_obj = cls.env["stock.production.lot"]
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.picking_type_in = cls.env.ref("stock.picking_type_in")
+        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+        cls.supplier = cls.env["res.partner"].create({"name": "Supplier - test"})
+
+    @classmethod
+    def _create_product(cls, tracking="lot", auto=True):
+        name = "{tracking} - {auto}".format(tracking=tracking, auto=auto)
+        return cls.env["product.product"].create(
+            {
+                "name": name,
+                "type": "product",
+                "tracking": tracking,
+                "auto_create_lot": auto,
+            }
+        )
+
+    @classmethod
+    def _create_picking(cls):
+        cls.picking = (
+            cls.env["stock.picking"]
+            .with_context(default_picking_type_id=cls.picking_type_in.id)
+            .create(
+                {
+                    "partner_id": cls.supplier.id,
+                    "picking_type_id": cls.picking_type_in.id,
+                    "location_id": cls.supplier_location.id,
+                }
+            )
+        )
+
+    @classmethod
+    def _create_move(cls, product=None, qty=1.0):
+        location_dest = cls.picking.picking_type_id.default_location_dest_id
+        cls.move = cls.env["stock.move"].create(
+            {
+                "name": "test-{product}".format(product=product.name),
+                "product_id": product.id,
+                "picking_id": cls.picking.id,
+                "picking_type_id": cls.picking.picking_type_id.id,
+                "product_uom_qty": qty,
+                "product_uom": product.uom_id.id,
+                "location_id": cls.supplier_location.id,
+                "location_dest_id": location_dest.id,
+            }
+        )

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
+# Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.tests import SavepointCase
 
@@ -7,10 +8,27 @@ class TestStockPickingAutoCreateLot(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.lot_obj = cls.env["stock.production.lot"]
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.picking_type_in = cls.env.ref("stock.picking_type_in")
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
         cls.supplier = cls.env["res.partner"].create({"name": "Supplier - test"})
+        cls.product_serial = cls.env["product.product"].create(
+            {
+                "name": "Product Serial Test",
+                "type": "product",
+                "tracking": "serial",
+                "auto_create_lot": True,
+            }
+        )
+        cls.product_serial_not_auto = cls.env["product.product"].create(
+            {
+                "name": "Product Serial Not Auto Test",
+                "type": "product",
+                "tracking": "serial",
+                "auto_create_lot": False,
+            }
+        )
         cls.product = cls.env["product.product"].create(
             {
                 "name": "test",
@@ -32,6 +50,30 @@ class TestStockPickingAutoCreateLot(SavepointCase):
         )
         cls.move = cls.env["stock.move"].create(
             {
+                "name": "test-auto-serial",
+                "product_id": cls.product_serial.id,
+                "picking_id": cls.picking.id,
+                "picking_type_id": cls.picking_type_in.id,
+                "product_uom_qty": 3.0,
+                "product_uom": cls.product.uom_id.id,
+                "location_id": cls.supplier_location.id,
+                "location_dest_id": cls.picking_type_in.default_location_dest_id.id,
+            }
+        )
+        cls.move = cls.env["stock.move"].create(
+            {
+                "name": "test-not-auto-serial",
+                "product_id": cls.product_serial_not_auto.id,
+                "picking_id": cls.picking.id,
+                "picking_type_id": cls.picking_type_in.id,
+                "product_uom_qty": 4.0,
+                "product_uom": cls.product.uom_id.id,
+                "location_id": cls.supplier_location.id,
+                "location_dest_id": cls.picking_type_in.default_location_dest_id.id,
+            }
+        )
+        cls.move = cls.env["stock.move"].create(
+            {
                 "name": "test-auto-lot",
                 "product_id": cls.product.id,
                 "picking_id": cls.picking.id,
@@ -46,8 +88,26 @@ class TestStockPickingAutoCreateLot(SavepointCase):
     def test_auto_create_lot(self):
         self.picking_type_in.auto_create_lot = True
         self.picking.action_assign()
+        # Check the display field
+        move = self.picking.move_lines.filtered(
+            lambda m: m.product_id == self.product_serial)
+        self.assertFalse(move.display_assign_serial)
+
+        move = self.picking.move_lines.filtered(
+            lambda m: m.product_id == self.product_serial_not_auto)
+        self.assertTrue(move.display_assign_serial)
+
+        # Assign manual serials
+        for line in move.move_line_ids:
+            line.lot_id = self.lot_obj.create(line._prepare_auto_lot_values())
+
         self.picking.button_validate()
         lot = self.env["stock.production.lot"].search(
             [("product_id", "=", self.product.id)]
         )
         self.assertEqual(len(lot), 1)
+        # Search for serials
+        lot = self.env["stock.production.lot"].search(
+            [("product_id", "=", self.product_serial.id)]
+        )
+        self.assertEqual(len(lot), 3)

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -7,21 +7,24 @@ from .common import CommonStockPickingAutoCreateLot
 
 
 class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, SavepointCase):
-    def test_auto_create_lot(self):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # Create 3 products with lot/serial and auto_create True/False
-        self.product = self._create_product()
-        self.product_serial = self._create_product(tracking="serial")
-        self.product_serial_not_auto = self._create_product(
-            tracking="serial", auto=False
-        )
-        self.picking_type_in.auto_create_lot = True
+        cls.product = cls._create_product()
+        cls.product_serial = cls._create_product(tracking="serial")
+        cls.product_serial_not_auto = cls._create_product(tracking="serial", auto=False)
+        cls.picking_type_in.auto_create_lot = True
 
-        self._create_picking()
-        self._create_move(product=self.product, qty=2.0)
-        self._create_move(product=self.product_serial, qty=3.0)
-        self._create_move(product=self.product_serial_not_auto, qty=4.0)
+        cls._create_picking()
+        cls._create_move(product=cls.product, qty=2.0)
+        cls._create_move(product=cls.product_serial, qty=3.0)
+        cls._create_move(product=cls.product_serial_not_auto, qty=4.0)
 
-        self.picking.action_assign()
+        cls.picking.action_assign()
+
+    def test_manual_lot(self):
+
         # Check the display field
         move = self.picking.move_lines.filtered(
             lambda m: m.product_id == self.product_serial
@@ -38,6 +41,56 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, SavepointCa
             line.lot_id = self.lot_obj.create(line._prepare_auto_lot_values())
 
         self.picking.button_validate()
+        lot = self.env["stock.production.lot"].search(
+            [("product_id", "=", self.product.id)]
+        )
+        self.assertEqual(len(lot), 1)
+        # Search for serials
+        lot = self.env["stock.production.lot"].search(
+            [("product_id", "=", self.product_serial.id)]
+        )
+        self.assertEqual(len(lot), 3)
+
+    def test_auto_create_lot(self):
+        # Check the display field
+        move = self.picking.move_lines.filtered(
+            lambda m: m.product_id == self.product_serial
+        )
+        self.assertFalse(move.display_assign_serial)
+
+        move = self.picking.move_lines.filtered(
+            lambda m: m.product_id == self.product_serial_not_auto
+        )
+        self.assertTrue(move.display_assign_serial)
+
+        self.picking.action_done()
+        lot = self.env["stock.production.lot"].search(
+            [("product_id", "=", self.product.id)]
+        )
+        self.assertEqual(len(lot), 1)
+        # Search for serials
+        lot = self.env["stock.production.lot"].search(
+            [("product_id", "=", self.product_serial.id)]
+        )
+        self.assertEqual(len(lot), 3)
+
+    def test_auto_create_transfer_lot(self):
+        # Check the display field
+        move = self.picking.move_lines.filtered(
+            lambda m: m.product_id == self.product_serial
+        )
+        self.assertFalse(move.display_assign_serial)
+
+        moves = self.picking.move_lines.filtered(
+            lambda m: m.product_id == self.product_serial
+        )
+        for line in moves.mapped("move_line_ids"):
+            self.assertFalse(line.lot_id)
+
+        self.picking.button_validate()
+        for line in moves.mapped("move_line_ids"):
+            self.assertTrue(line.lot_id)
+
         lot = self.env["stock.production.lot"].search(
             [("product_id", "=", self.product.id)]
         )


### PR DESCRIPTION
* Create lots using create_multi to reduce queries in case of large pickings.
* Hide the serial assignement for products that are not enabled for it.
* Improve tests

![image](https://user-images.githubusercontent.com/19529533/98253944-f5310100-1f7b-11eb-998f-50f2d004c0f2.png)
