### PR TITLE
[13.0][IMP] stock_picking_group_by_partner_by_carrier

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/__init__.py
+++ b/stock_picking_group_by_partner_by_carrier/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizard
+from . import report

--- a/stock_picking_group_by_partner_by_carrier/__manifest__.py
+++ b/stock_picking_group_by_partner_by_carrier/__manifest__.py
@@ -14,6 +14,7 @@
         "views/procurement_group.xml",
         "views/stock_picking_type.xml",
         "views/stock_warehouse.xml",
+        "report/assets.xml",
         "report/report_delivery_slip.xml",
         "wizard/stock_picking_merge_wiz.xml",
         "wizard/stock_picking_merge_wiz_info_template.xml",

--- a/stock_picking_group_by_partner_by_carrier/i18n/de.po
+++ b/stock_picking_group_by_partner_by_carrier/i18n/de.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-01 15:06+0000\n"
-"PO-Revision-Date: 2021-03-01 15:06+0000\n"
+"POT-Creation-Date: 2021-03-01 15:09+0000\n"
+"PO-Revision-Date: 2021-03-01 15:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,23 +17,8 @@ msgstr ""
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
-msgid "&lt;/strong&gt;"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
-msgid "&lt;strong&gt;"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
-msgid "<span attrs=\"{'invisible': [('nothing_todo', '=', True)]}\">or</span>"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
 msgid "All ordered items have been delivered."
-msgstr ""
+msgstr "Alle Produkte wurden vollständig ausgeliefert"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
@@ -182,7 +167,7 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking_type
 msgid "Picking Type"
-msgstr ""
+msgstr "Vorgangstyp"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
@@ -194,17 +179,17 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking__printed
 msgid "Printed"
-msgstr ""
+msgstr "Gedruckt"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_procurement_group
 msgid "Procurement Group"
-msgstr ""
+msgstr "Beschaffungsgruppe"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
 msgid "Remaining to deliver:"
-msgstr ""
+msgstr "Ausstehende Positionen:"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_procurement_group__sale_ids
@@ -215,12 +200,12 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_sale_order
 msgid "Sales Order"
-msgstr ""
+msgstr "Verkaufsauftrag "
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_sale_order_line
 msgid "Sales Order Line"
-msgstr ""
+msgstr "Kundenauftragszeile"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_merge__selected_picking_ids
@@ -245,7 +230,7 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_move
 msgid "Stock Move"
-msgstr ""
+msgstr "Lagerbuchung"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking_merge
@@ -255,7 +240,7 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_rule
 msgid "Stock Rule"
-msgstr ""
+msgstr "Lagerregel"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,help:stock_picking_group_by_partner_by_carrier.field_stock_picking__canceled_by_merge
@@ -267,12 +252,12 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking
 msgid "Transfer"
-msgstr ""
+msgstr "Lieferung vornehmen"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_sale_order__picking_ids
 msgid "Transfers"
-msgstr ""
+msgstr "Bewegungen"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_merge__valid_picking_ids
@@ -287,7 +272,7 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_warehouse
 msgid "Warehouse"
-msgstr ""
+msgstr "Lager"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.stock_picking_merge_wiz_info

--- a/stock_picking_group_by_partner_by_carrier/i18n/fr.po
+++ b/stock_picking_group_by_partner_by_carrier/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-01 15:06+0000\n"
-"PO-Revision-Date: 2021-03-01 15:06+0000\n"
+"POT-Creation-Date: 2021-03-01 15:08+0000\n"
+"PO-Revision-Date: 2021-03-01 15:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,23 +17,8 @@ msgstr ""
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
-msgid "&lt;/strong&gt;"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
-msgid "&lt;strong&gt;"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
-msgid "<span attrs=\"{'invisible': [('nothing_todo', '=', True)]}\">or</span>"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
 msgid "All ordered items have been delivered."
-msgstr ""
+msgstr "Tous les articles ont été livrés"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
@@ -182,7 +167,7 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking_type
 msgid "Picking Type"
-msgstr ""
+msgstr "Type de préparation"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
@@ -194,17 +179,17 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking__printed
 msgid "Printed"
-msgstr ""
+msgstr "Imprimé"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_procurement_group
 msgid "Procurement Group"
-msgstr ""
+msgstr "Groupe d'approvisionnement"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
 msgid "Remaining to deliver:"
