### PR TITLE
[14.0][IMP] stock_partner_delivery_window: copy time window ids of partner

### DIFF
--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -152,3 +152,22 @@ class ResPartner(models.Model):
                 )
             res[partner.id] = "\n".join(opening_times_description)
         return res
+
+    def copy_data(self, default=None):
+        result = super().copy_data(default=default)[0]
+        not_time_windows = self.delivery_time_preference != "time_windows"
+        not_copy_windows = not_time_windows or "delivery_time_window_ids" in result
+        if not_copy_windows:
+            return [result]
+        values = [
+            {
+                "time_window_start": window_id.time_window_start,
+                "time_window_end": window_id.time_window_end,
+                "time_window_weekday_ids": [
+                    (4, wd_id.id, 0) for wd_id in window_id.time_window_weekday_ids
+                ],
+            }
+            for window_id in self.delivery_time_window_ids
+        ]
+        result["delivery_time_window_ids"] = [(0, 0, val) for val in values]
+        return [result]

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -161,3 +161,10 @@ class TestPartnerDeliveryWindow(SavepointCase):
         self.assertTrue(
             isinstance(onchange_res, dict) and "warning" in onchange_res.keys()
         )
+
+    def test_copy_partner_with_time_window_ids(self):
+        copied_partner = self.customer_time_window.copy()
+        expecting = len(self.customer_time_window.delivery_time_window_ids)
+        self.assertEqual(len(copied_partner.delivery_time_window_ids), expecting)
+        copied_partner = self.customer_working_days.copy()
+        self.assertFalse(copied_partner.delivery_time_window_ids)


### PR DESCRIPTION
When copying partner, if the partner's delivery time preference is time
window, time window ids should be copied as well.