### PR TITLE
[13.0] stock_partner_delivery_window:: Fix default value on delivery_time_preference

### DIFF
--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -23,7 +23,7 @@ class ResPartner(models.Model):
             ("workdays", "Weekdays (Monday to Friday)"),
         ],
         string="Delivery time schedule preference",
-        default="workdays",
+        default="anytime",
         required=True,
         help="Define the scheduling preference for delivery orders:\n\n"
         "* Any time: Do not postpone deliveries\n"


### PR DESCRIPTION
The default value introduced by workdays feature breaks the installation
of Demo databases as the change is not reflected in sale_partner_delivery_window.

cc @simahawk @pedrobaeza @mmequignon 