### PR TITLE
[13.0][FIX] stock_picking_group_by_partner_by_carrier - Properly merge the procurement groups

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/README.rst
+++ b/stock_picking_group_by_partner_by_carrier/README.rst
@@ -36,7 +36,15 @@ Sale orders with a Shipping Policy set to 'When all products are ready' always
 get their own shipping.
 
 When the delivery slip is printed, the list of pending quantities to deliver
-is shown at the end, grouped by order.
+is shown at the end, grouped by sales order.
+
+The grouping can also be applied in case of external resupply. Moves at the
+destination of the same delivery address defined on the resupply stock rule
+will be grouped in a same delivery order.
+
+Note: The grouping is currently not propagated to the pulled internal moves if
+you don't use the module stock_available_to_promise_release in the wms
+repository.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.

--- a/stock_picking_group_by_partner_by_carrier/models/sale_order.py
+++ b/stock_picking_group_by_partner_by_carrier/models/sale_order.py
@@ -9,8 +9,10 @@ class SaleOrder(models.Model):
     def action_cancel(self):
         for sale_order in self:
             # change the context so we can intercept this in StockPicking.action_cancel
+            proc_groups = sale_order.order_line._get_procurement_group()
             super(
-                SaleOrder, sale_order.with_context(cancel_sale_id=sale_order.id)
+                SaleOrder,
+                sale_order.with_context(cancel_sale_group_ids=proc_groups.ids),
             ).action_cancel()
 
     def action_draft(self):

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -1,9 +1,9 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
-# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import re
 from collections import namedtuple
+from itertools import groupby
 
 from odoo import api, fields, models
 
@@ -30,28 +30,29 @@ class StockMove(models.Model):
         result = super(
             StockMove, self.with_context(picking_no_overwrite_partner_origin=1)
         )._assign_picking()
-        self.picking_id._merge_procurement_groups()
         return result
 
     def _assign_picking_post_process(self, new=False):
+        moves_by_picking = groupby(
+            sorted(self, key=lambda m: m.picking_id.id), key=lambda m: m.picking_id
+        )
+        for picking, imoves in moves_by_picking:
+            merged = picking._merge_procurement_groups()
+            if merged:
+                moves = self.browse(m.id for m in imoves)
+                moves.picking_id._update_merged_origin()
+                moves._on_assign_picking_message_link()
         res = super()._assign_picking_post_process(new=new)
-        if not new:
-            self._on_assign_picking_message_link()
         return res
 
     def _on_assign_picking_message_link(self):
-        picking = self.picking_id
-        picking.ensure_one()
-        sales = self.mapped("sale_line_id.order_id")
-        for sale in sales:
-            pattern = r"\b%s\b" % sale.name
-            if not re.search(pattern, picking.origin):
-                picking.origin += " " + sale.name
-                picking.message_post_with_view(
-                    "mail.message_origin_link",
-                    values={"self": picking, "origin": sale},
-                    subtype_id=self.env.ref("mail.mt_note").id,
-                )
+        sales = self.sale_line_id.order_id
+        if sales:
+            self.picking_id.message_post_with_view(
+                "mail.message_origin_link",
+                values={"self": self.picking_id, "origin": sales, "edit": True},
+                subtype_id=self.env.ref("mail.mt_note").id,
+            )
 
     def _domain_search_picking_for_assignation(self):
         domain = super()._domain_search_picking_for_assignation()

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
-# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from itertools import groupby
@@ -46,13 +46,15 @@ class StockPicking(models.Model):
         return super().write(values)
 
     def action_cancel(self):
-        cancel_sale_id = self.env.context.get("cancel_sale_id")
-        if cancel_sale_id:
+        # When a SO is canceled, cancel only moves related to this SO and not
+        # all moves of the picking
+        cancel_sale_group_ids = self.env.context.get("cancel_sale_group_ids")
+        if cancel_sale_group_ids:
             moves = self.move_lines.filtered(
-                lambda m: cancel_sale_id in m.original_group_id.sale_ids.ids
+                lambda m: m.original_group_id.id in cancel_sale_group_ids
                 and m.state not in ("done", "cancel")
             )
-            moves.with_context(cancel_sale_id=False)._action_cancel()
+            moves.with_context(cancel_sale_group_ids=False)._action_cancel()
             return True
         else:
             return super().action_cancel()
