### PR TITLE
[13.0][IMP] stock_split_picking: allow splitting pickings waiting for other operations

### DIFF
--- a/stock_split_picking/views/stock_partial_picking.xml
+++ b/stock_split_picking/views/stock_partial_picking.xml
@@ -8,7 +8,7 @@
             <field name="state" position="before">
                 <button
                     name="%(stock_split_picking.action_stock_split_picking)s"
-                    states="draft,confirmed,assigned"
+                    states="draft,confirmed,waiting,assigned"
                     string="Split"
                     groups="stock.group_stock_user"
                     type="action"


### PR DESCRIPTION
Make the split option available when the picking is in the "Waiting Another Operation" status. If, for example, you want to split two MTO moves into different pickings, you should be able to do so.