### PR TITLE
[13.0][IMP] stock_valuation_layer_usage: output layer selection for MTO case

### DIFF
--- a/stock_account_product_run_fifo_hook/hooks.py
+++ b/stock_account_product_run_fifo_hook/hooks.py
@@ -16,18 +16,15 @@ def post_load_hook():
         # Find back incoming stock valuation layers (called candidates here)
         # to value `quantity`.
         qty_to_take_on_candidates = quantity
+        # START HOOK Search Candidates
+        candidates_domain = self._get_candidates_domain(company)
         candidates = (
             self.env["stock.valuation.layer"]
             .sudo()
             .with_context(active_test=False)
-            .search(
-                [
-                    ("product_id", "=", self.id),
-                    ("remaining_qty", ">", 0),
-                    ("company_id", "=", company.id),
-                ]
-            )
+            .search(candidates_domain)
         )
+        # END HOOK Search Candidates
         new_standard_price = 0
         tmp_value = 0  # to accumulate the value taken on the candidates
         for candidate in candidates:
@@ -46,14 +43,14 @@ def post_load_hook():
                 "remaining_qty": candidate.remaining_qty - qty_taken_on_candidate,
                 "remaining_value": new_remaining_value,
             }
-            # Start Hook
+            # Start Hook Prepare Candidate
             candidate_vals = self._run_fifo_prepare_candidate_update(
                 candidate,
                 qty_taken_on_candidate,
                 value_taken_on_candidate,
                 candidate_vals,
             )
-            # End Hook
+            # End Hook Prepare Candidate
             candidate.write(candidate_vals)
 
             qty_to_take_on_candidates -= qty_taken_on_candidate

--- a/stock_account_product_run_fifo_hook/hooks.py
+++ b/stock_account_product_run_fifo_hook/hooks.py
@@ -62,11 +62,18 @@ def post_load_hook():
 
         # Update the standard price with the price of the last used candidate,
         # if any.
-        if new_standard_price and self.cost_method == "fifo":
-            self.sudo().with_context(
-                force_company=company.id
-            ).standard_price = new_standard_price
-
+        # START HOOK update standard price
+        if hasattr(self, "_price_updateable"):
+            if self._price_updateable(new_standard_price):
+                self.sudo().with_context(
+                    force_company=company.id
+                ).standard_price = new_standard_price
+        else:
+            if new_standard_price and self.cost_method == "fifo":
+                self.sudo().with_context(
+                    force_company=company.id
+                ).standard_price = new_standard_price
+        # END HOOK update standard price
         # If there's still quantity to value but we're out of candidates,
         # we fall in the
         # negative stock use case. We chose to value the out move at the price

--- a/stock_account_product_run_fifo_hook/model/product.py
+++ b/stock_account_product_run_fifo_hook/model/product.py
@@ -26,3 +26,11 @@ class ProductProduct(models.Model):
     ):
         self.ensure_one()
         return candidate_vals
+
+    def _get_candidates_domain(self, company):
+        candidates_domain = [
+            ("product_id", "=", self.id),
+            ("remaining_qty", ">", 0),
+            ("company_id", "=", company.id),
+        ]
+        return candidates_domain

--- a/stock_account_product_run_fifo_hook/model/product.py
+++ b/stock_account_product_run_fifo_hook/model/product.py
@@ -34,3 +34,7 @@ class ProductProduct(models.Model):
             ("company_id", "=", company.id),
         ]
         return candidates_domain
+
+    def _price_updateable(self, new_standard_price=False):
+        self.ensure_one()
+        return new_standard_price and self.cost_method == "fifo"

--- a/stock_valuation_layer_usage/models/stock_move.py
+++ b/stock_valuation_layer_usage/models/stock_move.py
@@ -19,7 +19,9 @@ class StockMove(models.Model):
     def _create_out_svl(self, forced_quantity=None):
         layers = self.env["stock.valuation.layer"]
         for move in self:
-            move = move.with_context(used_in_move_id=move.id)
+            move = move.with_context(
+                used_in_move_id=move.id, reserved_from=move.move_orig_ids.ids
+            )
             layer = super(StockMove, move)._create_out_svl(
                 forced_quantity=forced_quantity
             )

--- a/stock_valuation_layer_usage/readme/DESCRIPTION.rst
+++ b/stock_valuation_layer_usage/readme/DESCRIPTION.rst
@@ -5,3 +5,12 @@ used, and how much quantity was taken by the particular stock move.
 This kind of traceability is important in case that at some point you want
 to conduct an revaluation (for example, in case that the purchase order price
 changes after the products have been received into stock).
+
+Also, it changes the way the outgoing layers are created in order to respect
+the MTO case. When creating the out svl, Odoo takes the first layer available
+with value. The module stock_valuation_layer_usage arises an issue with that
+Odoo process. Odoo will take always the oldest svl. However, that is not the
+case for MTO. When there is a fixed link between the incoming move and the
+outgoing move, at the time of creating the outgoing svl the system should
+take the specific incoming svl not just the oldest one. Also, when the case
+is not MTO, the system should avoid using svl that are "reserved".

--- a/stock_valuation_layer_usage/readme/USAGE.rst
+++ b/stock_valuation_layer_usage/readme/USAGE.rst
@@ -7,3 +7,8 @@
   'Inventory / Reporting / Stock Moves'. You will see a section
   'Valuation Layers' where you will be able to identify the valuation layers
   that were used to value this move, and the quantity and value that was taken.
+
+* Create several MTO order
+
+* Deliver the products to a customer in a random way and check the section
+  'Valuation Layers Usage'. The MTO logic is respected, then FIFO applies.


### PR DESCRIPTION
This new module should be used together with stock_valuation_layer_usage.

This module means to fix this siutation:

When creating the out svl, Odoo takes the first layer available with value. The module stock_valuation_layer_usage arises an issue with that Odoo process. Odoo will take always the oldest svl. However, that is not the case for MTO. When there is a fixed link between the incoming move and the outgoing move, at the time of creating the outgoing svl the system should take the specific incoming svl not just the oldest one. Also, when the case is not MTO, the system should avoid using svl that are "reserved".

@ForgeFlow @MiquelRForgeFlow @JordiBForgeFlow 