-msgstr ""
+msgstr "Restant à livrer:"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_procurement_group__sale_ids
@@ -215,12 +200,12 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_sale_order
 msgid "Sales Order"
-msgstr ""
+msgstr "Bon de commande"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_sale_order_line
 msgid "Sales Order Line"
-msgstr ""
+msgstr "Ligne de bons de commande"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_merge__selected_picking_ids
@@ -245,7 +230,7 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_move
 msgid "Stock Move"
-msgstr ""
+msgstr "Stock déplacer"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking_merge
@@ -255,7 +240,7 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_rule
 msgid "Stock Rule"
-msgstr ""
+msgstr "Règle de stock minimum"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,help:stock_picking_group_by_partner_by_carrier.field_stock_picking__canceled_by_merge
@@ -267,12 +252,12 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking
 msgid "Transfer"
-msgstr ""
+msgstr "Transfert"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_sale_order__picking_ids
 msgid "Transfers"
-msgstr ""
+msgstr "Transferts"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_merge__valid_picking_ids
@@ -287,7 +272,7 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_warehouse
 msgid "Warehouse"
-msgstr ""
+msgstr "Entrepôt"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.stock_picking_merge_wiz_info

--- a/stock_picking_group_by_partner_by_carrier/i18n/it.po
+++ b/stock_picking_group_by_partner_by_carrier/i18n/it.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-01 15:06+0000\n"
-"PO-Revision-Date: 2021-03-01 15:06+0000\n"
+"POT-Creation-Date: 2021-03-01 15:08+0000\n"
+"PO-Revision-Date: 2021-03-01 15:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,38 +17,23 @@ msgstr ""
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
-msgid "&lt;/strong&gt;"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
-msgid "&lt;strong&gt;"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
-msgid "<span attrs=\"{'invisible': [('nothing_todo', '=', True)]}\">or</span>"
-msgstr ""
-
-#. module: stock_picking_group_by_partner_by_carrier
-#: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
 msgid "All ordered items have been delivered."
-msgstr ""
+msgstr "Tutti i prodotti sono stati forniti"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
 msgid "Cancel"
-msgstr ""
+msgstr "Annulla"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking__canceled_by_merge
 msgid "Canceled By Merge"
-msgstr ""
+msgstr "Annullato da unione"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
 msgid "Confirm"
-msgstr ""
+msgstr "Confema"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_merge__create_uid
@@ -89,36 +74,38 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.stock_picking_merge_wiz_info
 msgid "For customer:"
-msgstr ""
+msgstr "Per cliente:"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.stock_picking_merge_wiz_info
 msgid "Forecasted grouping"
-msgstr ""
+msgstr "Raggruppamento previsto"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_type__group_pickings
 msgid "Group pickings"
-msgstr ""
+msgstr "Raggruppa consegne"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,help:stock_picking_group_by_partner_by_carrier.field_stock_picking_type__group_pickings
 msgid ""
 "Group pickings for the same partner and carrier. Pickings with shipping "
 "policy set to 'When all products are ready' are never grouped."
-msgstr ""
+msgstr "Raggruppa consegne per stesso client e stesso corriere. "
+"Ordini con politica di consegna 'Quando tutti i prodotti sono pronti' non sono mai raggruppati."
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_warehouse__group_shippings
 msgid "Group shippings"
-msgstr ""
+msgstr "Raggruppa spedizioni"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,help:stock_picking_group_by_partner_by_carrier.field_stock_warehouse__group_shippings
 msgid ""
 "Group shippings for the same partner and carrier. Shippings with shipping "
 "policy set to 'When all products are ready' are never grouped."
-msgstr ""
+msgstr "Raggruppa spedizioni per stesso client e stesso corriere. "
+"Spedizioni con politica di consegna 'Quando tutti i prodotti sono pronti' non sono mai raggruppati."
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: code:addons/stock_picking_group_by_partner_by_carrier/wizard/stock_picking_merge_wiz.py:0
@@ -182,29 +169,29 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking_type
 msgid "Picking Type"
-msgstr ""
+msgstr "Tipologia ordine"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
 msgid ""
 "Pickings should match these parameters: picking type is groupable, state not"
 " cancelled or done, not printed."
-msgstr ""
+msgstr "Gli ordini devono soddisfare questi parametri: tipologia raggruppabile, stato non 'annullato' o 'completo', non stampato."
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking__printed
 msgid "Printed"
