### PR TITLE
[13.0][FIX] stock_move_line_auto_fill: Fix action assign method for allowed states.

### DIFF
--- a/stock_move_line_auto_fill/models/stock_move.py
+++ b/stock_move_line_auto_fill/models/stock_move.py
@@ -33,7 +33,10 @@ class StockMove(models.Model):
         is called for a new lines.
         """
         res = super()._action_assign()
-        for line in self:
+        for line in self.filtered(
+            lambda m: m.state
+            in ["confirmed", "assigned", "waiting", "partially_available"]
+        ):
             if (
                 line._should_bypass_reservation()
                 or not line.picking_id.auto_fill_operation

--- a/stock_move_line_auto_fill/tests/test_stock_picking_auto_fill.py
+++ b/stock_move_line_auto_fill/tests/test_stock_picking_auto_fill.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
 
@@ -417,3 +418,70 @@ class TestStockPicking(TransactionCase):
         product_quant.quantity = 1500.00
         self.picking.action_assign()
         self.assertEqual(self.picking.move_line_ids.qty_done, 1500.00)
+
+    def _picking_return(self, picking, qty):
+        # Make a return from picking
+        ReturnWiz = self.env["stock.return.picking"]
+        return_form = Form(
+            ReturnWiz.with_context(
+                active_ids=picking.ids,
+                active_id=picking.ids[0],
+                active_model="stock.picking",
+            )
+        )
+        stock_return_picking = return_form.save()
+        stock_return_picking.product_return_moves.quantity = qty
+        stock_return_picking_action = stock_return_picking.create_returns()
+        return_pick = self.env["stock.picking"].browse(
+            stock_return_picking_action["res_id"]
+        )
+        return_pick.action_assign()
+        # return_pick.move_lines.quantity_done = qty
+        return_pick.action_done()
+        return return_pick
+
+    def test_return_twice(self):
+        # Covered case:
+        # Return more than one times not duplicate quant units in stock
+        self.picking_type_out.auto_fill_operation = True
+        self.picking_type_in.auto_fill_operation = True
+        product = self.env["product.product"].create(
+            {"name": "Test return", "type": "product"}
+        )
+        self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "location_id": self.picking_type_out.default_location_src_id.id,
+                "quantity": 500.00,
+            }
+        )
+        self.move_model.create(
+            dict(
+                product_id=product.id,
+                picking_id=self.picking_out.id,
+                name=product.display_name,
+                picking_type_id=self.picking_type_out.id,
+                product_uom_qty=500.00,
+                location_id=self.picking_type_out.default_location_src_id.id,
+                location_dest_id=self.customer_location.id,
+                product_uom=product.uom_id.id,
+            )
+        )
+        self.picking_out.action_confirm()
+        self.picking_out.action_assign()
+        # self.picking_out.move_lines.quantity_done = 500
+        self.picking_out.action_done()
+        self.assertEqual(product.qty_available, 0.0)
+
+        # Make first return from customer location to stock location
+        returned_picking = self._picking_return(self.picking_out, 500.00)
+        self.assertEqual(product.qty_available, 500)
+
+        # Make second return from stock location to customer location
+        returned_picking = self._picking_return(returned_picking, 500.00)
+        self.assertEqual(product.qty_available, 0.0)
+
+        # Make third return from customer location to stock location
+        returned_picking = self._picking_return(returned_picking, 500.00)
+
+        self.assertEqual(product.qty_available, 500)


### PR DESCRIPTION
Coverage case:
Return more than one times duplicate quant units in stock.
cc @Tecnativa
ping @carlosdauden @CarlosRoca13 