### PR TITLE
[11.0] [BACKPORT] stock_split_picking: Mode selection to split in different ways

### DIFF
--- a/stock_split_picking/__init__.py
+++ b/stock_split_picking/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizards

--- a/stock_split_picking/__manifest__.py
+++ b/stock_split_picking/__manifest__.py
@@ -17,6 +17,7 @@
         'stock',
     ],
     'data': [
+        'wizards/stock_split_picking.xml',
         'views/stock_partial_picking.xml',
     ],
 }

--- a/stock_split_picking/models/stock_picking.py
+++ b/stock_split_picking/models/stock_picking.py
@@ -55,22 +55,7 @@ class StockPicking(models.Model):
 
             # If we have new moves to move, create the backorder picking
             if new_moves:
-                backorder_picking = picking.copy({
-                    'name': '/',
-                    'move_lines': [],
-                    'move_line_ids': [],
-                    'backorder_id': picking.id,
-                })
-                picking.message_post(
-                    _(
-                        'The backorder <a href="#" '
-                        'data-oe-model="stock.picking" '
-                        'data-oe-id="%d">%s</a> has been created.'
-                    ) % (
-                        backorder_picking.id,
-                        backorder_picking.name
-                    )
-                )
+                backorder_picking = picking._create_split_backorder()
                 new_moves.write({
                     'picking_id': backorder_picking.id,
                 })
@@ -78,3 +63,42 @@ class StockPicking(models.Model):
                     'picking_id': backorder_picking.id,
                 })
                 new_moves._action_assign()
+
+    def _create_split_backorder(self, default=None):
+        """Copy current picking with defaults passed, post message about
+        backorder"""
+        self.ensure_one()
+        backorder_picking = self.copy(dict({
+            'name': '/',
+            'move_lines': [],
+            'move_line_ids': [],
+            'backorder_id': self.id,
+        }, **(default or {})))
+        self.message_post(
+            body=_(
+                'The backorder <a href="#" '
+                'data-oe-model="stock.picking" '
+                'data-oe-id="%d">%s</a> has been created.'
+            ) % (
+                backorder_picking.id,
+                backorder_picking.name
+            )
+        )
+        return backorder_picking
+
+    def _split_off_moves(self, moves):
+        """Remove moves from pickings in self and put them into a new one"""
+        new_picking = self.env['stock.picking']
+        for this in self:
+            if this.state in ('done', 'cancel'):
+                raise UserError(_('Cannot split picking %s in state %s') % (
+                    this.name, this.state,
+                ))
+            new_picking = new_picking or this._create_split_backorder()
+            if not this.move_lines - moves:
+                raise UserError(
+                    _('Cannot split off all moves from picking %s') % this.name
+                )
+        moves.write({'picking_id': new_picking.id})
+        moves.mapped('move_line_ids').write({'picking_id': new_picking.id})
+        return new_picking

--- a/stock_split_picking/tests/test_stock_split_picking.py
+++ b/stock_split_picking/tests/test_stock_split_picking.py
@@ -85,3 +85,37 @@ class TestStockSplitPicking(SavepointCase):
         self.assertAlmostEqual(new_picking.move_lines.ordered_qty, 6.0)
 
         self.assertEqual(new_picking.state, 'assigned')
+
+    def test_stock_split_picking_wizard_move(self):
+        self.move2 = self.move.copy()
+        self.assertEqual(self.move2.picking_id, self.picking)
+        wizard = self.env['stock.split.picking'].with_context(
+            active_ids=self.picking.ids
+        ).create({
+            'mode': 'move',
+        })
+        wizard.action_apply()
+        self.assertNotEqual(self.move2.picking_id, self.picking)
+        self.assertEqual(self.move.picking_id, self.picking)
+
+    def test_stock_split_picking_wizard_selection(self):
+        self.move2 = self.move.copy()
+        self.assertEqual(self.move2.picking_id, self.picking)
+        wizard = self.env['stock.split.picking'].with_context(
+            active_ids=self.picking.ids
+        ).create({
+            'mode': 'selection',
+            'move_ids': [(6, False, self.move2.ids)],
+        })
+        wizard.action_apply()
+        self.assertNotEqual(self.move2.picking_id, self.picking)
+        self.assertEqual(self.move.picking_id, self.picking)
+
+    def test_stock_picking_split_off_moves(self):
+        with self.assertRaises(UserError):
+            # fails because we can't split off all lines
+            self.picking._split_off_moves(self.picking.move_lines)
+        with self.assertRaises(UserError):
+            # fails because we can't split cancelled pickings
+            self.picking.action_cancel()
+            self.picking._split_off_moves(self.picking.move_lines)