-msgstr ""
+msgstr "Stampato"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_procurement_group
 msgid "Procurement Group"
-msgstr ""
+msgstr "Gruppo di approvvigionamento"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.report_delivery_document
 msgid "Remaining to deliver:"
-msgstr ""
+msgstr "Posizioni in sospeso:"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_procurement_group__sale_ids
@@ -215,37 +202,37 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_sale_order
 msgid "Sales Order"
-msgstr ""
+msgstr "Ordine di vendita"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_sale_order_line
 msgid "Sales Order Line"
-msgstr ""
+msgstr "Riga ordine di vendita"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_merge__selected_picking_ids
 msgid "Selected Pickings"
-msgstr ""
+msgstr "Ordini selezionati"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_merge__show_discarded_detail
 msgid "Show Discarded Detail"
-msgstr ""
+msgstr "Mostra dettaglio scartati"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
 msgid "Some pickings you've selected are discarded"
-msgstr ""
+msgstr "Alcuni ordini selezionati sono stati scartati"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.stock_picking_merge_wiz_info
 msgid "Sorry, nothing to be done here."
-msgstr ""
+msgstr "Spiacente, nessun ordine da processare."
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_move
 msgid "Stock Move"
-msgstr ""
+msgstr "Movimento di magazzino"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking_merge
@@ -255,29 +242,29 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_rule
 msgid "Stock Rule"
-msgstr ""
+msgstr "Regola di magazzino"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,help:stock_picking_group_by_partner_by_carrier.field_stock_picking__canceled_by_merge
 msgid ""
 "Technical field. Indicates the transfer is canceled because it was left "
 "empty after a manual merge."
-msgstr ""
+msgstr "Campo tecnico. Indica che il trasferimento è stato annullato perchè rimasto vuoto dopo un raggruppamento"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_picking
 msgid "Transfer"
-msgstr ""
+msgstr "Trasferisci"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_sale_order__picking_ids
 msgid "Transfers"
-msgstr ""
+msgstr "Trasferimenti"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model.fields,field_description:stock_picking_group_by_partner_by_carrier.field_stock_picking_merge__valid_picking_ids
 msgid "Valid Pickings"
-msgstr ""
+msgstr "Trasferimenti validi"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.view_stock_picking_groupby_form
@@ -287,9 +274,9 @@ msgstr ""
 #. module: stock_picking_group_by_partner_by_carrier
 #: model:ir.model,name:stock_picking_group_by_partner_by_carrier.model_stock_warehouse
 msgid "Warehouse"
-msgstr ""
+msgstr "Magazzino"
 
 #. module: stock_picking_group_by_partner_by_carrier
 #: model_terms:ir.ui.view,arch_db:stock_picking_group_by_partner_by_carrier.stock_picking_merge_wiz_info
 msgid "With carrier:"
-msgstr ""
+msgstr "Con corriere:"

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -142,7 +142,9 @@ class StockPicking(models.Model):
                 fake_record["name"] = "fake move"
                 for sale, sale_moves in grouped_moves:
                     line_desc = sale.get_name_for_delivery_line()
-                    fake_record["description_picking"] = line_desc
+                    fake_record.update(
+                        {"description_picking": line_desc, "origin": sale.name}
+                    )
                     sales_and_moves |= sales_and_moves.new(fake_record.copy())
                     for move in sale_moves:
                         sales_and_moves |= move
@@ -152,7 +154,9 @@ class StockPicking(models.Model):
                 fake_record["product_uom_id"] = fake_record.pop("product_uom")
                 for sale, sale_moves in grouped_moves:
                     line_desc = sale.get_name_for_delivery_line()
-                    fake_record["description_picking"] = line_desc
+                    fake_record.update(
+                        {"description_picking": line_desc, "origin": sale.name}
+                    )
                     sales_and_moves |= sales_and_moves.new(fake_record.copy())
                     for move in sale_moves:
                         for move_line in move.move_line_ids:

--- a/stock_picking_group_by_partner_by_carrier/readme/DESCRIPTION.rst
+++ b/stock_picking_group_by_partner_by_carrier/readme/DESCRIPTION.rst
@@ -7,3 +7,6 @@ shares the same delivery address and carrier (or lack thereof).
 
 Sale orders with a Shipping Policy set to 'When all products are ready' always
 get their own shipping.
