### PR TITLE
[13.0][IMP] stock_picking_invoice_link: Better link invoices to stock_moves process

### DIFF
--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -2,31 +2,41 @@
 # Copyright 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from odoo import models
-from odoo.tools import float_compare
+from odoo.tools import float_compare, float_is_zero
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     def get_stock_moves_link_invoice(self):
-        return self.mapped("move_ids").filtered(
-            lambda mv: (
-                mv.state == "done"
-                and not (
-                    any(
-                        inv.state != "cancel"
-                        for inv in mv.invoice_line_ids.mapped("move_id").filtered(
-                            lambda x: x.type in ("out_invoice", "out_refund")
-                        )
+        moves_linked = self.env["stock.move"]
+        for stock_move in self.move_ids:
+            if (
+                stock_move.state != "done"
+                or stock_move.scrapped
+                or (
+                    stock_move.location_dest_id.usage != "customer"
+                    and (
+                        stock_move.location_id.usage != "customer"
+                        or not stock_move.to_refund
                     )
                 )
-                and not mv.scrapped
-                and (
-                    mv.location_dest_id.usage == "customer"
-                    or (mv.location_id.usage == "customer" and mv.to_refund)
-                )
+            ):
+                continue
+            invoice_lines = stock_move.invoice_line_ids.filtered(
+                lambda invl: invl.move_id.state != "cancel"
             )
-        )
+            invoiced_qty = 0
+            for inv_line in invoice_lines:
+                if inv_line.move_id.type == "out_refund":
+                    invoiced_qty -= inv_line.quantity
+                else:
+                    invoiced_qty += inv_line.quantity
+            if float_is_zero(
+                invoiced_qty, precision_rounding=self.product_uom.rounding
+            ):
+                moves_linked += stock_move
+        return moves_linked
 
     def _prepare_invoice_line(self):
         vals = super()._prepare_invoice_line()
@@ -38,8 +48,6 @@ class SaleOrderLine(models.Model):
             )
             < 0
         ):
-            stock_moves = stock_moves.filtered(
-                lambda m: m.to_refund and not m.invoice_line_ids
-            )
+            stock_moves = stock_moves.filtered(lambda m: m.to_refund)
         vals["move_line_ids"] = [(4, m.id) for m in stock_moves]
         return vals

--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -48,6 +48,6 @@ class SaleOrderLine(models.Model):
             )
             < 0
         ):
-            stock_moves = stock_moves.filtered(lambda m: m.to_refund)
+            stock_moves = stock_moves.filtered("to_refund")
         vals["move_line_ids"] = [(4, m.id) for m in stock_moves]
         return vals

--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -260,3 +260,29 @@ class TestStockPickingInvoiceLink(TestSale):
         res = new_invoice.action_show_picking()
         opened_picking = self.env["stock.picking"].browse(res["res_id"])
         self.assertEqual(pick_1, opened_picking)
+
+    def test_invoice_refund_invoice(self):
+        """Check that the invoice created after a refund is linked to the stock
+        picking.
+        """
+        pick_1 = self.so.picking_ids.filtered(
+            lambda x: x.picking_type_code == "outgoing"
+            and x.state in ("confirmed", "assigned", "partially_available")
+        )
+        pick_1.move_line_ids.write({"qty_done": 2})
+        pick_1.action_done()
+        # Create invoice
+        inv = self.so._create_invoices()
+        inv.action_post()
+        # Refund invoice
+        wiz_invoice_refund = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=inv.ids)
+            .create({"refund_method": "cancel", "reason": "test"})
+        )
+        wiz_invoice_refund.reverse_moves()
+        # Create invoice again
+        new_inv = self.so._create_invoices()
+        new_inv.action_post()
+        # Assert that new invoice has related picking
+        self.assertEqual(new_inv.picking_ids, pick_1)


### PR DESCRIPTION
Steps to reproduce the issue before this PR:
 - Invoice sale order
 - Create Credit note whith third option
 - Remove new draft invoice
 - Invoice sale order
 - Print invoice

@Tecnativa TT27156