### PR TITLE
[14] Add module stock_restrict_lot

### DIFF
--- a/stock_restrict_lot/__init__.py
+++ b/stock_restrict_lot/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_restrict_lot/__manifest__.py
+++ b/stock_restrict_lot/__manifest__.py
@@ -1,0 +1,14 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Stock Restrict Lot",
+    "summary": "Base module that add back the concept of restrict lot on stock move",
+    "version": "14.0.1.1.0",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["florian-dacosta"],
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": ["stock"],
+}

--- a/stock_restrict_lot/models/__init__.py
+++ b/stock_restrict_lot/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_move
+from . import stock_rule

--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -1,0 +1,73 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, exceptions, fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    restrict_lot_id = fields.Many2one("stock.production.lot", string="Restrict Lot")
+
+    def _prepare_procurement_values(self):
+        vals = super()._prepare_procurement_values()
+        vals["restrict_lot_id"] = self.restrict_lot_id.id
+        return vals
+
+    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
+        vals = super()._prepare_move_line_vals(
+            quantity=quantity, reserved_quant=reserved_quant
+        )
+        if self.restrict_lot_id:
+            if "lot_id" in vals and vals["lot_id"] != self.restrict_lot_id.id:
+                raise exceptions.UserError(
+                    _(
+                        "Inconsistencies between reserved quant and lot restriction on "
+                        "stock move"
+                    )
+                )
+            vals["lot_id"] = self.restrict_lot_id.id
+        return vals
+
+    def _get_available_quantity(
+        self,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+        allow_negative=False,
+    ):
+        self.ensure_one()
+        if not lot_id and self.restrict_lot_id:
+            lot_id = self.restrict_lot_id
+        return super()._get_available_quantity(
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+            allow_negative=allow_negative,
+        )
+
+    def _update_reserved_quantity(
+        self,
+        need,
+        available_quantity,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=True,
+    ):
+        self.ensure_one()
+        if self.restrict_lot_id:
+            lot_id = self.restrict_lot_id
+        return super()._update_reserved_quantity(
+            need,
+            available_quantity,
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )

--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -6,7 +6,12 @@ from odoo import _, exceptions, fields, models
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    restrict_lot_id = fields.Many2one("stock.production.lot", string="Restrict Lot")
+    # seems better to not copy this field except when a move is splitted, because a move
+    # can be copied in multiple different occasions and could even be copied with a
+    # different product...
+    restrict_lot_id = fields.Many2one(
+        "stock.production.lot", string="Restrict Lot", copy=False
+    )
 
     def _prepare_procurement_values(self):
         vals = super()._prepare_procurement_values()
@@ -71,3 +76,9 @@ class StockMove(models.Model):
             owner_id=owner_id,
             strict=strict,
         )
+
+    def _split(self, qty, restrict_partner_id=False):
+        vals_list = super()._split(qty, restrict_partner_id=restrict_partner_id)
+        if vals_list and self.restrict_lot_id:
+            vals_list[0]["restrict_lot_id"] = self.restrict_lot_id.id
+        return vals_list

--- a/stock_restrict_lot/models/stock_rule.py
+++ b/stock_restrict_lot/models/stock_rule.py
@@ -1,0 +1,12 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _get_custom_move_fields(self):
+        fields = super()._get_custom_move_fields()
+        fields += ["restrict_lot_id"]
+        return fields

--- a/stock_restrict_lot/readme/CONTRIBUTORS.rst
+++ b/stock_restrict_lot/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Florian da Costa <florian.dacosta@akretion.com>

--- a/stock_restrict_lot/readme/DESCRIPTION.rst
+++ b/stock_restrict_lot/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module add a field to restrict a stock move to a specific lot.
+It propagates it between chained moves. A move with a restrict lot will only be able to
+reserve or transfer products with the specified lot.
+This module is a based for other modules, it has not effect on its own.

--- a/stock_restrict_lot/tests/__init__.py
+++ b/stock_restrict_lot/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_restrict_lot

