### PR TITLE
12.0 add stock picking assign limit days

### DIFF
--- a/stock_picking_assign_limit_days/__init__.py
+++ b/stock_picking_assign_limit_days/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2021 PlanetaTIC <info@planetatic.com>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/stock_picking_assign_limit_days/__manifest__.py
+++ b/stock_picking_assign_limit_days/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2021 PlanetaTIC <info@planetatic.com>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+{
+    "name": "Stock Picking Assign Limit Days",
+    "summary":
+        "Do not assign a stock move until its expected date is below X days",
+    "version": "12.0.1.0.0",
+    "development_status": "Production/Stable",
+    "category": "Stock",
+    "website": "https://www.planetatic.com/",
+    "author": "PlanetaTIC",
+    "maintainers": ["PlanetaTIC"],
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "stock"
+    ],
+    "data": [
+        'data/ir_config_parameter.xml',
+    ],
+}

--- a/stock_picking_assign_limit_days/data/ir_config_parameter.xml
+++ b/stock_picking_assign_limit_days/data/ir_config_parameter.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<data>
+
+<record id="stock_picking_assign_limit_days_param" model="ir.config_parameter">
+    <field name="key">stock_picking_assign_limit_days.stock_picking_assign_limit_days</field>
+    <field name="value"></field>
+</record>
+
+</data>
+</odoo>

--- a/stock_picking_assign_limit_days/data/ir_config_parameter.xml
+++ b/stock_picking_assign_limit_days/data/ir_config_parameter.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-<data>
+<data noupdate="1">
 
 <record id="stock_picking_assign_limit_days_param" model="ir.config_parameter">
     <field name="key">stock_picking_assign_limit_days.stock_picking_assign_limit_days</field>

--- a/stock_picking_assign_limit_days/i18n/es.po
+++ b/stock_picking_assign_limit_days/i18n/es.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_picking_assign_limit_days
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-03 15:06+0000\n"
+"PO-Revision-Date: 2021-03-03 15:06+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_picking_assign_limit_days
+#: model:ir.model.fields,help:stock_picking_assign_limit_days.field_res_config_settings__stock_picking_assign_limit_days
+msgid "A stock move will not be assigned until its date_expected will be set before to today plus the indicated number of days"
+msgstr "Un movimiento de stock no se reservará hasta que su fecha prevista no sea antes del día de hoy más el número de días indicados"
+
+#. module: stock_picking_assign_limit_days
+#: model:ir.model,name:stock_picking_assign_limit_days.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de Configuración"
+
+#. module: stock_picking_assign_limit_days
+#: model:ir.model,name:stock_picking_assign_limit_days.model_stock_move
+msgid "Stock Move"
+msgstr "Movimiento de existencias"
+
+#. module: stock_picking_assign_limit_days
+#: model:ir.model.fields,field_description:stock_picking_assign_limit_days.field_res_config_settings__stock_picking_assign_limit_days
+msgid "Stock Picking Assign Limit Days"
+msgstr "Días límite para reservar movimientos de stock"
+

--- a/stock_picking_assign_limit_days/models/__init__.py
+++ b/stock_picking_assign_limit_days/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2021 PlanetaTIC <info@planetatic.com>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import res_config_settings
+from . import stock_move

--- a/stock_picking_assign_limit_days/models/res_config_settings.py
+++ b/stock_picking_assign_limit_days/models/res_config_settings.py
@@ -29,9 +29,9 @@ class ResConfigSettings(models.TransientModel):
         super(ResConfigSettings, self).set_values()
         param = self.env['ir.config_parameter'].sudo()
 
-        stock_picking_confirm_before_days =\
-            self.stock_picking_confirm_before_days or False
+        stock_picking_assign_limit_days =\
+            self.stock_picking_assign_limit_days or False
 
         param.set_param('stock_picking_assign_limit_days.'
                         'stock_picking_assign_limit_days',
-                        stock_picking_confirm_before_days)
+                        stock_picking_assign_limit_days)

