### PR TITLE
[13.0][FIX] stock_picking_group_by_partner_by_carrier: regression when creating backorders

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -59,9 +59,11 @@ class StockPicking(models.Model):
             return super().action_cancel()
 
     def _create_backorder(self):
-        self = self.with_context(picking_no_copy_if_can_group=1)
+        if self.picking_type_id.group_pickings:
+            self = self.with_context(picking_no_copy_if_can_group=1)
         backorders = super()._create_backorder()
-        backorders._merge_procurement_groups()
+        if self.picking_type_id.group_pickings:
+            backorders._merge_procurement_groups()
         return backorders
 
     def _prepare_merge_procurement_group_values(self, move_groups):


### PR DESCRIPTION
If the group pickings option is disabled, the creation of a backorder when validating a partial qty of a picking should work as usual.