--- a/stock_restrict_lot/tests/test_restrict_lot.py
+++ b/stock_restrict_lot/tests/test_restrict_lot.py
@@ -1,0 +1,96 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestRestrictLot(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.customer_loc = cls.env.ref("stock.stock_location_customers")
+        cls.output_loc = cls.env.ref("stock.stock_location_output")
+        cls.product = cls.env.ref("product.product_product_16")
+        cls.product.write({"tracking": "lot"})
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.write({"delivery_steps": "pick_ship"})
+        cls.lot = cls.env["stock.production.lot"].create(
+            {
+                "name": "lot1",
+                "product_id": cls.product.id,
+                "company_id": cls.warehouse.company_id.id,
+            }
+        )
+
+    def test_move_restrict_lot_propagation(self):
+        move = self.env["stock.move"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.output_loc.id,
+                "location_dest_id": self.customer_loc.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "name": "test",
+                "procure_method": "make_to_order",
+                "warehouse_id": self.warehouse.id,
+                "route_ids": [(6, 0, self.warehouse.delivery_route_id.ids)],
+                "restrict_lot_id": self.lot.id,
+            }
+        )
+        move._action_confirm()
+        orig_move = move.move_orig_ids
+        self.assertEqual(orig_move.restrict_lot_id.id, self.lot.id)
+
+    def _update_product_stock(self, qty, lot_id=False):
+        inventory = self.env["stock.inventory"].create(
+            {
+                "name": "Test Inventory",
+                "product_ids": [(6, 0, self.product.ids)],
+                "state": "confirm",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_qty": qty,
+                            "location_id": self.warehouse.lot_stock_id.id,
+                            "product_id": self.product.id,
+                            "product_uom_id": self.product.uom_id.id,
+                            "prod_lot_id": lot_id,
+                        },
+                    )
+                ],
+            }
+        )
+        inventory.action_validate()
+
+    def test_move_restrict_lot_reservation_and_transfer(self):
+        lot2 = self.env["stock.production.lot"].create(
+            {
+                "name": "lot2",
+                "product_id": self.product.id,
+                "company_id": self.warehouse.company_id.id,
+            }
+        )
+        self._update_product_stock(1, lot2.id)
+
+        move = self.env["stock.move"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.warehouse.lot_stock_id.id,
+                "location_dest_id": self.customer_loc.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "name": "test",
+                "warehouse_id": self.warehouse.id,
+                "restrict_lot_id": self.lot.id,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        # move should not reserve wrong free lot
+        self.assertEqual(move.state, "confirmed")
+
+        self._update_product_stock(1, self.lot.id)
+        move._action_assign()
+        self.assertEqual(move.state, "assigned")
+        self.assertEqual(move.move_line_ids.lot_id.id, self.lot.id)

--- a/stock_restrict_lot/tests/test_restrict_lot.py
+++ b/stock_restrict_lot/tests/test_restrict_lot.py
@@ -40,6 +40,28 @@ class TestRestrictLot(SavepointCase):
         orig_move = move.move_orig_ids
         self.assertEqual(orig_move.restrict_lot_id.id, self.lot.id)
 
+    def test_move_split_and_copy(self):
+        move = self.env["stock.move"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.output_loc.id,
+                "location_dest_id": self.customer_loc.id,
+                "product_uom_qty": 2,
+                "product_uom": self.product.uom_id.id,
+                "name": "test",
+                "procure_method": "make_to_stock",
+                "warehouse_id": self.warehouse.id,
+                "route_ids": [(6, 0, self.warehouse.delivery_route_id.ids)],
+                "restrict_lot_id": self.lot.id,
+            }
+        )
+        move._action_confirm()
+        vals_list = move._split(1)
+        new_move = self.env["stock.move"].create(vals_list)
+        self.assertEqual(new_move.restrict_lot_id.id, move.restrict_lot_id.id)
+        other_move = move.copy()
+        self.assertFalse(other_move.restrict_lot_id.id)
+
     def _update_product_stock(self, qty, lot_id=False):
         inventory = self.env["stock.inventory"].create(
             {
@@ -63,7 +85,7 @@ class TestRestrictLot(SavepointCase):
         )
         inventory.action_validate()
 
-    def test_move_restrict_lot_reservation_and_transfer(self):
+    def test_move_restrict_lot_reservation(self):
         lot2 = self.env["stock.production.lot"].create(
             {
                 "name": "lot2",


### PR DESCRIPTION
The purpose of this module is to be able to restrict the lot reservation of a stock move.
The restrict lot id did exist in previous Odoo version (v10 and less).
This module allows to build other module on top with different logic where we would like to restrict a stock move to a specific lot.
One example is in module sale_order_lot_selection, which was buggy but should be more reliable depending on this module.

@sebastienbeau @bguillot 