### PR TITLE
[14.0][IMP] stock_return_request: Apply putaway strategy for the stock move lines in returned picking

### DIFF
--- a/stock_return_request/models/stock_return_request.py
+++ b/stock_return_request/models/stock_return_request.py
@@ -224,7 +224,10 @@ class StockReturnRequest(models.Model):
             "product_uom_id": line.product_uom_id.id,
             "lot_id": line.lot_id.id,
             "location_id": return_move.location_id.id,
-            "location_dest_id": return_move.location_dest_id.id,
+            "location_dest_id": return_move.location_dest_id._get_putaway_strategy(
+                line.product_id
+            ).id
+            or return_move.location_dest_id.id,
             "qty_done": qty,
         }
         if not quant:


### PR DESCRIPTION
cc @Tecantiva TT32262

Ported from https://github.com/OCA/stock-logistics-workflow/pull/902

ping @chienandalu @CarlosRoca13 