### PR TITLE
[13.0][FIX] s_p_g_by_partner_by_carrier: remaining to deliver

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -124,7 +124,7 @@ class StockPicking(models.Model):
         self.ensure_one()
         moves = self.move_lines
         if self.state != "done":
-            moves = moves.filtered("product_uom_qty")
+            moves = moves.filtered("reserved_availability")
         moves = moves.sorted(lambda m: m.sale_line_id.order_id)
 
         if len(moves.mapped("sale_line_id.order_id")) > 1:

--- a/stock_picking_group_by_partner_by_carrier/tests/test_report.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_report.py
@@ -127,16 +127,11 @@ class TestReport(TestGroupByBase):
         so1.action_confirm()
         so2.action_confirm()
         picking = so1.picking_ids
+        # No qty reserved thus nothing to print
         res = picking.get_delivery_report_lines()
-        self.assertEqual(len(res), 4)
+        self.assertEqual(len(res), 0)
         self.assertEqual(res._name, "stock.move")
-        # Check that we have two display moves (sale name)
-        # And two real moves.
-        self.assertFalse(res[0].id)
-        self.assertTrue(res[1].id)
-        self.assertFalse(res[2].id)
-        self.assertTrue(res[3].id)
-        # Deliver and test again
+        # Reserve goods and test again
         self._update_qty_in_location(
             picking.location_id,
             so1.order_line[0].product_id,
@@ -148,6 +143,14 @@ class TestReport(TestGroupByBase):
             so2.order_line[0].product_uom_qty,
         )
         picking.action_assign()
+        # Check that we have two display moves (sale name)
+        # And two real moves.
+        res = picking.get_delivery_report_lines()
+        self.assertFalse(res[0].id)
+        self.assertTrue(res[1].id)
+        self.assertFalse(res[2].id)
+        self.assertTrue(res[3].id)
+        # Deliver and test again
         line = picking.move_lines[0].move_line_ids
         line.qty_done = line.product_uom_qty
         line = picking.move_lines[1].move_line_ids


### PR DESCRIPTION
Several moves could be related to a sale order line, qty should be computed from all of them.

+ regarding the delivered qties, print only the moves having some qty reserved if the transfer is not yet done.

Ref. 2484