@@ -63,47 +65,85 @@ class StockPicking(models.Model):
             if not picking._is_grouping_disabled():
                 picking = picking.with_context(picking_no_copy_if_can_group=1)
             backorder = super(StockPicking, picking)._create_backorder()
-            if not picking._is_grouping_disabled():
+            if backorder and not picking._is_grouping_disabled():
                 backorder._merge_procurement_groups()
+                backorder._update_merged_origin()
             backorders |= backorder
         return backorders
 
+    def _prepare_merged_origin(self):
+        """Concatenate all origin together.
+        Note that in standard, only max 5 are displayed"""
+        moves = self.move_lines.filtered(lambda m: m.state != "cancel")
+        origins = moves.filtered(lambda m: m.origin).mapped("origin")
+        origins = sorted(list(set(origins)))
+        return " ".join(origins)
+
+    def _update_merged_origin(self):
+        self.origin = self._prepare_merged_origin()
+
     def _prepare_merge_procurement_group_values(self, move_groups):
+        """Build a new procurement group that is the merge of given procurement
+        group."""
         sales = move_groups.sale_id
         return {
             "sale_ids": [(6, 0, sales.ids)],
-            "name": ", ".join(move_groups.mapped("name")),
+            "name": ", ".join(move_groups.sorted("name").mapped("name")),
         }
 
     def _merge_procurement_groups(self):
-        for picking in self:
-            if picking._is_grouping_disabled():
-                continue
-            if picking.picking_type_id.code != "outgoing":
-                continue
-            base_group = picking.group_id
-            # If we have different sales in the line's group, it means moves
-            # have been merged in the same picking/group but they come from a
-            # different sale.
-            moves = picking.move_lines
-            moves_groups = moves.original_group_id
-            moves_sales = moves_groups.sale_id
-            group_sales = base_group.sale_ids
-            # if we have different sales, it means "_assign_picking" added
-            # moves from another SO in the picking
-            if moves_sales != group_sales:
-                # create a new joint group for the existing different groups
+        self.ensure_one()
+        if self._is_grouping_disabled():
+            return False
+        if self.picking_type_id.code != "outgoing":
+            return False
+        group_pickings = self.move_lines.group_id.picking_ids.filtered(
+            # Do no longer modify a printed or done transfer: they are
+            # started and their group is now fixed. It prevents keeping
+            # old, done sales orders in new groups forever
+            lambda picking: not (picking.printed or picking.state == "done")
+        )
+        moves = group_pickings.move_lines
+        base_group = self.group_id
+
+        # If we have moves of different procurement groups, it means moves
+        # have been merged in the same picking. In this case a new
+        # procurement group is required
+        if len(moves.original_group_id) > 1 and base_group in moves.original_group_id:
+            # Create a new procurement group
+            new_group = base_group.copy(
+                self._prepare_merge_procurement_group_values(moves.original_group_id)
+            )
+            group_pickings.move_lines.group_id = new_group
+            return True
+
+        new_moves = moves.filtered(lambda move: move.group_id != base_group)
+        old_moves = moves - new_moves
+        if new_moves.original_group_id - old_moves.original_group_id:
+            # A move with a new procurement group has been added. Adapt
+            # the procurement group
+            closed_pickings = self.move_lines.group_id.picking_ids.filtered(
+                lambda picking: picking.printed or picking.state == "done"
+            )
+            if closed_pickings:
+                # Do no longer modify a printed or done transfer: they
+                # are started and their group is now fixed. So create a
+                # new procurement group
                 new_group = base_group.copy(
-                    self._prepare_merge_procurement_group_values(moves_groups)
+                    self._prepare_merge_procurement_group_values(
+                        moves.original_group_id
+                    )
                 )
-                pickings = base_group.picking_ids.filtered(
-                    lambda picking: picking.picking_type_id.group_pickings
-                    # Do no longer modify a printed or done transfer: they are
-                    # started and their group is now fixed. It prevents keeping
-                    # old, done sales orders in new groups forever
-                    and not (picking.printed or picking.state == "done")
-                )
-                pickings.move_lines.group_id = new_group
+                group_pickings.move_lines.group_id = new_group
+                return True
+
+            base_group.write(
+                self._prepare_merge_procurement_group_values(moves.original_group_id)
+            )
+            new_moves.group_id = base_group
+            return True
+        new_moves.group_id = base_group
+        return False
 
     def copy(self, defaults=None):
         if self.env.context.get("picking_no_copy_if_can_group") and self.move_lines:

