### PR TITLE
[14.0][FIX] stock_picking_filter_lot configurable per operation_type

### DIFF
--- a/stock_picking_filter_lot/__manifest__.py
+++ b/stock_picking_filter_lot/__manifest__.py
@@ -6,10 +6,14 @@
     "version": "14.0.1.0.1",
     "category": "Warehouse",
     "website": "https://github.com/OCA/stock-logistics-workflow",
-    "author": "Agile Business Group, Odoo Community Association (OCA)",
+    "author": "Le Filament, Agile Business Group, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,
     "depends": ["stock"],
-    "data": ["views/stock_move_line_view.xml", "views/stock_scrap_view.xml"],
+    "data": [
+        "views/stock_move_line_view.xml",
+        "views/stock_picking_type_view.xml",
+        "views/stock_scrap_view.xml",
+    ],
 }

--- a/stock_picking_filter_lot/models/__init__.py
+++ b/stock_picking_filter_lot/models/__init__.py
@@ -1,1 +1,3 @@
+from . import stock_move_line
+from . import stock_picking_type
 from . import stock_production_lot

--- a/stock_picking_filter_lot/models/stock_move_line.py
+++ b/stock_picking_filter_lot/models/stock_move_line.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Le Filament (https://le-filament.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo import fields, models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    picking_type_use_filter_lots = fields.Boolean(
+        related="picking_id.picking_type_id.use_filter_lots"
+    )

--- a/stock_picking_filter_lot/models/stock_picking_type.py
+++ b/stock_picking_filter_lot/models/stock_picking_type.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Le Filament (https://le-filament.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    use_filter_lots = fields.Boolean(
+        "Use only available lots",
+        default=True,
+        help="If this is checked, only lots available in source location \
+            would be displayed in drop down list for selecting lot.",
+    )

--- a/stock_picking_filter_lot/readme/CONFIGURATION.rst
+++ b/stock_picking_filter_lot/readme/CONFIGURATION.rst
@@ -1,0 +1,5 @@
+By default, all operation types use filter on lots, should you want to disable this for a particular operation type, follow the next steps :
+- Go to Inventory > Configuration > Operation Types.
+- Unselect "Use only available lots" for all the operation types on which you want to disable filtering.
+
+In case you can receive a second time the same lot number (from supplier for instance), this filter should not be applied on Reception.

--- a/stock_picking_filter_lot/readme/CONTRIBUTORS.rst
+++ b/stock_picking_filter_lot/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Alan Ramos <alan.ramos@jarsa.com.mx> (www.jarsa.com.mx)
 * Tharathip Chaweewongphan <tharathipc@ecosoft.co.th> (www.ecosoft.co.th)
 * Jesus Alcala <jesus.alcala@jarsa.com.mx> (www.jarsa.com.mx)
+* Le Filament (le-filament.com)

--- a/stock_picking_filter_lot/views/stock_move_line_view.xml
+++ b/stock_picking_filter_lot/views/stock_move_line_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright 2018 Simone Rubino - Agile Business Group
+<!-- Copyright 2021 Le Filament
+     Copyright 2018 Simone Rubino - Agile Business Group
      Copyright 2018 ForgeFlow S.L.
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
@@ -10,10 +11,13 @@
         <field name="model">stock.move.line</field>
         <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
         <field name="arch" type="xml">
+            <field name="picking_id" position="after">
+                <field name="picking_type_use_filter_lots" invisible="1" />
+            </field>
             <field name="lot_id" position="attributes">
-                <attribute
-                    name="domain"
-                >[('product_id','=', parent.product_id), ('company_id', '=', company_id), ('location_ids', 'child_of', location_id)]</attribute>
+                <attribute name="domain">
+                    picking_type_use_filter_lots and [('product_id','=', product_id), ('company_id', '=', company_id), ('location_ids', 'child_of', location_id)] or [('product_id','=', product_id), ('company_id', '=', company_id)]
+                </attribute>
             </field>
         </field>
     </record>
@@ -27,10 +31,13 @@
             ref="stock.view_stock_move_line_detailed_operation_tree"
         />
         <field name="arch" type="xml">
+            <field name="picking_id" position="after">
+                <field name="picking_type_use_filter_lots" invisible="1" />
+            </field>
             <field name="lot_id" position="attributes">
-                <attribute
-                    name="domain"
-                >[('product_id','=', product_id), ('company_id', '=', company_id), ('location_ids', 'child_of', location_id)]</attribute>
+                <attribute name="domain">
+                    picking_type_use_filter_lots and [('product_id','=', product_id), ('company_id', '=', company_id), ('location_ids', 'child_of', location_id)] or [('product_id','=', product_id), ('company_id', '=', company_id)]
+                </attribute>
             </field>
         </field>
     </record>

--- a/stock_picking_filter_lot/views/stock_picking_type_view.xml
+++ b/stock_picking_filter_lot/views/stock_picking_type_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Le Filament
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <data>
+        <record id="stock_picking_type_add_filter_form" model="ir.ui.view">
+            <field name="name">stock_picking_type_add_filter_form</field>
+            <field name="model">stock.picking.type</field>
+            <field name="inherit_id" ref="stock.view_picking_type_form" />
+            <field name="arch" type="xml">
+                <field name="use_existing_lots" position="after">
+                    <field name="use_filter_lots" />
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
I have finally found a solution for #865 

This PR proposes to :
- add boolean use_filter_lots on stock_picking_type
- apply filter on lots only for picking where picking_type has use_filter enabled