### PR TITLE
[13][ADD] procurement_auto_create_group_carrier

### DIFF
--- a/procurement_auto_create_group_carrier/__init__.py
+++ b/procurement_auto_create_group_carrier/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/procurement_auto_create_group_carrier/__manifest__.py
+++ b/procurement_auto_create_group_carrier/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Procurement Auto Create Group Carrier",
+    "Summary": """Adds the delivery carrier in the procurement group data.""",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "category": "Warehouse Managemen",
+    "depends": [
+        "stock_picking_group_by_partner_by_carrier",
+        "procurement_auto_create_group",
+    ],
+    "installable": True,
+    "auto_install": True,
+    "license": "AGPL-3",
+}

--- a/procurement_auto_create_group_carrier/models/__init__.py
+++ b/procurement_auto_create_group_carrier/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_rule

--- a/procurement_auto_create_group_carrier/models/stock_rule.py
+++ b/procurement_auto_create_group_carrier/models/stock_rule.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class StockRule(models.Model):
+
+    _inherit = "stock.rule"
+
+    def _prepare_auto_procurement_group_data(self):
+        data = super()._prepare_auto_procurement_group_data()
+        if self.partner_address_id.property_delivery_carrier_id:
+            data["carrier_id"] = self.partner_address_id.property_delivery_carrier_id.id
+        return data

--- a/procurement_auto_create_group_carrier/readme/CONTRIBUTORS.rst
+++ b/procurement_auto_create_group_carrier/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Camptocamp:
+    * Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/procurement_auto_create_group_carrier/readme/DESCRIPTION.rst
+++ b/procurement_auto_create_group_carrier/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module is the glue between `procurement_auto_create_group` and `stock_picking_group_by_partner_by_carrier`.
+It stores the delivery carrier id into the procurement group.

--- a/procurement_auto_create_group_carrier/tests/__init__.py
+++ b/procurement_auto_create_group_carrier/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_procurement_auto_create_group_carrier

--- a/procurement_auto_create_group_carrier/tests/test_procurement_auto_create_group_carrier.py
+++ b/procurement_auto_create_group_carrier/tests/test_procurement_auto_create_group_carrier.py
@@ -1,0 +1,62 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests import SavepointCase
+
+
+class TestProcurementAutoCreateGroupCarrier(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.StockMove = cls.env["stock.move"]
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.location1 = cls.env.ref("stock.stock_location_stock")
+        cls.location2 = cls.env.ref("stock.stock_location_components")
+        cls.picking_type = cls.env.ref("stock.picking_type_internal")
+        cls.partner = cls.env["res.partner"].create({"name": "Partner"})
+        cls.carrier = cls.env.ref("delivery.normal_delivery_carrier")
+        cls.partner.property_delivery_carrier_id = cls.carrier
+        route_auto = cls.env["stock.location.route"].create(
+            {"name": "Auto Create Group"}
+        )
+        cls.rule_1 = cls.env["stock.rule"].create(
+            {
+                "name": "rule with autocreate",
+                "route_id": route_auto.id,
+                "auto_create_group": True,
+                "action": "pull_push",
+                "warehouse_id": cls.warehouse.id,
+                "picking_type_id": cls.picking_type.id,
+                "location_id": cls.location1.id,
+                "location_src_id": cls.location2.id,
+                "partner_address_id": cls.partner.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product 1",
+                "type": "product",
+                "route_ids": [(6, 0, [route_auto.id])],
+            }
+        )
+
+    def test_carrier_is_set_on_procurement_group(self):
+        move = self.StockMove.search([("product_id", "=", self.product.id)])
+        self.assertFalse(move)
+        self.env["procurement.group"].run(
+            [
+                self.env["procurement.group"].Procurement(
+                    self.product,
+                    5.0,
+                    self.product.uom_id,
+                    self.location1,
+                    "Test",
+                    "Odoo test",
+                    self.env.company,
+                    {},
+                )
+            ]
+        )
+        move = self.StockMove.search([("product_id", "=", self.product.id)])
+        self.assertEqual(move.group_id.carrier_id, self.carrier)

--- a/setup/procurement_auto_create_group_carrier/odoo/addons/procurement_auto_create_group_carrier
+++ b/setup/procurement_auto_create_group_carrier/odoo/addons/procurement_auto_create_group_carrier
@@ -1,0 +1,1 @@
+../../../../procurement_auto_create_group_carrier

--- a/setup/procurement_auto_create_group_carrier/setup.py
+++ b/setup/procurement_auto_create_group_carrier/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module is the glue between `procurement_auto_create_group` and
`stock_picking_group_by_partner_by_carrier`.
It stores the delivery carrier id into the procurement group.

It needs this change

* https://github.com/OCA/stock-logistics-warehouse/pull/1269

to work as intended.