### PR TITLE
[13.0][IMP] s_picking_group_by_partner_by_carrier: Fix MockedMove

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -2,7 +2,6 @@
 # Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from collections import namedtuple
 from itertools import groupby
 
 from odoo import api, fields, models
@@ -116,52 +115,53 @@ class StockPicking(models.Model):
         ).copy(defaults)
 
     def get_delivery_report_lines(self):
+        """Return the lines that will be on the report.
+
+        If the picking concerns multiple sale order some fake records are
+        inserted to have the sale information as line separators.
+        Otherwise standard records are returned.
+        """
         self.ensure_one()
+        moves = self.move_lines
         if self.state != "done":
-            moves = self.move_lines.filtered("product_uom_qty").sorted(
-                lambda m: m.sale_line_id.order_id
-            )
-            if len(moves.mapped("sale_line_id.order_id")) > 1:
-                sales_and_moves = []
-                for sale, sale_moves in groupby(
-                    moves, lambda m: m.sale_line_id.order_id
-                ):
-                    sales_and_moves.append(
-                        MockedMove(
-                            product_id=False,
-                            description_picking=sale.get_name_for_delivery_line(),
-                            product_uom_qty=0,
-                            product_uom=False,
-                            lot_name="",
-                        )
-                    )
+            moves = moves.filtered("product_uom_qty")
+        moves = moves.sorted(lambda m: m.sale_line_id.order_id)
+
+        if len(moves.mapped("sale_line_id.order_id")) > 1:
+            grouped_moves = groupby(moves, lambda m: m.sale_line_id.order_id)
+            fake_record = {
+                "product_id": 1,
+                "product_uom_qty": 0,
+                "product_uom": self.env.ref("uom.product_uom_unit").id,
+                "company_id": self.env.user.company_id.id,
+                "location_id": self.env.ref("stock.stock_location_output").id,
+                "location_dest_id": self.env.ref("stock.stock_location_output").id,
+            }
+            if self.state != "done":
+                sales_and_moves = self.env["stock.move"]
+                fake_record["name"] = "fake move"
+                for sale, sale_moves in grouped_moves:
+                    line_desc = sale.get_name_for_delivery_line()
+                    fake_record["description_picking"] = line_desc
+                    sales_and_moves |= sales_and_moves.new(fake_record.copy())
                     for move in sale_moves:
-                        sales_and_moves.append(move)
+                        sales_and_moves |= move
                 return sales_and_moves
             else:
-                return moves
-        else:
-            moves = self.move_lines.sorted(lambda m: m.sale_line_id.order_id)
-            if len(moves.mapped("sale_line_id.order_id")) > 1:
-                sales_and_moves = []
-                for sale, sale_moves in groupby(
-                    moves, lambda m: m.sale_line_id.order_id
-                ):
-                    sales_and_moves.append(
-                        MockedMove(
-                            product_id=False,
-                            description_picking=sale.get_name_for_delivery_line(),
-                            product_uom_qty=0,
-                            product_uom=False,
-                            lot_name="",
-                        )
-                    )
+                sales_and_moves = self.env["stock.move.line"]
+                fake_record["product_uom_id"] = fake_record.pop("product_uom")
+                for sale, sale_moves in grouped_moves:
+                    line_desc = sale.get_name_for_delivery_line()
+                    fake_record["description_picking"] = line_desc
+                    sales_and_moves |= sales_and_moves.new(fake_record.copy())
                     for move in sale_moves:
                         for move_line in move.move_line_ids:
-                            sales_and_moves.append(move_line)
+                            sales_and_moves |= move_line
                 return sales_and_moves
-            else:
-                return self.move_line_ids
+        elif self.state != "done":
+            return moves
+        else:
+            return self.move_line_ids
 
     def get_customer_refs(self):
         """Returns all unique sales order customer references."""
@@ -171,9 +171,3 @@ class StockPicking(models.Model):
             move_lines = self.move_lines
         references = move_lines.mapped("sale_line_id.order_id.client_order_ref")
         return set(filter(None, references))
-
-
-MockedMove = namedtuple(
-    "MockedMove",
-    ["product_id", "description_picking", "product_uom_qty", "product_uom", "lot_name"],
-)

--- a/stock_picking_group_by_partner_by_carrier/readme/CONTRIBUTORS.rst
+++ b/stock_picking_group_by_partner_by_carrier/readme/CONTRIBUTORS.rst
@@ -1,4 +1,5 @@
 * Camptocamp:
   * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+  * Thierry Ducrest <thierry.ducrest@camptocamp.com>
 * BCIM:
   * Jacques-Etienne Baudoux <je@bcim.be>

--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -12,7 +12,7 @@
             expr='//table[@name="stock_move_table"]/tbody/tr/td[span[@t-field="move.product_id"]]'
             position="replace"
         >