--- a/stock_split_picking/views/stock_partial_picking.xml
+++ b/stock_split_picking/views/stock_partial_picking.xml
@@ -7,12 +7,11 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <field name ="state" position="before">
-                <button name="split_process"
-                        states="draft,assigned,partially_available"
+                <button name="%(stock_split_picking.action_stock_split_picking)s"
+                        states="draft,confirmed,assigned"
                         string="Split"
-                        confirm="Are you sure you want to split current picking?"
                         groups="stock.group_stock_user"
-                        type="object"/>
+                        type="action"/>
             </field>
         </field>
     </record>

--- a/stock_split_picking/wizards/__init__.py
+++ b/stock_split_picking/wizards/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 Hunki Enterprises BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import stock_split_picking

--- a/stock_split_picking/wizards/stock_split_picking.py
+++ b/stock_split_picking/wizards/stock_split_picking.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Hunki Enterprises BV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+
+
+class StockSplitPicking(models.TransientModel):
+    _name = 'stock.split.picking'
+    _description = 'Split a picking'
+
+    mode = fields.Selection([
+        ('done', 'Done quantities'),
+        ('move', 'One picking per move'),
+        ('selection', 'Select move lines to split off'),
+    ], required=True, default='done')
+
+    picking_ids = fields.Many2many(
+        'stock.picking', default=lambda self: self._default_picking_ids(),
+    )
+    move_ids = fields.Many2many('stock.move')
+
+    def _default_picking_ids(self):
+        return self.env['stock.picking'].browse(
+            self.env.context.get('active_ids', [])
+        )
+
+    def action_apply(self):
+        return getattr(self, '_apply_%s' % self[:1].mode)()
+
+    def _apply_done(self):
+        return self.mapped('picking_ids').split_process()
+
+    def _apply_move(self):
+        """Create new pickings for every move line, keep first
+        move line in original picking
+        """
+        new_pickings = self.env['stock.picking']
+        for picking in self.mapped('picking_ids'):
+            for move in picking.move_lines[1:]:
+                new_pickings += picking._split_off_moves(move)
+        return self._picking_action(new_pickings)
+
+    def _apply_selection(self):
+        """Create one picking for all selected moves"""
+        moves = self.mapped('move_ids')
+        new_picking = moves.mapped('picking_id')._split_off_moves(moves)
+        return self._picking_action(new_picking)
+
+    def _picking_action(self, pickings):
+        action = self.env['ir.actions.act_window'].for_xml_id(
+            'stock', 'action_picking_tree_all',
+        )
+        action['domain'] = [('id', 'in', pickings.ids)]
+        return action

--- a/stock_split_picking/wizards/stock_split_picking.xml
+++ b/stock_split_picking/wizards/stock_split_picking.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<record id="view_stock_split_picking" model="ir.ui.view">
+    <field name="model">stock.split.picking</field>
+    <field name="arch" type="xml">
+        <form>
+            <group>
+                <field name="mode" />
+                <field name="picking_ids" invisible="True" />
+                <field name="move_ids" attrs="{'invisible': [('mode', '!=', 'selection')], 'required': [('mode', '=', 'selection')]}" domain="[('picking_id', 'in', picking_ids)]" />
+            </group>
+            <footer>
+                <button name="action_apply" class="btn btn-primary" string="Split" type="object" />
+                or
+                <button special="cancel" class="btn btn-secondary" string="Cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+<act_window
+    id="action_stock_split_picking"
+    res_model="stock.split.picking"
+    src_model="stock.picking"
+    multi="True"
+    target="new"
+    name="Split pickings"
+    view_id="view_stock_split_picking"
+/>
+
+</odoo>


### PR DESCRIPTION
Backport to v11.
https://github.com/OCA/stock-logistics-workflow/pull/714
cc @AaronHForgeFlow @ForgeFlow 