+
+When the delivery slip is printed, the list of pending quantities to deliver
+is shown at the end, grouped by order.

--- a/stock_picking_group_by_partner_by_carrier/report/__init__.py
+++ b/stock_picking_group_by_partner_by_carrier/report/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2021 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from . import report_delivery_slip

--- a/stock_picking_group_by_partner_by_carrier/report/assets.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/assets.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="report_assets_common"
+        inherit_id="web.report_assets_common"
+        name="Delivery Slip Assets"
+    >
+        <xpath expr="link[last()]" position="after">
+            <link
+                rel="stylesheet"
+                type="text/scss"
+                href="/stock_picking_group_by_partner_by_carrier/static/src/scss/report_delivery_slip.scss"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.py
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.py
@@ -1,0 +1,103 @@
+# Copyright 2021 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from collections import OrderedDict
+
+from odoo import api, models
+from odoo.tools import float_is_zero, float_round
+
+
+class DeliverySlipReport(models.AbstractModel):
+    _name = "report.stock.report_deliveryslip"
+    _description = "Delivery Slip Report"
+
+    @api.model
+    def _get_remaining_to_deliver(self, picking):
+        """Return dictionaries encoding pending quantities to deliver
+
+        Returns a list of dictionaries per sales order, encoding the data
+        to be displayed at the end of the delivery slip, summarising for
+        each order the pending quantities for each of its lines.
+        """
+        stock_move = self.env["stock.move"]
+
+        sales_data = OrderedDict()
+        for sale in picking.group_id.sale_ids.sorted(key=lambda s: s.id):
+            order_name = sale.get_name_for_delivery_line()
+            for line in sale.order_line.filtered(
+                lambda l: not l.display_type and l.product_id.type != "service"
+            ):
+                move = stock_move.search(
+                    [("sale_line_id", "=", line.id), ("picking_id", "=", picking.id)],
+                    limit=1,
+                )
+                qty = 0
+                if picking.state == "done" or not move:
+                    # If the picking is done, or if the line is not in any move
+                    # of this picking, we rely only in the sales order.
+                    qty = line.product_uom_qty - line.qty_delivered
+                elif picking.state not in ("cancel", "done"):
+                    # Else, we consider the amount reserved in the move.
+                    qty = (
+                        line.product_uom_qty - line.qty_delivered - move.product_uom_qty
+                    )
+
+                uom = move.product_uom if move else line.product_uom
+                uom_rounding = uom.rounding
+                if not float_is_zero(qty, precision_rounding=uom_rounding):
+                    if order_name not in sales_data:
+                        sales_data[order_name] = [
+                            {"is_header": True, "concept": order_name}
+                        ]
+                    sales_data[order_name].append(
+                        {
+                            "is_header": False,
+                            "concept": line.product_id.name_get()[0][-1],
+                            "qty": float_round(qty, precision_rounding=uom_rounding),
+                            "product": line.product_id,
+                            "uom": uom,
+                            "sale_order_line": line,
+                        }
+                    )
+
+        return sales_data
+
+    @api.model
+    def get_remaining_to_deliver(self, picking):
+        sales_data = self._get_remaining_to_deliver(picking)
+
+        # Check: being sales_data an *ordered* dictonary, maybe .values()
+        #        returns the items in orders, so would be as easy as:
+        #        `return sales_data.values()`
+        remaining_to_deliver = []
+        for _, sale_data in sales_data.items():
+            # Remove those orders having just the line of the title.
+            if len(sale_data) > 1:
+                remaining_to_deliver.extend(sale_data)
+        return remaining_to_deliver
+
+    @api.model
+    def rounding_to_precision(self, rounding):
+        """ Convert rounding specification to precision digits
+
+        Rounding is encoded in Odoo as a floating number with as
+        many meaningful decimals as used for the rounding, e.g.
+        0.001 means rounding to 3 decimals. Precision is an integer
+        that indicates that amount, directly, in this case 3. This
+        method allows to convert from rounding to precision.
+        """
+        return len(str(int(1 / rounding))) - 1
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        docs = self.env["stock.picking"].browse(docids)
+        data = data if data is not None else {}
+        docargs = {
+            "doc_ids": docids,
+            "doc_model": "stock.picking",
+            "docs": docs,
+            "get_remaining_to_deliver": self.get_remaining_to_deliver,
+            "rounding_to_precision": self.rounding_to_precision,
+            "data": data.get("form", False),
+        }
+        return docargs

