### PR TITLE
[12.0][IMP] stock_picking_force_assign: Force pickings to not have to wait for purchase orders

### DIFF
--- a/stock_picking_force_assign/tests/test_stock_picking_force_assign.py
+++ b/stock_picking_force_assign/tests/test_stock_picking_force_assign.py
@@ -8,9 +8,31 @@ from odoo.exceptions import UserError
 class TestStockPickingForceAssign(TransactionCase):
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
+        route_buy = self.env['stock.location.route'].create({
+            'name': 'Buy',
+            'rule_ids': [(0, 0, {
+                'name': 'Buy',
+                'action': 'buy',
+                'picking_type_id': self.env.ref('stock.picking_type_in').id,
+                'location_id': self.env.ref('stock.stock_location_stock').id,
+            })]
+        })
+        route_mto = self.env.ref('stock.route_warehouse0_mto')
         self.product = self.env['product.product'].create({
             'name': 'stockable',
             'type': 'product',
+        })
+        self.product2 = self.product.copy({
+            'name': 'stockable-mto',
+            'purchase_ok': True,
+            'sale_ok': True,
+            'route_ids': [(6, 0, [route_mto.id, route_buy.id])],
+            'seller_ids': [(0, 0, {
+                'name': self.env.ref('base.main_partner').id,
+                'min_qty': 1,
+                'product_name': 'stockable',
+                'product_code': 'stockable',
+            })],
         })
         self.assigned_picking = self.env['stock.picking'].create({
             'name': 'Picking to unassign',
@@ -37,6 +59,26 @@ class TestStockPickingForceAssign(TransactionCase):
         })
         self.waiting_picking.action_assign()
         self.assertEqual(self.waiting_picking.state, 'confirmed')
+        self.waitanother_picking = self.env['stock.picking'].create({
+            'name': 'Picking to unchain',
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+            'location_dest_id':
+            self.env.ref('stock.stock_location_customers').id,
+            'move_lines': [(0, 0, {
+                'name': self.product2.name,
+                'product_id': self.product2.id,
+                'product_uom': self.product2.uom_id.id,
+                'product_uom_qty': 12,
+                'state': 'waiting',
+                'procure_method': 'make_to_order',
+            })],
+        })
+        self.env['stock.quant'].create({
+            'location_id': self.waitanother_picking.location_id.id,
+            'product_id': self.product2.id,
+            'quantity': 12,
+        })
 
     def test_happy_flow(self):
         """ Test unreservation works """
@@ -51,3 +93,14 @@ class TestStockPickingForceAssign(TransactionCase):
         self.assertEqual(self.assigned_picking.state, 'done')
         with self.assertRaises(UserError):
             self.waiting_picking.action_force_assign_pickings()
+
+    def test_waiting_another(self):
+        """ Test unchaining moves waiting another operation """
+        self.assertEqual(len(self.waitanother_picking), 1)
+        self.assertEqual(self.waitanother_picking.state, 'waiting')
+        self.assertEqual(
+            self.waitanother_picking.move_lines[0].procure_method, 'make_to_order')
+        self.waitanother_picking.action_force_assign_pickings()
+        self.assertNotEqual(self.waitanother_picking.state, 'waiting')
+        self.assertEqual(
+            self.waitanother_picking.move_lines[0].procure_method, 'make_to_stock')


### PR DESCRIPTION
This allows pickings to get unstuck when they are created with a make to order route.
Instead of waiting for stock from a linked purchase order, the procurement rule is set to make to stock, and the origin move is unlinked, so that stock from the same location will be considered.
If any moves are unreserved, those will be set to make to stock as well, so related moves will not get stuck waiting for another move either.