### PR TITLE
[14.0] cherry-pick [FIX] stock_no_negative: Use product display_name instead of name

### DIFF
--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -43,7 +43,7 @@ class StockQuant(models.Model):
                         "not allowed for this product and/or location."
                     )
                     % (
-                        quant.product_id.name,
+                        quant.product_id.display_name,
                         msg_add,
                         quant.quantity,
                         quant.location_id.complete_name,


### PR DESCRIPTION
Cherry-pick of https://github.com/OCA/stock-logistics-workflow/pull/660 https://github.com/OCA/stock-logistics-workflow/pull/660/commits/ae6837722a7e945d5be1c3842454923bd44d6d6d

Use `product.display_name` instead of `product.name`