-            <t t-if="move.product_id">
+            <t t-if="move.id">
                 <td>
                     <span t-field="move.product_id" />
                     <p t-if="move.description_picking != move.product_id.name">
@@ -30,13 +30,13 @@
             expr='//table[@name="stock_move_table"]/tbody/tr/td/span[@t-field="move.product_uom_qty"]'
             position="attributes"
         >
-            <attribute name="t-if">move.product_id</attribute>
+            <attribute name="t-if">move.id</attribute>
         </xpath>
         <xpath
             expr='//table[@name="stock_move_table"]/tbody/tr/td/span[@t-field="move.product_uom"]'
             position="attributes"
         >
-            <attribute name="t-if">move.product_id</attribute>
+            <attribute name="t-if">move.id</attribute>
         </xpath>
         <!-- overrides when the picking is done -->
         <xpath
@@ -49,7 +49,7 @@
             expr='//table[@name="stock_move_line_table"]/tbody/tr/td[span[@t-field="move_line.product_id"]]'
             position="replace"
         >
-            <t t-if="move_line.product_id">
+            <t t-if="move_line.id">
                 <td>
                     <span t-field="move_line.product_id" />
                     <p
@@ -69,25 +69,25 @@
             expr='//table[@name="stock_move_line_table"]/tbody/tr/td/span[@t-field="move_line.lot_name"]'
             position="attributes"
         >
-            <attribute name="t-if">move_line.product_id</attribute>
+            <attribute name="t-if">move_line.id</attribute>
         </xpath>
         <xpath
             expr='//table[@name="stock_move_line_table"]/tbody/tr/td/span[@t-field="move_line.lot_id.name"]'
             position="attributes"
         >
-            <attribute name="t-if">move_line.product_id</attribute>
+            <attribute name="t-if">move_line.id</attribute>
         </xpath>
         <xpath
             expr='//table[@name="stock_move_line_table"]/tbody/tr/td/span[@t-field="move_line.qty_done"]'
             position="attributes"
         >
-            <attribute name="t-if">move_line.product_id</attribute>
+            <attribute name="t-if">move_line.id</attribute>
         </xpath>
         <xpath
             expr='//table[@name="stock_move_line_table"]/tbody/tr/td/span[@t-field="move_line.product_uom_id"]'
             position="attributes"
         >
-            <attribute name="t-if">move_line.product_id</attribute>
+            <attribute name="t-if">move_line.id</attribute>
         </xpath>
         <!-- Remove "All items could not be shipped..." sentence -->
         <xpath expr='//div[hasclass("page")]/p[last()]' position="attributes">

--- a/stock_picking_group_by_partner_by_carrier/tests/__init__.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_grouping
+from . import test_report

--- a/stock_picking_group_by_partner_by_carrier/tests/test_report.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_report.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from .common import TestGroupByBase
+
+
+class TestReport(TestGroupByBase):
+    def test_delivery_report_lines_two_sales_merged(self):
+        """Check report lines for two sale orders merged in same picking."""
+        so1 = self._get_new_sale_order()
+        so2 = self._get_new_sale_order(amount=11)
+        so1.action_confirm()
+        so2.action_confirm()
+        picking = so1.picking_ids
+        res = picking.get_delivery_report_lines()
+        self.assertEqual(len(res), 4)
+        self.assertEqual(res._name, "stock.move")
+        # Check that we have two display moves (sale name)
+        # And two real moves.
+        self.assertFalse(res[0].id)
+        self.assertTrue(res[1].id)
+        self.assertFalse(res[2].id)
+        self.assertTrue(res[3].id)
+        # Deliver and test again
+        self._update_qty_in_location(
+            picking.location_id,
+            so1.order_line[0].product_id,
+            so1.order_line[0].product_uom_qty,
+        )
+        self._update_qty_in_location(
+            picking.location_id,
+            so2.order_line[0].product_id,
+            so2.order_line[0].product_uom_qty,
+        )
+        picking.action_assign()
+        line = picking.move_lines[0].move_line_ids
+        line.qty_done = line.product_uom_qty
+        line = picking.move_lines[1].move_line_ids
+        line.qty_done = line.product_uom_qty
+        res = picking.action_done()
+        self.assertEqual(picking.state, "done")
+        res = picking.get_delivery_report_lines()
+        self.assertEqual(len(res), 4)
+        self.assertEqual(res._name, "stock.move.line")
+        # Check that we have two display moves (sale name)
+        # And two real moves.
+        self.assertFalse(res[0].id)
+        self.assertTrue(res[1].id)
+        self.assertFalse(res[2].id)
+        self.assertTrue(res[3].id)


### PR DESCRIPTION
Using an alternative data structure to store the separation of the
sale order on the delivery note as been sensible to breakage from
changes upstream.

Using the same type of records than the rest of the information
will hopefully help.

ref: 1998