--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
+        <div class="page" position="before">
+            <t t-set="report_lines" t-value="o.get_delivery_report_lines()" />
+        </div>
         <!-- overrides when the picking is not done -->
         <xpath
             expr='//table[@name="stock_move_table"]/tbody/t[@t-set="lines"]'
             position="attributes"
         >
-            <attribute name="t-value">o.get_delivery_report_lines()</attribute>
+            <attribute name="t-value">report_lines</attribute>
         </xpath>
         <xpath
             expr='//table[@name="stock_move_table"]/tbody/tr/td[span[@t-field="move.product_id"]]'
@@ -89,9 +92,48 @@
         >
             <attribute name="t-if">move_line.id</attribute>
         </xpath>
-        <!-- Remove "All items could not be shipped..." sentence -->
+        <!-- Remove "All items could not be shipped..." sentence
+            Substitute it by a message indicating if all goods have been delivered. -->
         <xpath expr='//div[hasclass("page")]/p[last()]' position="attributes">
             <attribute name="t-if">False</attribute>
+        </xpath>
+        <xpath expr='//div[hasclass("page")]/p[last()]' position="after">
+            <t t-if="o.picking_type_id.code == 'outgoing'">
+                <t t-set="remainings" t-value="get_remaining_to_deliver(o)" />
+                <t t-if="not remainings">
+                    <p
+                        class="remaining-to-deliver-separator"
+                    >All ordered items have been delivered.</p>
+                </t>
+                <t t-else="">
+                    <p class="remaining-to-deliver-separator">Remaining to deliver:</p>
+                    <table class="table table-sm" name="remaining_to_deliver_table">
+                        <tbody>
+                            <tr t-foreach="remainings" t-as="remaining">
+                                <td>
+                                    <span
+                                        t-att-class="'font-weight-bold' if remaining['is_header'] else None"
+                                        t-esc="remaining['concept']"
+                                    />
+                                </td>
+                                <td style="text-align: right">
+                                    <t t-if="not remaining['is_header']">
+                                        <span
+                                            t-esc="remaining['qty']"
+                                            t-options="{'widget': 'float',
+                                                          'precision': rounding_to_precision(remaining['uom'].rounding)}"
+                                        />
+                                        <span
+                                            class="remaining_uom_name"
+                                            t-field="remaining['uom'].name"
+                                        />
+                                    </t>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </t>
+            </t>
         </xpath>
     </template>
     <template

--- a/stock_picking_group_by_partner_by_carrier/static/src/scss/report_delivery_slip.scss
+++ b/stock_picking_group_by_partner_by_carrier/static/src/scss/report_delivery_slip.scss
@@ -1,0 +1,3 @@
+.remaining-to-deliver-separator {
+    background-color: #c6c6c6;
+}

--- a/stock_picking_group_by_partner_by_carrier/tests/test_report.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_report.py
@@ -5,6 +5,121 @@ from .common import TestGroupByBase
 
 
 class TestReport(TestGroupByBase):
