### PR TITLE
delivery_total_weight_from_packaging: fix shipping_weight

### DIFF
--- a/delivery_total_weight_from_packaging/models/stock_quant_package.py
+++ b/delivery_total_weight_from_packaging/models/stock_quant_package.py
@@ -9,7 +9,9 @@ class StockQuantPackage(models.Model):
 
     # This fiels already exists and it's stored.
     # Here is made computed but kept editable using readonly=False
-    shipping_weight = fields.Float(compute="_compute_shipping_weight", readonly=False)
+    shipping_weight = fields.Float(
+        compute="_compute_shipping_weight", readonly=False, store=True
+    )
 
     @api.depends("quant_ids")
     @api.depends_context("picking_id")


### PR DESCRIPTION
Turns out I was partially wrong on https://github.com/OCA/stock-logistics-workflow/pull/818
`store=True` is still required because even if the field is kept in the DB is not stored anymore :sweat: 