### PR TITLE
[12.0][FIX] stock_picking_force_assign: message_post() argument

### DIFF
--- a/stock_picking_force_assign/models/stock_picking.py
+++ b/stock_picking_force_assign/models/stock_picking.py
@@ -12,12 +12,12 @@ class StockPicking(models.Model):
         link_template = '<a href="#" data-oe-model="%s" data-oe-id="%d">%s</a>'
         to_unreserve = self._force_assign_find_moves()
         to_unreserve._do_unreserve()
-        self.message_post(_(
+        self.message_post(body=_(
             'Unreserved picking(s) %s in order to assign this one'
         ) % ', '.join(to_unreserve.mapped('picking_id').mapped(
             lambda x: link_template % (x._name, x.id, x.name)
         )))
-        to_unreserve.mapped('picking_id').message_post(_(
+        to_unreserve.mapped('picking_id').message_post(body=_(
             'Unreserved this picking in order to assign %s'
         ) % ', '.join(self.mapped(
             lambda x: link_template % (x._name, x.id, x.name)


### PR DESCRIPTION
Fixes this error:

```
  File "/home/odoo/odoo/parts/stock-logistics-workflow/stock_picking_force_assign/models/stock_picking.py", line 15, in action_force_assign_pickings
    self.message_post(_(
TypeError: message_post() takes 1 positional argument but 2 were given
```