### PR TITLE
[13.0][FIX] sale_stock_mto_as_mts_orderpoint

### DIFF
--- a/sale_stock_mto_as_mts_orderpoint/models/sale_order.py
+++ b/sale_stock_mto_as_mts_orderpoint/models/sale_order.py
@@ -67,13 +67,19 @@ class SaleOrderLine(models.Model):
                 {"active": True, "product_min_qty": 0.0, "product_max_qty": 0.0}
             )
         elif not orderpoint:
-            orderpoint = self.env["stock.warehouse.orderpoint"].create(
-                {
-                    "product_id": self.product_id.id,
-                    "warehouse_id": warehouse.id,
-                    "location_id": warehouse._get_locations_for_mto_orderpoints().id,
-                    "product_min_qty": 0.0,
-                    "product_max_qty": 0.0,
-                }
+            orderpoint = (
+                self.env["stock.warehouse.orderpoint"]
+                .sudo()
+                .create(
+                    {
+                        "product_id": self.product_id.id,
+                        "warehouse_id": warehouse.id,
+                        "location_id": (
+                            warehouse._get_locations_for_mto_orderpoints().id
+                        ),
+                        "product_min_qty": 0.0,
+                        "product_max_qty": 0.0,
+                    }
+                )
             )
         return orderpoint

--- a/sale_stock_mto_as_mts_orderpoint/tests/test_sale_stock_mto_as_mts_orderpoint.py
+++ b/sale_stock_mto_as_mts_orderpoint/tests/test_sale_stock_mto_as_mts_orderpoint.py
@@ -73,3 +73,16 @@ class TestSaleStockMtoAsMtsOrderpoint(SavepointCase):
         order.action_draft()
         order.action_confirm()
         self.assertEqual(order.state, "sale")
+
+    def test_confirm_mto_as_mts_sudo_needed(self):
+        """Check access right needed to confirm sale.
+
+        A sale manager user with no right on inventory will raise an access
+        right error on confirmation.
+        This is the why of the sudo in `sale_stock_mto_as_mts_orderpoint`
+        """
+        user = self.env.ref("base.user_demo")
+        sale_group = self.env.ref("sales_team.group_sale_manager")
+        sale_group.users = [(4, user.id)]
+        order = self._create_sale_order()
+        order.with_user(user).action_confirm()


### PR DESCRIPTION
For user without proper rights the confirmation of a sale.order can lead
to an access error on the orderpoint creation.
The sudo fixes that.