### PR TITLE
[13.0][FIX] stock_picking_group_by_partner_by_carrier_by_date: group moves same day different time

### DIFF
--- a/stock_picking_group_by_partner_by_carrier_by_date/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier_by_date/models/stock_move.py
@@ -25,7 +25,7 @@ class StockMove(models.Model):
         domain = []
         if self._skip_assign_picking_group_domain_by_date():
             return domain
-        date_planned = self.date_expected
+        date_planned = self.date_expected.replace(hour=0, minute=0, second=0)
         date_planned_end = date_planned.replace(hour=23, minute=59, second=59)
         domain = [
             ("scheduled_date", "<=", date_planned_end),

--- a/stock_picking_group_by_partner_by_carrier_by_date/tests/test_grouping_by_date.py
+++ b/stock_picking_group_by_partner_by_carrier_by_date/tests/test_grouping_by_date.py
@@ -56,17 +56,17 @@ class TestGroupByDate(TestGroupByDateBase):
             p1, p2 = self._create_orders_and_pickings()
             self.assertEqual(p1, p2)
 
-        # Same day, inside time window
+        # Same day
         with freeze_time("2020-11-27 11:00:00"):
             p3, p4 = self._create_orders_and_pickings()
             self.assertEqual(p3, p4)
             self.assertEqual(p3, p1)
 
-        # Same day, out of time window
-        with freeze_time("2020-11-27 18:00:00"):
+        # Same day, one minute later
+        with freeze_time("2020-11-27 11:01:00"):
             p5, p6 = self._create_orders_and_pickings()
             self.assertEqual(p5, p6)
-            self.assertNotEqual(p5, p1)
+            self.assertEqual(p5, p1)
 
         # Delay 1st picking date
         p1.scheduled_date = "2020-11-27 18:30:00"


### PR DESCRIPTION
<s>The first commit add a test to reproduce the issue while the second one fix it.</s> squashed