### PR TITLE
12.0 add stock picking purchase limit days

### DIFF
--- a/stock_picking_purchase_limit_days/__init__.py
+++ b/stock_picking_purchase_limit_days/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/stock_picking_purchase_limit_days/__manifest__.py
+++ b/stock_picking_purchase_limit_days/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Stock Picking Purchase Limit Days',
+    "summary": "Do not purchase products required for orders beyond X days",
+    'version': '12.0.1.0.1',
+    "development_status": "Production/Stable",
+    'category': 'Stock',
+    'author': "PlanetaTIC,Odoo Community Association (OCA)",
+    'license': 'AGPL-3',
+    'website': 'https://github.com/OCA/edi',
+    'depends': [
+        'stock',
+    ],
+    'demo': [],
+    'data': [
+        'data/ir_config_parameter.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/stock_picking_purchase_limit_days/data/ir_config_parameter.xml
+++ b/stock_picking_purchase_limit_days/data/ir_config_parameter.xml
@@ -2,9 +2,9 @@
 <!-- Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-<data>
+<data noupdate="1">
 
-<record id="purchase_limit_date_param" model="ir.config_parameter">
+<record id="purchase_limit_days_param" model="ir.config_parameter">
     <field name="key">stock_picking_purchase_limit_date.purchase_limit_days</field>
     <field name="value"></field>
 </record>

--- a/stock_picking_purchase_limit_days/data/ir_config_parameter.xml
+++ b/stock_picking_purchase_limit_days/data/ir_config_parameter.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<data>
+
+<record id="purchase_limit_date_param" model="ir.config_parameter">
+    <field name="key">stock_picking_purchase_limit_date.purchase_limit_days</field>
+    <field name="value"></field>
+</record>
+
+</data>
+</odoo>

--- a/stock_picking_purchase_limit_days/models/__init__.py
+++ b/stock_picking_purchase_limit_days/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import res_config_settings
 from . import stock_rule
+from . import product

--- a/stock_picking_purchase_limit_days/models/__init__.py
+++ b/stock_picking_purchase_limit_days/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import res_config_settings
+from . import stock_rule

--- a/stock_picking_purchase_limit_days/models/product.py
+++ b/stock_picking_purchase_limit_days/models/product.py
@@ -1,0 +1,34 @@
+# Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date, datetime
+from dateutil.relativedelta import relativedelta 
+from odoo import models, fields, api, _
+
+
+class Product(models.Model):
+    _inherit = "product.product"
+
+    def _product_available(self, field_names=None, arg=False):
+        if self.env.context.get('purchase_limit_days'):
+            limited_qties = super(Product, self)._product_available(
+                field_names=field_names, arg=arg)
+            unlimited_qties = super(Product, self).with_context(
+                to_date=False, purchase_limit_days=False)._product_available(
+                    field_names=field_names, arg=arg)
+            res = {}
+            for product_id, qties in limited_qties.items():
+                incoming_qty = unlimited_qties[product_id]['incoming_qty']
+                virtual_qty = (qties['qty_available']
+                               + incoming_qty - qties['outgoing_qty'])
+                res[product_id] = {
+                    'qty_available': qties['qty_available'],
+                    'incoming_qty': incoming_qty,
+                    'outgoing_qty': qties['outgoing_qty'],
+                    'virtual_available': virtual_qty,
+                }
+        else:
+            res = super(Product, self)._product_available(
+                field_names=field_names, arg=arg)
+
+        return res

--- a/stock_picking_purchase_limit_days/models/res_config_settings.py
+++ b/stock_picking_purchase_limit_days/models/res_config_settings.py
@@ -1,0 +1,36 @@
+# Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    purchase_limit_days = fields.Char(
+        string='Purchase Limit Days',
+        help='Limit Days forward to check whether or not is necessary to buy requiered stock',)
+
+    @api.model
+    def get_values(self):
+        param_obj = self.env['ir.config_parameter']
+        res = super(ResConfigSettings, self).get_values()
+        res.update(
+            deliveryslip_folder=param_obj.sudo().get_param(
+                'stock_picking_purchase_limit_days.'
+                'field_res_config_settings__purchase_limit_days'),
+        )
+        return res
+
+    @api.multi
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        param = self.env['ir.config_parameter'].sudo()
+
+        purchase_limit_days = self.purchase_limit_days or False
+
+        param.set_param(
+            'stock_picking_purchase_limit_days.'
+            'field_res_config_settings__purchase_limit_days',
+            purchase_limit_days
+        )

--- a/stock_picking_purchase_limit_days/models/stock_rule.py
+++ b/stock_picking_purchase_limit_days/models/stock_rule.py
@@ -25,3 +25,11 @@ class ProcurementGroup(models.Model):
             'to_date': limit_date,
             'procurement_values': dict()
         }]
+
+    @api.model
+    def _procure_orderpoint_confirm(
+            self, use_new_cursor=False, company_id=False):
+        res = super(ProcurementGroup, self.with_context(
+            purchase_limit_days=True))._procure_orderpoint_confirm(
+                use_new_cursor=use_new_cursor, company_id=company_id)
+        return res

--- a/stock_picking_purchase_limit_days/models/stock_rule.py
+++ b/stock_picking_purchase_limit_days/models/stock_rule.py
@@ -1,0 +1,27 @@
+# Copyright 2021 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date, datetime
+from dateutil.relativedelta import relativedelta 
+from odoo import models, fields, api, _
+
+
+class ProcurementGroup(models.Model):
+    _inherit = 'procurement.group'
+
+    @api.model
+    def _procurement_from_orderpoint_get_groups(self, orderpoint_ids):
+        param_obj = self.env['ir.config_parameter']
+
+        # get system parameter to check if limit virtual stock at date:
+        # and set this param into context.
+        purchase_limit_days = param_obj.sudo().get_param(
+            'stock_picking_purchase_limit_date.purchase_limit_days')
+
+        limit_date = False
+        if purchase_limit_days:
+            limit_date = date.today() + relativedelta(days=int(purchase_limit_days))
+        return [{
+            'to_date': limit_date,
+            'procurement_values': dict()
+        }]

--- a/stock_picking_purchase_limit_days/readme/CONSTRIBUTRORS.rst
+++ b/stock_picking_purchase_limit_days/readme/CONSTRIBUTRORS.rst
@@ -1,0 +1,1 @@
+* Marc Poch <mpoch@planetatic.com>

--- a/stock_picking_purchase_limit_days/readme/DESCRIPTION.rst
+++ b/stock_picking_purchase_limit_days/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module permits to set purchase_limit_days parameter,
+When set, Odoo only will satisfy procurements required before than purchase_limit_days days 


### PR DESCRIPTION
This module permits to set purchase_limit_days parameter,
When set, Odoo only will satisfy procurements required before purchase_limit_days days.