### PR TITLE
[IMP] stock_move_quick_lot: Allow to assign existing lots in detailed operations for pickings with create lots option enable.

### DIFF
--- a/stock_move_quick_lot/models/__init__.py
+++ b/stock_move_quick_lot/models/__init__.py
@@ -1,4 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-# from . import stock_move_line
 from . import stock_move
+from . import stock_move_line

--- a/stock_move_quick_lot/models/stock_move_line.py
+++ b/stock_move_quick_lot/models/stock_move_line.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Sergio Teruel - Tecnativa
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    @api.onchange("lot_name")
+    def onchange_lot_name(self):
+        if self.lot_name:
+            self.lot_id = self.env["stock.production.lot"].search(
+                [
+                    ("product_id", "=", self.product_id.id),
+                    ("name", "=", self.lot_name),
+                ]
+            )
+        else:
+            self.lot_id = False

--- a/stock_move_quick_lot/views/stock_view.xml
+++ b/stock_move_quick_lot/views/stock_view.xml
@@ -18,6 +18,12 @@
             <field name="life_date"
                    attrs="{'column_invisible': [('parent.picking_type_code', '!=', 'incoming')], 'readonly': ['|', ('has_tracking','=', 'none'), ('has_move_lines', '=', False)]}"/>
         </xpath>
+
+        <!-- Force save lot_id when changes lot_name from detailed operations -->
+        <xpath expr="//field[@name='move_line_ids_without_package']/tree//field[@name='lot_id']" position="attributes">
+            <attribute name="force_save">1</attribute>
+        </xpath>
+
     </field>
 </record>
 


### PR DESCRIPTION
cc @Tecnativa TT30997

ping @chienandalu @carlosdauden 