### PR TITLE
[13.0][FIX] stock_picking_group_by_partner_by_carrier_by_date: Add freezegun requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+freezegun


### PR DESCRIPTION
Add freezegun requirement (used in tests https://github.com/OCA/stock-logistics-workflow/blob/13.0/stock_picking_group_by_partner_by_carrier_by_date/tests/test_grouping_by_date.py#L3)

Error in https://travis-ci.com/github/OCA/stock-logistics-workflow/jobs/483493713#L1957