### PR TITLE
[13.0][FIX] stock_return_request: Fix tests

### DIFF
--- a/stock_return_request/tests/test_stock_return_request.py
+++ b/stock_return_request/tests/test_stock_return_request.py
@@ -139,7 +139,7 @@ class PurchaseReturnRequestCase(StockReturnRequestCase):
                 "lot_id": self.prod_3_lot3.id,
                 "qty_done": 30.0,
             }
-            move.write({"move_line_ids": [(0, 0, vals)], "quantity_done": 30.0})
+            move.write({"move_line_ids": [(0, 0, vals)]})
         picking.action_done()
         self.return_request_supplier.write(
             {

--- a/stock_return_request/tests/test_stock_return_request_common.py
+++ b/stock_return_request/tests/test_stock_return_request_common.py
@@ -165,9 +165,7 @@ class StockReturnRequestCase(SavepointCase):
                 ],
             }
         )
-        move3.qty_done = 30
         cls.picking_supplier_1.action_confirm()
-        cls.picking_supplier_1.action_assign()
         cls.picking_supplier_1.action_done()
         cls.picking_supplier_2 = cls.picking_supplier_1.copy(
             {
@@ -229,9 +227,7 @@ class StockReturnRequestCase(SavepointCase):
                 ],
             }
         )
-        move3.qty_done = 30
         cls.picking_supplier_2.action_confirm()
-        cls.picking_supplier_2.action_assign()
         cls.picking_supplier_2.action_done()
         # Test could run so fast that the move lines date would be in the same
         # second. We need to sort them by date, so we'll be faking the line
@@ -274,7 +270,6 @@ class StockReturnRequestCase(SavepointCase):
             }
         )
         cls.picking_customer_1.action_confirm()
-        cls.picking_customer_1.action_assign()
         cls.picking_customer_1.action_done()
         cls.picking_customer_2 = cls.picking_customer_1.copy(
             {
@@ -305,7 +300,6 @@ class StockReturnRequestCase(SavepointCase):
             }
         )
         cls.picking_customer_2.action_confirm()
-        cls.picking_customer_2.action_assign()
         cls.picking_customer_2.action_done()
         # Test could run so fast that the move lines date would be in the same
         # second. We need to sort them by date, so we'll be faking the line


### PR DESCRIPTION
cc @Tecnativa
Ported from v12 PR https://github.com/OCA/stock-logistics-workflow/pull/804
ping @carlosdauden @CarlosRoca13 

This PR remove the use of non existing field qty_done in stock.move model.
The action_assign method invoke is not necessary.
This tests creates stock move lines and if user invokes action_assign can unreserve moves.
