### PR TITLE
[14.0][FIX] stock_restrict_lot

### DIFF
--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -23,7 +23,11 @@ class StockMove(models.Model):
             quantity=quantity, reserved_quant=reserved_quant
         )
         if self.restrict_lot_id:
-            if "lot_id" in vals and vals["lot_id"] != self.restrict_lot_id.id:
+            if (
+                "lot_id" in vals
+                and vals["lot_id"] is not False
+                and vals["lot_id"] != self.restrict_lot_id.id
+            ):
                 raise exceptions.UserError(
                     _(
                         "Inconsistencies between reserved quant and lot restriction on "


### PR DESCRIPTION
No validate `Inconsistencies between reserved quant and lot restriction on stock move` if vals['lot_id'] is False

I'm migrating on [`sale_tier_validation`](https://github.com/OCA/sale-workflow/pull/1455) module and found some error on `sale_order_lot_generator` module
![Selection_198](https://user-images.githubusercontent.com/24691983/109770819-9f6d1c80-7c2e-11eb-81d0-4dd20ddc0101.png)

**Step to reproduce**
1. Create Quotation with product as tracking = lot
2. Confirm Quotation
3. Add sale_order_line with product as tracking = lot
4. Save Quotation and found message `Inconsistencies between reserved quant and lot restriction on stock move`

This is occur from have lot_id on sale_order_line but no have on stock_move_line

![Peek 2021-03-03 14-55](https://user-images.githubusercontent.com/24691983/109772461-9715e100-7c30-11eb-9233-74fa54e31ddf.gif)

I fix no check this if vals['lot_id'] is False. Is there any concern ? @florian-dacosta
