### PR TITLE
[13.0][IMP] stock_picking_invoice_link: Allow to update stock move depending on context.

### DIFF
--- a/stock_picking_invoice_link/models/stock_move.py
+++ b/stock_picking_invoice_link/models/stock_move.py
@@ -27,7 +27,9 @@ class StockMove(models.Model):
         line quantities. So to avoid this inconsistency you can not update any
         stock move line in done state and have invoice lines linked.
         """
-        if "product_uom_qty" in vals:
+        if "product_uom_qty" in vals and not self.env.context.get(
+            "bypass_stock_move_update_restriction"
+        ):
             for move in self:
                 if move.state == "done" and move.invoice_line_ids:
                     raise UserError(_("You can not modify an invoiced stock move"))


### PR DESCRIPTION
Ported from v12.0 https://github.com/OCA/stock-logistics-workflow/pull/742
cc @Tecnativa
ping @carlosdauden @chienandalu 