--- a/stock_picking_group_by_partner_by_carrier/readme/DESCRIPTION.rst
+++ b/stock_picking_group_by_partner_by_carrier/readme/DESCRIPTION.rst
@@ -10,3 +10,11 @@ get their own shipping.
 
 When the delivery slip is printed, the list of pending quantities to deliver
 is shown at the end, grouped by order.
+
+The grouping can also be applied in case of external resupply. Moves at the
+destination of the same delivery address defined on the resupply stock rule
+will be grouped in a same delivery order.
+
+Note: The grouping is currently not propagated to the pulled internal moves if
+you don't use the module stock_available_to_promise_release in the wms
+repository.

--- a/stock_picking_group_by_partner_by_carrier/tests/common.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/common.py
@@ -35,6 +35,16 @@ class TestGroupByBase(TestSale):
         quantity -= sum(quants.mapped("quantity"))
         self.env["stock.quant"]._update_available_quantity(product, location, quantity)
 
+    def _prepare_new_sale_order_line(self, amount=10.0):
+        product = self.env.ref("product.product_delivery_01")
+        return {
+            "name": product.name,
+            "product_id": product.id,
+            "product_uom_qty": amount,
+            "product_uom": product.uom_id.id,
+            "price_unit": product.list_price,
+        }
+
     def _get_new_sale_order(self, amount=10.0, partner=None, carrier=None):
         """Creates and returns a sale order with one default order line.
 
@@ -46,25 +56,12 @@ class TestGroupByBase(TestSale):
             carrier_id = False
         else:
             carrier_id = carrier.id
-        product = self.env.ref("product.product_delivery_01")
         sale_order_vals = {
             "partner_id": partner.id,
             "partner_invoice_id": partner.id,
             "partner_shipping_id": partner.id,
             "carrier_id": carrier_id,
-            "order_line": [
-                (
-                    0,
-                    0,
-                    {
-                        "name": product.name,
-                        "product_id": product.id,
-                        "product_uom_qty": amount,
-                        "product_uom": product.uom_id.id,
-                        "price_unit": product.list_price,
-                    },
-                )
-            ],
+            "order_line": [(0, 0, self._prepare_new_sale_order_line(amount))],
             "pricelist_id": self.env.ref("product.list0").id,
         }
         sale_order = self.env["sale.order"].create(sale_order_vals)

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping.py
@@ -191,26 +191,50 @@ class TestGroupBy(TestGroupByBase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        self.assertEqual(len(so1.picking_ids), 2)
-        self.assertEqual(len(so2.picking_ids), 2)
+        self.assertEqual(len(so1.picking_ids), 3)
+        self.assertEqual(len(so2.picking_ids), 3)
+        self.assertEqual(so1.picking_ids, so2.picking_ids)
         # ship should be shared between so1 and so2
-        ships = so1.picking_ids & so2.picking_ids
+        ships = (so1.picking_ids | so2.picking_ids).filtered(
+            lambda p: p.picking_type_code == "outgoing"
+        )
         self.assertEqual(len(ships), 1)
         self.assertEqual(ships.picking_type_id, warehouse.out_type_id)
         # but not picks
-        self.assertTrue(so1.picking_ids - so2.picking_ids)
-        self.assertTrue(so2.picking_ids - so1.picking_ids)
-        picks = (so1.picking_ids - so2.picking_ids) | (
-            so2.picking_ids - so1.picking_ids
-        )
-
+        # Note: When grouping the ships, all pulled internal moves should also
+        # be regrouped but this is currently not supported by this module. You
+        # need the stock_available_to_promise_release module to have this
+        # feature
+        picks = so1.picking_ids - ships
         self.assertEqual(len(picks), 2)
-        self.assertEqual(picks.mapped("picking_type_id"), warehouse.pick_type_id)
+        self.assertEqual(picks.picking_type_id, warehouse.pick_type_id)
+        # the group is the same on the move lines and picking
+        self.assertEqual(len(so1.picking_ids.group_id), 1)
+        self.assertEqual(so1.picking_ids.group_id, so1.picking_ids.move_lines.group_id)
+        # Add a line to so1
+        self.assertEqual(len(ships.move_lines), 2)
+        so1.order_line = [(0, 0, self._prepare_new_sale_order_line(4))]
+        self.assertEqual(len(ships.move_lines), 3)
+        # the group is the same on the move lines and picking
+        self.assertEqual(len(so1.picking_ids.group_id), 1)
+        self.assertEqual(so1.picking_ids.group_id, so1.picking_ids.move_lines.group_id)
+        # Add a line to so2
+        self.assertEqual(len(ships.move_lines), 3)
+        so1.order_line = [(0, 0, self._prepare_new_sale_order_line(4))]
+        self.assertEqual(len(ships.move_lines), 4)
+        # the group is the same on the move lines and picking
+        self.assertEqual(len(so2.picking_ids.group_id), 1)
+        self.assertEqual(so1.picking_ids.group_id, so2.picking_ids.move_lines.group_id)
 
     def test_delivery_multi_step_group_pick(self):
         """the warehouse uses pick + ship (with grouping enabled on pick)
 
