### PR TITLE
[13.0][FIX] stock_picking_group_by_partner_by_carrier

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/sale_order.py
+++ b/stock_picking_group_by_partner_by_carrier/models/sale_order.py
@@ -13,6 +13,11 @@ class SaleOrder(models.Model):
                 SaleOrder, sale_order.with_context(cancel_sale_id=sale_order.id)
             ).action_cancel()
 
+    def action_draft(self):
+        res = super().action_draft()
+        self.procurement_group_id = False
+        return res
+
     def get_name_for_delivery_line(self):
         """Get the name for the sale order displayed on the delivery note"""
         self.ensure_one()


### PR DESCRIPTION
When a sale order is cancelled then set to quotation again, all
related picking are cancelled also.

If before reconfirming the sale order for a 2nd time the delivery
carrier is changed, the procurement group linked on the sale order
will be used and related to the wrong carrier.

Removing the procurement group on the cancelation of the sale order
fixes the issue.