--- a/stock_picking_assign_limit_days/models/res_config_settings.py
+++ b/stock_picking_assign_limit_days/models/res_config_settings.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    stock_picking_assign_limit_days = fields.Integer(
+        string='Stock Picking Assign Limit Days',
+        help="A stock move will not be assigned until its date_expected"
+        " will be set before to today plus the indicated number of days")
+
+    @api.model
+    def get_values(self):
+        param_obj = self.env['ir.config_parameter']
+        res = super(ResConfigSettings, self).get_values()
+        res.update(
+            stock_picking_assign_limit_days=param_obj.sudo().get_param(
+                'stock_picking_assign_limit_days.'
+                'stock_picking_assign_limit_days')
+        )
+        return res
+
+    @api.multi
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        param = self.env['ir.config_parameter'].sudo()
+
+        stock_picking_confirm_before_days =\
+            self.stock_picking_confirm_before_days or False
+
+        param.set_param('stock_picking_assign_limit_days.'
+                        'stock_picking_assign_limit_days',
+                        stock_picking_confirm_before_days)

--- a/stock_picking_assign_limit_days/models/stock_move.py
+++ b/stock_picking_assign_limit_days/models/stock_move.py
@@ -1,0 +1,27 @@
+# Copyright 2020 PlanetaTIC <info@planetatic.com>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from dateutil.relativedelta import relativedelta
+from datetime import datetime
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _action_assign(self):
+        param_obj = self.env['ir.config_parameter']
+
+        move_to_assign = self.browse()
+        for move in self:
+            if move.date_expected:
+                confirm_before_days = param_obj.sudo().get_param(
+                    'stock_picking_assign_limit_days.'
+                    'stock_picking_assign_limit_days') or 0
+                if confirm_before_days:
+                    limit_date_to_assign = datetime.now() + relativedelta(
+                        days=int(confirm_before_days))
+                    if move.date_expected <= limit_date_to_assign:
+                        move_to_assign |= move
+        res = super(StockMove, move_to_assign)._assign_picking()
+        return res

--- a/stock_picking_assign_limit_days/models/stock_move.py
+++ b/stock_picking_assign_limit_days/models/stock_move.py
@@ -14,6 +14,7 @@ class StockMove(models.Model):
 
         move_to_assign = self.browse()
         for move in self:
+            skip_move = False
             if move.date_expected:
                 confirm_before_days = param_obj.sudo().get_param(
                     'stock_picking_assign_limit_days.'
@@ -21,7 +22,9 @@ class StockMove(models.Model):
                 if confirm_before_days:
                     limit_date_to_assign = datetime.now() + relativedelta(
                         days=int(confirm_before_days))
-                    if move.date_expected <= limit_date_to_assign:
-                        move_to_assign |= move
+                    if move.date_expected > limit_date_to_assign:
+                        skip_move = True
+            if not skip_move:
+                move_to_assign |= move
         res = super(StockMove, move_to_assign)._action_assign()
         return res

--- a/stock_picking_assign_limit_days/models/stock_move.py
+++ b/stock_picking_assign_limit_days/models/stock_move.py
@@ -23,5 +23,5 @@ class StockMove(models.Model):
                         days=int(confirm_before_days))
                     if move.date_expected <= limit_date_to_assign:
                         move_to_assign |= move
-        res = super(StockMove, move_to_assign)._assign_picking()
+        res = super(StockMove, move_to_assign)._action_assign()
         return res

--- a/stock_picking_assign_limit_days/readme/CONSTRIBUTRORS.rst
+++ b/stock_picking_assign_limit_days/readme/CONSTRIBUTRORS.rst
@@ -1,0 +1,1 @@
+* Marc Poch <mpoch@planetatic.com>

--- a/stock_picking_assign_limit_days/readme/DESCRIPTION.rst
+++ b/stock_picking_assign_limit_days/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module permits to set stock_picking_assign_limit_days parameter,
+When set, Odoo won't assign any stock.move if its date_expected is below
+to today plus the indicated number of days.


### PR DESCRIPTION
stock_picking_assign_limit_days permits to set stock_picking_assign_limit_days parameter,
When set, Odoo won't assign any stock.move if its date_expected is below
to today plus the indicated number of days.