-        -> shippings are grouped, as well as pickings"""
+        -> shippings are grouped, as well as pickings
+
+        Note that the grouping of pickings cannot be enabled, the grouping
+        option is only visible on the outgoing picking types. Grouping
+        conditions are based on some data that are only available on the
+        shipping."""
         warehouse = self.env.ref("stock.warehouse0")
         warehouse.delivery_steps = "pick_ship"
         warehouse.pick_type_id.group_pickings = True
@@ -232,39 +256,6 @@ class TestGroupBy(TestGroupByBase):
         self.assertEqual(len(picks), 1)
         self.assertFalse(so1.picking_ids - so2.picking_ids)
 
-    def test_delivery_multi_step_group_pick_pack(self):
-        """the warehouse uses pick + pack + ship (with grouping enabled on pack)
-
-        -> shippings are grouped, as well as pickings"""
-        warehouse = self.env.ref("stock.warehouse0")
-        warehouse.delivery_steps = "pick_pack_ship"
-        warehouse.pick_type_id.group_pickings = False
-        warehouse.pack_type_id.group_pickings = True
-        so1 = self._get_new_sale_order(carrier=self.carrier1)
-        so1.action_confirm()
-        so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
-        so2.action_confirm()
-        self.assertEqual(len(so1.picking_ids), 3)
-        self.assertEqual(len(so2.picking_ids), 3)
-        # ship & pack should be shared between so1 and so2, but not pick
-        all_transfers = so1.picking_ids | so2.picking_ids
-        common_transfers = so1.picking_ids & so2.picking_ids
-        self.assertEqual(len(all_transfers), 4)
-        self.assertEqual(len(common_transfers), 2)
-        ships = all_transfers.filtered(
-            lambda o: o.picking_type_id == warehouse.out_type_id
-        )
-        packs = all_transfers.filtered(
-            lambda o: o.picking_type_id == warehouse.pack_type_id
-        )
-        picks = all_transfers.filtered(
-            lambda o: o.picking_type_id == warehouse.pick_type_id
-        )
-        self.assertEqual(len(ships), 1)
-        self.assertEqual(len(packs), 1)
-        self.assertEqual(len(picks), 2)
-        self.assertTrue(so1.picking_ids - so2.picking_ids)
-
     def test_delivery_multi_step_cancel_so1(self):
         """the warehouse uses pick + ship. Cancel SO1
 
@@ -275,12 +266,14 @@ class TestGroupBy(TestGroupByBase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        ships = so1.picking_ids & so2.picking_ids
+        ships = (so1.picking_ids | so2.picking_ids).filtered(
+            lambda p: p.picking_type_code == "outgoing"
+        )
+        pick1 = so1.order_line.move_ids.move_orig_ids.picking_id
+        pick2 = so2.order_line.move_ids.move_orig_ids.picking_id
         so1.action_cancel()
         self.assertEqual(ships.state, "waiting")
-        pick1 = so1.picking_ids - ships
         self.assertEqual(pick1.state, "cancel")
-        pick2 = so2.picking_ids - ships
         self.assertEqual(pick2.state, "confirmed")
 
     def test_delivery_multi_step_cancel_so2(self):
@@ -293,12 +286,14 @@ class TestGroupBy(TestGroupByBase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        ships = so1.picking_ids & so2.picking_ids
+        ships = (so1.picking_ids | so2.picking_ids).filtered(
+            lambda p: p.picking_type_code == "outgoing"
+        )
+        pick1 = so1.order_line.move_ids.move_orig_ids.picking_id
+        pick2 = so2.order_line.move_ids.move_orig_ids.picking_id
         so2.action_cancel()
         self.assertEqual(ships.state, "waiting")
-        pick1 = so1.picking_ids - ships
         self.assertEqual(pick1.state, "confirmed")
-        pick2 = so2.picking_ids - ships
         self.assertEqual(pick2.state, "cancel")
 
     def test_delivery_multi_step_group_pick_cancel_so1(self):
@@ -353,12 +348,14 @@ class TestGroupBy(TestGroupByBase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        ships = so1.picking_ids & so2.picking_ids
+        ships = (so1.picking_ids | so2.picking_ids).filtered(
+            lambda p: p.picking_type_code == "outgoing"
+        )
         so1.action_cancel()
         so3 = self._get_new_sale_order(amount=12, carrier=self.carrier1)
         so3.action_confirm()
         self.assertTrue(ships in so3.picking_ids)
-        pick3 = so3.picking_ids - ships
+        pick3 = so3.order_line.move_ids.move_orig_ids.picking_id
         self.assertEqual(len(pick3), 1)
         self.assertEqual(pick3.state, "confirmed")
 
@@ -376,7 +373,7 @@ class TestGroupBy(TestGroupByBase):
         self.assertFalse(so1.picking_ids & so2.picking_ids)
 
     def test_sale_stock_merge_procurement_group(self):
-        """sale orders are merged, procurement groups are merged
+        """sales orders moves are merged, procurement groups are merged
 
         Ensure that the procurement group is linked with both SO
         and we find the stock.picking records from the SO.
@@ -414,10 +411,6 @@ class TestGroupBy(TestGroupByBase):
         picking.action_done()
 
         backorder = picking.backorder_ids
-        # as we no longer have anything of so1 in the backorder,
-        # now it's only related to so2
-        self.assertEqual(backorder.group_id.sale_ids, so2)
-        self.assertEqual(backorder.group_id.name, so2.name)
 
         so3 = self._get_new_sale_order(carrier=self.carrier1)
         so3.name = "SO3"


### PR DESCRIPTION
### Fixing the procurement group of pulled internal moves related to SO
There is an inconsistency depending on the usage of this module. The grouping configuration can only be enabled on a delivery order (SHIP). This updates the procurement group of that SHIP.

* If this module is used with the release of operation module, then this grouping module set the same procurement to all the moves. Then, at release of operations, the pulled moves that already all shares the same procurement group will be regrouped in the internal operations.
* Elif this module is used with the dynamic routing to reclassify internal moves inside the right operation, then as this grouping module set the same procurement to all the moves, the pulled moves that already all shares the same procurement group will be regrouped in the internal operations.
* Else, only the ship moves belong to the same procurement group but not the pulled internal moves as there were assigned to picking before the merge of the procurement group. Conceptually, the purpose of grouping the ship moves is because we want to make a single pick and pack for multiple SO. I have added a note in the readme about this current limitation.

Note: the fix here consist of ensuring that all the moves of all the pickings related to a procurement group have the same procurement group. This wasn't the case for added SO line after confirmation.

### Fixing the grouping of pulled internal moves related to inter-WH resupply
In case of a resupply delivery order (i.e. not linked to any SO), the grouping was effective but the procurement group was not merged properly preventing any pulled internal move to be regrouped

### Merge procurement group by name
The new regrouped procurement group will contain the name of all regrouped procurement group sorted by name

### Reduce the amount of created procurement group
Do not create a new procurement group when not necessary and a rename can be applied.
In case of backorder, the backorder will keep the same procurement group as the original picking. So from whatever sales you are, you will continue to see newly created backorder (previously if the SO was not part of that backorder you could not see it anymore from the SO). However, as soon as another SO is added in the backorder, that backorder will only be visible for the new concerned group of SO.

cc @jgrandguillaume @gurneyalex @sebalix 