### PR TITLE
[13.0][ADD] stock_quant_package_dimension_total_weight_from_packaging

### DIFF
--- a/setup/stock_quant_package_dimension_total_weight_from_packaging/odoo/addons/stock_quant_package_dimension_total_weight_from_packaging
+++ b/setup/stock_quant_package_dimension_total_weight_from_packaging/odoo/addons/stock_quant_package_dimension_total_weight_from_packaging
@@ -1,0 +1,1 @@
+../../../../stock_quant_package_dimension_total_weight_from_packaging

--- a/setup/stock_quant_package_dimension_total_weight_from_packaging/setup.py
+++ b/setup/stock_quant_package_dimension_total_weight_from_packaging/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_putaway_by_route/tests/test_route_putaway.py
+++ b/stock_putaway_by_route/tests/test_route_putaway.py
@@ -103,7 +103,6 @@ class TestRoutePutaway(SavepointCase):
         # the onchange is applied on move line only for NewID records
         # otherwise we are not even allowed to change the product
         view_move_line = Form(self.env["stock.move.line"])
-        view_move_line.product_uom_qty = 2.0
         view_move_line.picking_id = picking
         view_move_line.location_id = self.input_location
         view_move_line.location_dest_id = picking.location_dest_id

--- a/stock_quant_package_dimension/tests/common.py
+++ b/stock_quant_package_dimension/tests/common.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests import SavepointCase
+
+
+class TestStockQuantPackageCommon(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.wh = cls.env.ref("stock.warehouse0")
+        cls.wh.out_type_id.default_location_dest_id = cls.env.ref(
+            "stock.stock_location_customers"
+        )
+        cls.product = cls.env.ref("product.product_delivery_02")
+        cls.product.write(
+            {
+                "weight": 1,
+                "packaging_ids": [
+                    (0, 0, {"name": "Small Box", "qty": "1", "max_weight": "2"}),
+                    (0, 0, {"name": "Box", "qty": "5", "max_weight": "7"}),
+                ],
+            }
+        )
+        cls.package = cls.env["stock.quant.package"].create({})
+        cls.move = cls.env["stock.move"].create(
+            {
+                "name": cls.product.name,
+                "picking_type_id": cls.wh.out_type_id.id,
+                "product_id": cls.product.id,
+                "product_uom_qty": 11.0,
+                "product_uom": cls.product.uom_id.id,
+                "location_id": cls.wh.out_type_id.default_location_src_id.id,
+                "location_dest_id": cls.wh.out_type_id.default_location_dest_id.id,
+                "procure_method": "make_to_stock",
+                "group_id": cls.env["procurement.group"].create({"name": "Test"}).id,
+            }
+        )
+        cls.move._assign_picking()
+        cls.move.picking_id.action_confirm()

--- a/stock_quant_package_dimension/tests/test_package_dimension.py
+++ b/stock_quant_package_dimension/tests/test_package_dimension.py
@@ -1,15 +1,16 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo.tests import Form, SavepointCase
+from odoo.tests import Form
+
+from . import common
 
 
-class TestStockQuantPackageProductPackaging(SavepointCase):
+class TestStockQuantPackageProductPackaging(common.TestStockQuantPackageCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.product = cls.env.ref("product.product_delivery_02")
-        cls.packaging = cls.env["product.packaging"].create(
+        cls.product.packaging_ids = cls.packaging = cls.env["product.packaging"].create(
             {
                 "name": "10 pack",
                 "product_id": cls.product.id,
@@ -20,7 +21,6 @@ class TestStockQuantPackageProductPackaging(SavepointCase):
                 "max_weight": 15,
             }
         )
-        cls.package = cls.env["stock.quant.package"].create({})
 
     def test_set_dimensions_on_write(self):
         self.package.with_context(
@@ -47,4 +47,23 @@ class TestStockQuantPackageProductPackaging(SavepointCase):
         # onchange overrides values
         self.assertRecordValues(
             self.package, [{"lngth": 12, "width": 13, "height": 14, "pack_weight": 15}]
+        )
+
+    def test_package_estimated_pack_weight(self):
+        self.env["stock.quant"]._update_available_quantity(
+            self.product,
+            self.wh.out_type_id.default_location_src_id,
+            7.0,
+            package_id=self.package,
+        )
+        # Weight are taken from product, like the delivery module
+        self.assertEqual(self.package.estimated_pack_weight, 7)
+        self.move._action_assign()
+        for line in self.move.move_line_ids:
+            line.qty_done = line.product_uom_qty
+        self.assertEqual(
+            self.package.with_context(
+                picking_id=self.move.picking_id.id
+            ).estimated_pack_weight,
+            7,
         )

--- a/stock_quant_package_dimension/views/stock_quant_package.xml
+++ b/stock_quant_package_dimension/views/stock_quant_package.xml
@@ -11,6 +11,7 @@
                     <field name="width" />
                     <field name="height" />
                     <field name="pack_weight" />
+                    <field name="estimated_pack_weight" />
                     <field name="volume" />
                 </group>
             </xpath>

--- a/stock_quant_package_dimension_total_weight_from_packaging/__init__.py
+++ b/stock_quant_package_dimension_total_weight_from_packaging/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_quant_package_dimension_total_weight_from_packaging/__manifest__.py
+++ b/stock_quant_package_dimension_total_weight_from_packaging/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Quant Package Dimension Total Weight From Packaging",
+    "summary": "Estimated weight of a package",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "stock_quant_package_dimension",
+        # OCA/product-attribute
+        "product_total_weight_from_packaging",
+    ],
+}

--- a/stock_quant_package_dimension_total_weight_from_packaging/models/__init__.py
+++ b/stock_quant_package_dimension_total_weight_from_packaging/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_quant_package

--- a/stock_quant_package_dimension_total_weight_from_packaging/models/stock_quant_package.py
+++ b/stock_quant_package_dimension_total_weight_from_packaging/models/stock_quant_package.py
@@ -1,0 +1,31 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockQuantPackage(models.Model):
+    _inherit = "stock.quant.package"
+
+    estimated_pack_weight = fields.Float(
+        # Overloaded field
+        help="Based on the weight of the product packagings."
+    )
+
+    def _get_weight_from_move_lines(self, move_lines):
+        # Overridden from 'stock_quant_package_dimension' module to use the
+        # 'get_total_weight_from_packaging' method supplied by the
+        # 'product_total_weight_from_packaging' module
+        return sum(
+            ml.product_id.get_total_weight_from_packaging(ml.qty_done)
+            for ml in move_lines
+        )
+
+    def _get_weight_from_quants(self, quants):
+        # Overridden from 'stock_quant_package_dimension' module to use the
+        # 'get_total_weight_from_packaging' method supplied by the
+        # 'product_total_weight_from_packaging' module
+        return sum(
+            quant.product_id.get_total_weight_from_packaging(quant.quantity)
+            for quant in quants
+        )

--- a/stock_quant_package_dimension_total_weight_from_packaging/tests/__init__.py
+++ b/stock_quant_package_dimension_total_weight_from_packaging/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_package_weight

--- a/stock_quant_package_dimension_total_weight_from_packaging/tests/test_package_weight.py
+++ b/stock_quant_package_dimension_total_weight_from_packaging/tests/test_package_weight.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo.addons.stock_quant_package_dimension.tests import common
+
+
+class TestStockQuantPackageWeight(common.TestStockQuantPackageCommon):
+    def test_package_estimated_pack_weight(self):
+        self.env["stock.quant"]._update_available_quantity(
+            self.product,
+            self.wh.out_type_id.default_location_src_id,
+            7.0,
+            package_id=self.package,
+        )
+        # 1 Box + 2 Small Box to satisfy 7 qties => 11kg
+        self.assertEqual(self.package.estimated_pack_weight, 11)
+        self.move._action_assign()
+        for line in self.move.move_line_ids:
+            line.qty_done = line.product_uom_qty
+        self.assertEqual(
+            self.package.with_context(
+                picking_id=self.move.picking_id.id
+            ).estimated_pack_weight,
+            11,
+        )


### PR DESCRIPTION
First, we add a new `estimated_pack_weight` on the package in `stock_quant_package_dimension` module which is similar to the `weight` field implemented in the standard `delivery` module: it is done on purpose to not depend on `delivery`. This weight is thus computed from product weight.

Second, we re-implement this field in `stock_quant_package_dimension_total_weight_from_packaging` module (`auto_install=True`) which make use of the weight computation mechanism from `product_total_weight_from_packaging`. The weight here is computed from the packaging weight.

Ref. 1900