+    def _set_qty_only_in_location(self, location, product, qty):
+        for other_location in self.env["stock.location"].search(
+            [("usage", "!=", "view"), ("id", "!=", location.id)]
+        ):
+            self._update_qty_in_location(other_location, product, 0)
+        self._update_qty_in_location(location, product, qty)
+        self.assertEqual(product.qty_available, qty)
+
+    def test_get_remaining_to_deliver_nondelivered_line(self):
+        """One sale with two lines, one of them non delivered"""
+        report = self.env["report.stock.report_deliveryslip"]
+
+        stock_location = self.env.ref("stock.stock_location_stock")
+
+        # SO1 has 5 units of product1, we have 3 in stock;
+        # and has 7 units of product2, we have 0 in stock.
+        so = self._get_new_sale_order(amount=5)
+        prod1 = so.order_line[0].product_id
+        self.assertEqual(prod1, self.env.ref("product.product_delivery_01"))
+        prod2 = self.env.ref("product.product_delivery_02")
+        self.env["sale.order.line"].create(
+            {
+                "order_id": so.id,
+                "name": prod2.name,
+                "product_id": prod2.id,
+                "product_uom_qty": 7,
+                "product_uom": prod2.uom_id.id,
+                "price_unit": prod2.list_price,
+            }
+        )
+        self._set_qty_only_in_location(stock_location, prod1, 3)
+        self._set_qty_only_in_location(stock_location, prod2, 0)
+        self.assertEqual(len(so.order_line), 2)
+        so.action_confirm()
+
+        self.assertEqual(len(so.picking_ids), 1)
+        picking = so.picking_ids
+        remaining_data = report.get_remaining_to_deliver(picking)
+        self.assertEqual(len(remaining_data), 0)
+
+        self.env["stock.immediate.transfer"].create(
+            {"pick_ids": [(4, picking.id)]}
+        ).process()
+        backorder_wiz = self.env["stock.backorder.confirmation"].create(
+            {"pick_ids": [(4, picking.id)]}
+        )
+        backorder_wiz.process()
+
+        remaining_data = report.get_remaining_to_deliver(picking)
+        self.assertEqual(len(remaining_data), 3)
+
+        self.assertTrue(remaining_data[0]["is_header"])
+        self.assertEqual(remaining_data[0]["concept"], so.name)
+        self.assertFalse(remaining_data[1]["is_header"])
+        self.assertEqual(remaining_data[1]["qty"], 2)
+        self.assertFalse(remaining_data[2]["is_header"])
+        self.assertEqual(remaining_data[2]["qty"], 7)
+
+    def test_get_remaining_to_deliver_two_sales(self):
+        """Two sales that combine into one picking"""
+        report = self.env["report.stock.report_deliveryslip"]
+
+        stock_location = self.env.ref("stock.stock_location_stock")
+
+        # SO1 has 5 units of product_delivery_01, we have 3 in stock,
+        # so 5-3=2 will be pending.
+        so1 = self._get_new_sale_order(amount=5)
+        prod_so1 = so1.order_line[0].product_id
+        self.assertEqual(prod_so1, self.env.ref("product.product_delivery_01"))
+        self._set_qty_only_in_location(stock_location, prod_so1, 3)
+
+        # SO2 has 10 units of product_delivery_02, we have 4 in stock,
+        # so 10-4=6 will be pending.
+        so2 = self._get_new_sale_order(amount=10)
+        prod_so2 = self.env.ref("product.product_delivery_02")
+        so2.order_line[0].update(
+            {
+                "name": prod_so2.name,
+                "product_id": prod_so2.id,
+                "product_uom": prod_so2.uom_id.id,
+                "price_unit": prod_so2.list_price,
+            }
+        )
+        self._set_qty_only_in_location(stock_location, prod_so2, 4)
+
+        so1.action_confirm()
+        so2.action_confirm()
+
+        self.assertEqual(set(so1.picking_ids.ids), set(so2.picking_ids.ids))
+        self.assertEqual(len(so1.picking_ids), 1)
+        picking = so1.picking_ids
+        self.assertEqual(len(picking.move_line_ids), 2)
+
+        remaining_data = report.get_remaining_to_deliver(picking)
+        self.assertEqual(len(remaining_data), 0)
+
+        self.env["stock.immediate.transfer"].create(
+            {"pick_ids": [(4, picking.id)]}
+        ).process()
+        backorder_wiz = self.env["stock.backorder.confirmation"].create(
+            {"pick_ids": [(4, picking.id)]}
+        )
+        backorder_wiz.process()
+        remaining_data = report.get_remaining_to_deliver(picking)
+        self.assertEqual(len(remaining_data), 4)
+
+        self.assertTrue(remaining_data[0]["is_header"])
+        self.assertEqual(remaining_data[0]["concept"], so1.name)
+        self.assertFalse(remaining_data[1]["is_header"])
+        self.assertEqual(remaining_data[1]["qty"], 2)
+        self.assertTrue(remaining_data[2]["is_header"])
+        self.assertEqual(remaining_data[2]["concept"], so2.name)
+        self.assertFalse(remaining_data[3]["is_header"])
+        self.assertEqual(remaining_data[3]["qty"], 6)
+
     def test_delivery_report_lines_two_sales_merged(self):
         """Check report lines for two sale orders merged in same picking."""
         so1 = self._get_new_sale_order()


### PR DESCRIPTION
~**!! This PR buids on https://github.com/OCA/stock-logistics-workflow/pull/781 !!**~

When the delivery slip is printed, the list of pending quantities
to deliver is shown at the end, grouped by order.