### PR TITLE
[12.0] stock_picking_filter_lot: make product_qty storable to filter lot_id selection only for quantity greater than 0

### DIFF
--- a/stock_picking_filter_lot/models/stock_production_lot.py
+++ b/stock_picking_filter_lot/models/stock_production_lot.py
@@ -10,6 +10,7 @@ class StockProductionLot(models.Model):
     location_ids = fields.Many2many(
         comodel_name='stock.location', compute='_compute_location_ids',
         store=True)
+    product_qty = fields.Float(store=True)
 
     @api.depends('quant_ids', 'quant_ids.location_id')
     def _compute_location_ids(self):

--- a/stock_picking_filter_lot/views/stock_move_line_view.xml
+++ b/stock_picking_filter_lot/views/stock_move_line_view.xml
@@ -10,7 +10,7 @@
         <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree"/>
         <field name="arch" type="xml">
             <field name="lot_id" position="attributes">
-                <attribute name="domain">[('product_id','=', parent.product_id),('location_ids', 'child_of', location_id)]</attribute>
+                <attribute name="domain">[('product_id','=', parent.product_id),('location_ids', 'child_of', location_id),('product_qty', '>', 0)]</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
See [https://github.com/OCA/stock-logistics-workflow/issues/765](https://github.com/OCA/stock-logistics-workflow/issues/765)