### PR TITLE
[13.0] s_p_group_by_partner_by_carrier: Fix translations in report

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.py
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.py
@@ -65,6 +65,10 @@ class DeliverySlipReport(models.AbstractModel):
 
     @api.model
     def get_remaining_to_deliver(self, picking):
+        # As data fetched here is meant to be displayed on a report,
+        # set the lang
+        self = self.with_context(lang=picking.partner_id.lang)
+        picking = picking.with_context(lang=picking.partner_id.lang)
         sales_data = self._get_remaining_to_deliver(picking)
 
         # Check: being sales_data an *ordered* dictonary, maybe .values()


### PR DESCRIPTION
On the deliveryslip report, in the remaining products to deliver part, the lang have to be passed in order to make everything correctly translated.