### PR TITLE
[FIX][12.0] stock_move_manual_lot: various fixes

### DIFF
--- a/stock_move_manual_lot/__manifest__.py
+++ b/stock_move_manual_lot/__manifest__.py
@@ -3,10 +3,14 @@
 {
     "name": "Enforce manually selected lot",
     "summary": "Force the user to manually select a lot",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "category": "Stock",
     "website": "https://github.com/OCA/stock-logistics-workflow",
-    "author": "Hunki Enterprises BV, Odoo Community Association (OCA)",
+    "author": (
+        "Hunki Enterprises BV,"
+        "Opener B.V.,"
+        "Odoo Community Association (OCA)"
+    ),
     "license": "AGPL-3",
     "installable": True,
     "depends": [

--- a/stock_move_manual_lot/migrations/12.0.1.1.0/post-migration.py
+++ b/stock_move_manual_lot/migrations/12.0.1.1.0/post-migration.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Opener B.V. <stefan@opener.amsterdam>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    """
+    Sync manual lots with transferred lots
+
+    Sync manual lots to cover the following cases
+    * an untracked product transferred without setting a manual lot
+    * an update of a picking type to use manual lot selection
+    """
+    cr.execute(
+        """
+        update stock_move_line
+        set manual_lot_id=lot_id
+        where state = 'done'
+        and manual_lot_id is distinct from lot_id
+        """
+    )

--- a/stock_move_manual_lot/models/__init__.py
+++ b/stock_move_manual_lot/models/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Hunki Enterprises BV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import stock_move
 from . import stock_move_line
 from . import stock_picking
 from . import stock_picking_type

--- a/stock_move_manual_lot/models/stock_move.py
+++ b/stock_move_manual_lot/models/stock_move.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Opener B.V. <stefan@opener.amsterdam>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _do_unreserve(self):
+        """Prevent a loop between stock.move.line's unlink and this one that
+        occurs because we keep the move line after freeing it for a manual lot
+        assignment.
+        """
+        if not self:
+            return True
+        return super()._do_unreserve()

--- a/stock_move_manual_lot/models/stock_move_line.py
+++ b/stock_move_manual_lot/models/stock_move_line.py
@@ -133,7 +133,8 @@ class StockMoveLine(models.Model):
                     ml_to_ignore=self,
                 )
                 self.env.cr.execute(
-                    'select distinct picking_id from stock_move where write_date = %s', (now,),
+                    'select distinct picking_id from stock_move where write_date = %s',
+                    (now,),
                 )
                 updated_picking_ids = [row for row, in self.env.cr.fetchall() if row]
 

--- a/stock_move_manual_lot/models/stock_move_line.py
+++ b/stock_move_manual_lot/models/stock_move_line.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Hunki Enterprises BV
 # Copyright 2021 Opener B.V. <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-import operator
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools.float_utils import float_compare
@@ -110,11 +109,9 @@ class StockMoveLine(models.Model):
                     ml_to_ignore=self,
                 )
                 self.env.cr.execute(
-                    'select id from stock_picking where write_date = %s', (now,),
+                    'select distinct picking_id from stock_move where write_date = %s', (now,),
                 )
-                updated_picking_ids = list(map(
-                    operator.itemgetter(0), self.env.cr.fetchall(),
-                ))
+                updated_picking_ids = [row for row, in self.env.cr.fetchall() if row]
 
             this.lot_id = this.manual_lot_id
             if this.product_qty < product_qty:

--- a/stock_move_manual_lot/models/stock_picking.py
+++ b/stock_move_manual_lot/models/stock_picking.py
@@ -1,6 +1,9 @@
 # Copyright 2021 Hunki Enterprises BV
+# Copyright 2021 Opener B.V. <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 
 class StockPicking(models.Model):
@@ -11,12 +14,88 @@ class StockPicking(models.Model):
     )
 
     def button_validate(self):
-        """Call the logic to reserve lots selected in field
-        manual_lot_id. The result is an error if no manual lot
-        is selected for products with tracking!=none"""
-        self.mapped("move_line_ids")._reserve_manual_lot(
-            {
-                "manual_lot_id": True,
-            }
-        )
+        """Check for missing manually assigned lots"""
+        if self.picking_type_id.use_manual_lot_selection:
+            precision_digits = self.env['decimal.precision'].precision_get(
+                'Product Unit of Measure')
+            no_quantities_done = all(
+                float_is_zero(move_line.qty_done,
+                              precision_digits=precision_digits)
+                for move_line in self.move_line_ids.filtered(
+                    lambda m: m.state not in ('done', 'cancel')))
+            lines_to_check = self.move_line_ids
+            if not no_quantities_done:
+                lines_to_check = lines_to_check.filtered(
+                    lambda line: float_compare(
+                        line.qty_done, 0,
+                        precision_rounding=line.product_uom_id.rounding)
+                )
+            missing = lines_to_check.filtered(
+                lambda line: line.product_id.tracking != 'none'
+                and not line.manual_lot_id).mapped("product_id")
+            if missing:
+                raise UserError(
+                    _('Please supply a Lot/Serial number for products %s.') %
+                    ", ".join(product.name or product.default_code
+                              for product in missing))
         return super().button_validate()
+
+    def action_done(self):
+        """Keep manual lots up to date not to lose visibility.
+
+        Keep visibility of transferred lot in the case of
+        * an untracked product transferred without setting a manual lot
+        * an update of a picking type to use manual lot selection
+        """
+        res = super().action_done()
+        for ml in self.mapped("move_line_ids").filtered(
+                lambda ml: ml.lot_id != ml.manual_lot_id):
+            ml.manual_lot_id = ml.lot_id
+        return res
+
+    def write(self, vals):
+        """Encode move line quantities in the context if necessary.
+
+        If manual_lot_id is being written on the move lines, this could lead
+        to freeing move lines from the same picking that are also being
+        written in this very same call. We encode the original reserved
+        quantities of the move lines in the context so that they can be
+        rereserved for these quantities.
+        """
+        StockMoveLine = self.env['stock.move.line']
+        defer_delete_lines = StockMoveLine.browse([])
+        explicit_delete_lines = StockMoveLine.browse([])
+        writes_manual_lot_id = False
+        for command in (vals.get("move_line_ids", []) or []) + (
+                vals.get("move_line_ids_without_package", []) or []
+        ):
+            if writes_manual_lot_id and command[0] in (1, 2, 3, 4):
+                defer_delete_lines += StockMoveLine.browse(command[1])
+                if command[0] == 2:
+                    explicit_delete_lines += StockMoveLine.browse(command[1])
+            if command[0] in (0, 1) and 'manual_lot_id' in command[2]:
+                writes_manual_lot_id = True
+        if defer_delete_lines:
+            original_context = self.env.context
+            self = self.with_context(
+                manual_lot_move_lines=dict(
+                    (ml.id, ml.product_qty) for ml in defer_delete_lines)
+                )
+        result = super().write(vals)
+        explicit_delete_lines.unlink()
+        if defer_delete_lines:
+            self = self.with_context(original_context)
+            # Clean up any remaining zero qty move lines
+            move_lines = self.env["stock.move.line"].search(
+                [("id", "in", defer_delete_lines.ids), ("product_qty", "=", 0)])
+            if move_lines:
+                moves = move_lines.mapped("move_id")
+                move_lines.unlink()
+                moves._recompute_state()
+                for picking in moves.mapped("picking_id").with_context():
+                    try:
+                        with self.env.cr.savepoint():
+                            picking.action_assign()
+                    except UserError:
+                        pass
+        return result

--- a/stock_move_manual_lot/readme/CONTRIBUTORS.rst
+++ b/stock_move_manual_lot/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Holger Brunn <mail@hunki-enterprises.com> (https://hunki-enterprises.com)
+* Stefan Rijnhart <stefan@opener.amsterdam>

--- a/stock_move_manual_lot/tests/test_stock_move_manual_lot.py
+++ b/stock_move_manual_lot/tests/test_stock_move_manual_lot.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Opener B.V. <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from datetime import timedelta
 from uuid import uuid1
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
@@ -90,7 +91,12 @@ class TestStockMoveManualLot(TransactionCase):
         self.assertEqual(self.quant2.reserved_quantity, 1)
         self.assertEqual(picking2.move_line_ids.lot_id, self.lot2)
         self.assertTrue(self.picking.move_line_ids)
-        picking2.move_line_ids.manual_lot_id = self.lot1
+        self.picking.move_lines.write_date -= timedelta(minutes=1)
+        picking2.write({
+            "move_line_ids": [
+                (1, picking2.move_line_ids.id, {
+                    "manual_lot_id": self.lot1.id,
+                })]})
         self.assertTrue(self.picking.move_line_ids)
         self.assertEqual(self.picking.move_line_ids.lot_id, self.lot2)
         with self.assertRaises(

--- a/stock_move_manual_lot/tests/test_stock_move_manual_lot.py
+++ b/stock_move_manual_lot/tests/test_stock_move_manual_lot.py
@@ -15,15 +15,65 @@ class TestStockMoveManualLot(TransactionCase):
             }
         )
 
-    def _create_quant(self, lot):
-        return self.env["stock.quant"].create(
+    def _create_quant(self, lot=None, qty=1):
+        """Create any number of quants.
+
+        :param lot: create quants with these lot(s).
+        When None, create lots on the fly.
+        When empty recordset, create quants without lot.
+        :param qty: number of quants to create. If more than one lot is
+        passed, the number of lots overrides this.
+        """
+        if lot and len(lot) > qty:
+            qty = len(lot)
+        quants = self.env["stock.quant"]
+        for i in range(0, qty):
+            if lot and len(lot) > 0:
+                use_lot = lot[i]
+            elif lot is None:
+                use_lot = self._create_lot()
+            else:
+                use_lot = lot
+            quants += self.env["stock.quant"].create(
+                {
+                    "product_id": self.product.id,
+                    "quantity": 1,
+                    "location_id": self.location.id,
+                    "lot_id": use_lot.id,
+                }
+            )
+        return quants
+
+    def _create_picking(self, qty=1, confirm=True, assign=True):
+        picking = self.env["stock.picking"].create(
             {
-                "product_id": self.product.id,
-                "quantity": 1,
-                "location_id": self.picking.location_id.id,
-                "lot_id": lot.id,
+                "picking_type_id": self.picking_type.id,
+                "location_id": self.location.id,
+                "location_dest_id": self.dest_location.id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "testmove",
+                            "product_id": self.product.id,
+                            "product_uom": self.product.uom_id.id,
+                            "product_uom_qty": qty,
+                        },
+                    )
+                ],
             }
         )
+        if confirm:
+            picking.action_confirm()
+            if assign:
+                picking.action_assign()
+        return picking
+
+    def _backdate_moves(self):
+        """Moves are selected for reassignment based on their write dates"""
+        for move in self.env["stock.move"].search([]):
+            move.write_date -= timedelta(minutes=1)
 
     def setUp(self):
         super().setUp()
@@ -34,101 +84,82 @@ class TestStockMoveManualLot(TransactionCase):
                 "type": "product",
             }
         )
-        self.lot1 = self._create_lot()
-        self.lot2 = self._create_lot()
-        self.picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.env.ref("stock.picking_type_out").id,
-                "location_id": self.env.ref("stock.stock_location_stock").id,
-                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
-                "move_lines": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "testmove",
-                            "product_id": self.product.id,
-                            "product_uom": self.product.uom_id.id,
-                            "product_uom_qty": 1,
-                        },
-                    )
-                ],
-            }
-        )
-        self.picking.picking_type_id.use_manual_lot_selection = True
-        self.quant1 = self._create_quant(self.lot1)
-        self.picking.action_assign()
-        self.quant2 = self._create_quant(self.lot2)
+        self.picking_type = self.env.ref("stock.picking_type_out")
+        self.picking_type.use_manual_lot_selection = True
+        self.location = self.env.ref("stock.stock_location_stock")
+        self.dest_location = self.env.ref("stock.stock_location_customers")
 
     def test_01_force_manual_selection(self):
         """Picking can not be validated without manual lot selection"""
-        self.picking.move_line_ids.qty_done = self.picking.move_line_ids.product_qty
+        lot = self._create_quant().lot_id
+        picking = self._create_picking()
+        picking.move_line_ids.qty_done = picking.move_line_ids.product_qty
         with self.assertRaisesRegex(
                 UserError, "Serial"
         ), self.env.clear_upon_failure(), self.env.cr.savepoint():
-            self.picking.button_validate()
-        self.picking.move_line_ids.manual_lot_id = self.lot1
-        self.picking.button_validate()
-        self.assertEqual(self.picking.state, "done")
+            picking.button_validate()
+        picking.move_line_ids.manual_lot_id = lot
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
         self.assertEqual(
             self.env["stock.quant"]
             .search(
                 [
-                    ("location_id", "=", self.picking.location_dest_id.id),
+                    ("location_id", "=", self.dest_location.id),
                     ("product_id", "=", self.product.id),
                 ]
             )
             .mapped("lot_id"),
-            self.lot1,
+            lot,
         )
 
     def test_02_reassign_reservation(self):
         """Pickings are rereserved after their lots were fetched on another"""
-        self.assertEqual(self.quant1.reserved_quantity, 1)
-        picking2 = self.picking.copy()
-        self.assertFalse(self.quant2.reserved_quantity, 1)
-        picking2.action_assign()
-        self.assertEqual(self.quant2.reserved_quantity, 1)
-        self.assertEqual(picking2.move_line_ids.lot_id, self.lot2)
-        self.assertTrue(self.picking.move_line_ids)
-        self.picking.move_lines.write_date -= timedelta(minutes=1)
+        quant1 = self._create_quant()
+        picking = self._create_picking()
+        self.assertEqual(quant1.reserved_quantity, 1)
+        quant2 = self._create_quant()
+        picking2 = self._create_picking()
+        self.assertEqual(quant2.reserved_quantity, 1)
+        self.assertEqual(picking2.move_line_ids.lot_id, quant2.lot_id)
+        self.assertTrue(picking.move_line_ids)
+        self._backdate_moves()
         picking2.write({
             "move_line_ids": [
                 (1, picking2.move_line_ids.id, {
-                    "manual_lot_id": self.lot1.id,
+                    "manual_lot_id": quant1.lot_id.id,
                 })]})
-        self.assertTrue(self.picking.move_line_ids)
-        self.assertEqual(self.picking.move_line_ids.lot_id, self.lot2)
+        self.assertTrue(picking.move_line_ids)
+        self.assertEqual(picking.move_line_ids.lot_id, quant2.lot_id)
         with self.assertRaises(
             UserError
         ), self.env.clear_upon_failure(), self.env.cr.savepoint():
-            self.picking.button_validate()
+            picking.button_validate()
         self.assertEqual(
-            self.picking.move_lines.product_qty, self.picking.move_line_ids.product_qty
+            picking.move_lines.product_qty, picking.move_line_ids.product_qty
         )
-        self.picking.move_line_ids.update(
+        picking.move_line_ids.update(
             dict(
-                qty_done=self.picking.move_line_ids.product_qty,
-                manual_lot_id=self.lot2,
+                qty_done=picking.move_line_ids.product_qty,
+                manual_lot_id=quant2.lot_id,
             )
         )
         quant_domain = [
-            ("location_id", "=", self.picking.location_dest_id.id),
+            ("location_id", "=", self.dest_location.id),
             ("product_id", "=", self.product.id),
         ]
         self.assertFalse(self.env["stock.quant"].search(quant_domain))
-        self.picking.button_validate()
+        picking.button_validate()
         self.assertEqual(
-            self.env["stock.quant"].search(quant_domain).mapped("lot_id"), self.lot2
+            self.env["stock.quant"].search(quant_domain).lot_id, quant2.lot_id
         )
 
     def test_03_multiple_lines_flip(self):
         """Multiple lines (with each other's lots) can be reassigned at once.
         """
-        self.picking.action_cancel()
-        picking = self.picking.copy()
-        picking.move_lines.product_uom_qty = 2
-        picking.action_assign()
+        quant1, quant2 = self._create_quant(qty=2)
+        picking = self._create_picking(2)
+        self.assertEqual(quant1.reserved_quantity, 1)
         move_line1, move_line2 = picking.move_line_ids
         lot1 = move_line1.lot_id
         lot2 = move_line2.lot_id
@@ -155,8 +186,8 @@ class TestStockMoveManualLot(TransactionCase):
                 (1, picking.move_line_ids[1].id, {"manual_lot_id": lot1.id}),
             ],
         })
-        self.assertEqual(self.quant1.reserved_quantity, 1)
-        self.assertEqual(self.quant2.reserved_quantity, 1)
+        self.assertEqual(quant1.reserved_quantity, 1)
+        self.assertEqual(quant2.reserved_quantity, 1)
         self.assertTrue(picking.move_line_ids[0].lot_id)
         self.assertTrue(picking.move_line_ids[1].lot_id)
         self.assertEqual(
@@ -168,38 +199,27 @@ class TestStockMoveManualLot(TransactionCase):
         picking.button_validate()
         self.assertEqual(picking.state, "done")
 
-    def _setup_multiple_lines(self):
-        """
-        Replace self.picking with a picking with multiple lines, where one
-        line has a manual lot set
-        """
-        self.picking.action_cancel()
-        self.picking = self.picking.copy()
-        self.picking.move_lines.product_uom_qty = 2
-        self.picking.action_confirm()
-        self.picking.action_assign()
-        line_with_lot = self.picking.move_line_ids[0]
-        line_with_lot.manual_lot_id = self.lot1
-        line_without_lot = self.picking.move_line_ids[1]
-        return line_with_lot, line_without_lot
-
     def test_04_multiple_lines_move_lot(self):
         """
         Test that moving a manual lot from one line to the other works
         """
-        line_with_lot, line_without_lot = self._setup_multiple_lines()
-        self.picking.write({
+        self._create_quant(qty=2)
+        picking = self._create_picking(2)
+        line_with_lot, line_without_lot = picking.move_line_ids
+        lot1 = line_with_lot.lot_id
+        line_with_lot.manual_lot_id = lot1
+        picking.write({
             'move_line_ids': [
                 (1, line_without_lot.id, {
-                    'manual_lot_id': line_with_lot.manual_lot_id.id,
+                    'manual_lot_id': lot1.id,
                 }),
                 (1, line_with_lot.id, {
                     'manual_lot_id': False,
                 }),
             ],
         })
-        self.assertEqual(line_without_lot.lot_id, self.lot1)
-        other_line = self.picking.move_line_ids - line_without_lot
+        self.assertEqual(line_without_lot.lot_id, lot1)
+        other_line = picking.move_line_ids - line_without_lot
         self.assertTrue(other_line.lot_id)
         self.assertFalse(other_line.manual_lot_id)
         self.assertEqual(other_line.product_qty, 1)
@@ -208,8 +228,12 @@ class TestStockMoveManualLot(TransactionCase):
         """
         Test that just reassigning a manual lot from one line to the other works
         """
-        line_with_lot, line_without_lot = self._setup_multiple_lines()
-        self.picking.write({
+        self._create_quant(qty=2)
+        picking = self._create_picking(2)
+        line_with_lot, line_without_lot = picking.move_line_ids
+        lot1 = line_with_lot.lot_id
+        line_with_lot.manual_lot_id = lot1
+        picking.write({
             'move_line_ids': [
                 (1, line_without_lot.id, {
                     'manual_lot_id': line_with_lot.manual_lot_id.id,
@@ -219,8 +243,8 @@ class TestStockMoveManualLot(TransactionCase):
                 (4, line_with_lot.id, False),
             ],
         })
-        self.assertEqual(line_without_lot.lot_id, self.lot1)
-        other_line = self.picking.move_line_ids - line_without_lot
+        self.assertEqual(line_without_lot.lot_id, lot1)
+        other_line = picking.move_line_ids - line_without_lot
         self.assertTrue(other_line.lot_id)
         self.assertFalse(other_line.manual_lot_id)
         self.assertEqual(other_line.product_qty, 1)
@@ -230,8 +254,12 @@ class TestStockMoveManualLot(TransactionCase):
         Test that reassigning a manual lot from one line to the other works
         when deleting the first one
         """
-        line_with_lot, line_without_lot = self._setup_multiple_lines()
-        self.picking.write({
+        self._create_quant(qty=2)
+        picking = self._create_picking(2)
+        line_with_lot, line_without_lot = picking.move_line_ids
+        lot1 = line_with_lot.lot_id
+        line_with_lot.manual_lot_id = lot1
+        picking.write({
             'move_line_ids': [
                 (1, line_without_lot.id, {
                     'manual_lot_id': line_with_lot.manual_lot_id.id,
@@ -239,28 +267,25 @@ class TestStockMoveManualLot(TransactionCase):
                 (2, line_with_lot.id, False),
             ],
         })
-        self.assertEqual(line_without_lot.lot_id, self.lot1)
+        self.assertEqual(line_without_lot.lot_id, lot1)
         self.assertFalse(line_with_lot.exists())
 
     def test_07_serial_not_in_stock(self):
         """It is not allowed to assign a serial that is not in stock"""
-        lot3 = self.env["stock.production.lot"].create({
-            "name": "lot3",
-            "product_id": self.product.id,
-        })
+        self._create_quant()
+        picking = self._create_picking()
         with self.assertRaisesRegex(UserError, "than you have in stock"):
-            self.picking.move_line_ids.manual_lot_id = lot3
+            picking.move_line_ids.manual_lot_id = self._create_lot()
 
     def test_08_backorder(self):
         """An assigned move line on a picking can be left untransferred."""
-        self.picking.action_cancel()
-        picking = self.picking.copy()
+        picking = self._create_picking(confirm=False)
         line = picking.move_lines
         # Create up to 4 lines
         line.copy()
         line.copy()
         line.copy()
-        self._create_quant(self._create_lot())
+        self._create_quant(qty=3)
         picking.action_assign()
         # Of the 4 lines, 3 are assigned.
         ml1, ml2, ml3 = picking.move_line_ids
@@ -282,68 +307,74 @@ class TestStockMoveManualLot(TransactionCase):
         Manual lot is synced with lot_id automatically. If the manual lot
         is unset, reservation of stock without serial is enforced.
         """
+        lot1, lot2 = self._create_quant(qty=2).mapped("lot_id")
+        picking = self._create_picking()
         self.product.tracking = 'none'
-        self.picking.do_unreserve()
-        self.picking.action_assign()
-        self.assertTrue(self.picking.move_line_ids.manual_lot_id)
+        picking.do_unreserve()
+        picking.action_assign()
+        self.assertTrue(picking.move_line_ids.manual_lot_id)
         self.assertEqual(
-            self.picking.move_line_ids.manual_lot_id,
-            self.picking.move_line_ids.lot_id)
+            picking.move_line_ids.manual_lot_id,
+            picking.move_line_ids.lot_id)
         # Lot is synced with manual lot
-        self.picking.move_line_ids.manual_lot_id = self.lot2
-        self.assertEqual(self.picking.move_line_ids.lot_id, self.lot2)
+        picking.move_line_ids.manual_lot_id = lot2
+        self.assertEqual(picking.move_line_ids.lot_id, lot2)
         # Manual lot is synced with lot
-        self.picking.move_line_ids.lot_id = self.lot1
-        self.assertEqual(self.picking.move_line_ids.manual_lot_id, self.lot1)
+        picking.move_line_ids.lot_id = lot1
+        self.assertEqual(picking.move_line_ids.manual_lot_id, lot1)
         # Unsetting the serial raises if there is stock without serial.
         with self.assertRaisesRegex(
                 UserError, "than you have in stock"
         ), self.env.clear_upon_failure(), self.env.cr.savepoint():
-            self.picking.move_line_ids.manual_lot_id = False
+            picking.move_line_ids.manual_lot_id = False
 
         # Create stock without serial. Serial can now be unset
         self._create_quant(self.env["stock.production.lot"])
-        self.picking.move_line_ids.manual_lot_id = False
-        self.assertFalse(self.picking.move_line_ids.lot_id)
-        self.assertTrue(self.picking.move_line_ids.product_qty)
+        picking.move_line_ids.manual_lot_id = False
+        self.assertFalse(picking.move_line_ids.lot_id)
+        self.assertTrue(picking.move_line_ids.product_qty)
 
-        self.picking.move_line_ids.qty_done = (
-            self.picking.move_line_ids.product_qty
+        picking.move_line_ids.qty_done = (
+            picking.move_line_ids.product_qty
         )
-        self.picking.button_validate()
-        self.assertEqual(self.picking.state, "done")
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
 
     def test_10_unset_manual_lot(self):
         """Unsetting a manual lot does not unreserve the move line."""
-        ml = self.picking.move_line_ids
+        lot1 = self._create_quant(qty=2).mapped("lot_id")[0]
+        picking = self._create_picking()
+        ml = picking.move_line_ids
         ml.qty_done = ml.product_qty
-        self.picking.move_line_ids.manual_lot_id = self.lot1
-        self.picking.move_line_ids.manual_lot_id = False
+        picking.move_line_ids.manual_lot_id = lot1
+        picking.move_line_ids.manual_lot_id = False
         self.assertEqual(ml.product_qty, 1)
         with self.assertRaisesRegex(
                 UserError, "Serial"
         ), self.env.clear_upon_failure(), self.env.cr.savepoint():
-            self.picking.button_validate()
-        self.picking.move_line_ids.manual_lot_id = self.lot1
-        self.picking.button_validate()
-        self.assertEqual(self.picking.state, "done")
+            picking.button_validate()
+        picking.move_line_ids.manual_lot_id = lot1
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
 
     def test_11_no_manual_selection(self):
         """Manual lot is kept in sync with lot.
 
         Also, picking can be validated if manual lot is not set.
         """
-        self.picking.picking_type_id.use_manual_lot_selection = False
-        ml = self.picking.move_line_ids
+        lot2 = self._create_quant(qty=2).mapped("lot_id")[1]
+        picking = self._create_picking()
+        self.picking_type.use_manual_lot_selection = False
+        ml = picking.move_line_ids
         ml.qty_done = ml.product_qty
-        self.picking.move_line_ids.lot_id = self.lot2
-        self.assertEqual(self.picking.move_line_ids.manual_lot_id, self.lot2)
-        self.picking.move_line_ids.manual_lot_id = False
-        self.assertEqual(self.picking.move_line_ids.lot_id, self.lot2)
-        self.assertFalse(self.picking.move_line_ids.manual_lot_id)
-        self.assertEqual(self.picking.move_line_ids.lot_id, self.lot2)
-        self.picking.move_line_ids.qty_done = (
-            self.picking.move_line_ids.product_qty)
-        self.picking.button_validate()
-        self.assertEqual(self.picking.state, "done")
-        self.assertEqual(self.picking.move_line_ids.manual_lot_id, self.lot2)
+        picking.move_line_ids.lot_id = lot2
+        self.assertEqual(picking.move_line_ids.manual_lot_id, lot2)
+        picking.move_line_ids.manual_lot_id = False
+        self.assertEqual(picking.move_line_ids.lot_id, lot2)
+        self.assertFalse(picking.move_line_ids.manual_lot_id)
+        self.assertEqual(picking.move_line_ids.lot_id, lot2)
+        picking.move_line_ids.qty_done = (
+            picking.move_line_ids.product_qty)
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+        self.assertEqual(picking.move_line_ids.manual_lot_id, lot2)

--- a/stock_move_manual_lot/tests/test_stock_move_manual_lot.py
+++ b/stock_move_manual_lot/tests/test_stock_move_manual_lot.py
@@ -1,10 +1,29 @@
-# Copyright 2021 Hunki Enterprises BV
+# Copyright 2021 Opener B.V. <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from uuid import uuid1
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
 class TestStockMoveManualLot(TransactionCase):
+    def _create_lot(self):
+        return self.env["stock.production.lot"].create(
+            {
+                "name": str(uuid1()),
+                "product_id": self.product.id,
+            }
+        )
+
+    def _create_quant(self, lot):
+        return self.env["stock.quant"].create(
+            {
+                "product_id": self.product.id,
+                "quantity": 1,
+                "location_id": self.picking.location_id.id,
+                "lot_id": lot.id,
+            }
+        )
+
     def setUp(self):
         super().setUp()
         self.product = self.env["product.product"].create(
@@ -14,18 +33,8 @@ class TestStockMoveManualLot(TransactionCase):
                 "type": "product",
             }
         )
-        self.lot1 = self.env["stock.production.lot"].create(
-            {
-                "name": "lot1",
-                "product_id": self.product.id,
-            }
-        )
-        self.lot2 = self.env["stock.production.lot"].create(
-            {
-                "name": "lot2",
-                "product_id": self.product.id,
-            }
-        )
+        self.lot1 = self._create_lot()
+        self.lot2 = self._create_lot()
         self.picking = self.env["stock.picking"].create(
             {
                 "picking_type_id": self.env.ref("stock.picking_type_out").id,
@@ -46,28 +55,15 @@ class TestStockMoveManualLot(TransactionCase):
             }
         )
         self.picking.picking_type_id.use_manual_lot_selection = True
-        self.quant = self.env["stock.quant"].create(
-            {
-                "product_id": self.product.id,
-                "quantity": 1,
-                "location_id": self.picking.location_id.id,
-                "lot_id": self.lot1.id,
-            }
-        )
+        self.quant1 = self._create_quant(self.lot1)
         self.picking.action_assign()
-        self.quant = self.env["stock.quant"].create(
-            {
-                "product_id": self.product.id,
-                "quantity": 1,
-                "location_id": self.picking.location_id.id,
-                "lot_id": self.lot2.id,
-            }
-        )
+        self.quant2 = self._create_quant(self.lot2)
 
-    def test_force_manual_selection(self):
+    def test_01_force_manual_selection(self):
+        """Picking can not be validated without manual lot selection"""
         self.picking.move_line_ids.qty_done = self.picking.move_line_ids.product_qty
-        with self.assertRaises(
-            UserError
+        with self.assertRaisesRegex(
+                UserError, "Serial"
         ), self.env.clear_upon_failure(), self.env.cr.savepoint():
             self.picking.button_validate()
         self.picking.move_line_ids.manual_lot_id = self.lot1
@@ -85,9 +81,13 @@ class TestStockMoveManualLot(TransactionCase):
             self.lot1,
         )
 
-    def test_reassign_reservation(self):
+    def test_02_reassign_reservation(self):
+        """Pickings are rereserved after their lots were fetched on another"""
+        self.assertEqual(self.quant1.reserved_quantity, 1)
         picking2 = self.picking.copy()
+        self.assertFalse(self.quant2.reserved_quantity, 1)
         picking2.action_assign()
+        self.assertEqual(self.quant2.reserved_quantity, 1)
         self.assertEqual(picking2.move_line_ids.lot_id, self.lot2)
         self.assertTrue(self.picking.move_line_ids)
         picking2.move_line_ids.manual_lot_id = self.lot1
@@ -115,3 +115,205 @@ class TestStockMoveManualLot(TransactionCase):
         self.assertEqual(
             self.env["stock.quant"].search(quant_domain).mapped("lot_id"), self.lot2
         )
+
+    def test_03_multiple_lines_flip(self):
+        """Multiple lines (with each other's lots) can be reassigned at once.
+        """
+        self.picking.action_cancel()
+        picking = self.picking.copy()
+        picking.move_lines.product_uom_qty = 2
+        picking.action_assign()
+        move_line1, move_line2 = picking.move_line_ids
+        lot1 = move_line1.lot_id
+        lot2 = move_line2.lot_id
+        picking.write({
+            "move_line_ids": [
+                (1, picking.move_line_ids[1].id, {"manual_lot_id": lot1.id}),
+            ],
+        })
+        picking.write({
+            "move_line_ids": [
+                (1, picking.move_line_ids[0].id, {"manual_lot_id": lot1.id}),
+                (1, picking.move_line_ids[1].id, {"manual_lot_id": False}),
+            ],
+        })
+        picking.write({
+            "move_line_ids": [
+                (1, picking.move_line_ids[0].id, {"manual_lot_id": False}),
+                (1, picking.move_line_ids[1].id, {"manual_lot_id": lot1.id}),
+            ],
+        })
+        picking.write({
+            "move_line_ids": [
+                (1, picking.move_line_ids[0].id, {"manual_lot_id": lot2.id}),
+                (1, picking.move_line_ids[1].id, {"manual_lot_id": lot1.id}),
+            ],
+        })
+        self.assertEqual(self.quant1.reserved_quantity, 1)
+        self.assertEqual(self.quant2.reserved_quantity, 1)
+        self.assertTrue(picking.move_line_ids[0].lot_id)
+        self.assertTrue(picking.move_line_ids[1].lot_id)
+        self.assertEqual(
+            picking.move_line_ids.mapped("lot_id"), lot1 + lot2)
+        self.assertEqual(picking.move_line_ids[0].product_uom_qty, 1)
+        self.assertEqual(picking.move_line_ids[1].product_uom_qty, 1)
+        picking.move_line_ids[0].qty_done = picking.move_line_ids[0].product_qty
+        picking.move_line_ids[1].qty_done = picking.move_line_ids[1].product_qty
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+
+    def _setup_multiple_lines(self):
+        """
+        Replace self.picking with a picking with multiple lines, where one
+        line has a manual lot set
+        """
+        self.picking.action_cancel()
+        self.picking = self.picking.copy()
+        self.picking.move_lines.product_uom_qty = 2
+        self.picking.action_confirm()
+        self.picking.action_assign()
+        line_with_lot = self.picking.move_line_ids[0]
+        line_with_lot.manual_lot_id = self.lot1
+        line_without_lot = self.picking.move_line_ids[1]
+        return line_with_lot, line_without_lot
+
+    def test_04_multiple_lines_move_lot(self):
+        """
+        Test that moving a manual lot from one line to the other works
+        """
+        line_with_lot, line_without_lot = self._setup_multiple_lines()
+        self.picking.write({
+            'move_line_ids': [
+                (1, line_without_lot.id, {
+                    'manual_lot_id': line_with_lot.manual_lot_id.id,
+                }),
+                (1, line_with_lot.id, {
+                    'manual_lot_id': False,
+                }),
+            ],
+        })
+        self.assertEqual(line_without_lot.lot_id, self.lot1)
+        other_line = self.picking.move_line_ids - line_without_lot
+        self.assertTrue(other_line.lot_id)
+        self.assertFalse(other_line.manual_lot_id)
+        self.assertEqual(other_line.product_qty, 1)
+
+    def test_05_multiple_lines_assign(self):
+        """
+        Test that just reassigning a manual lot from one line to the other works
+        """
+        line_with_lot, line_without_lot = self._setup_multiple_lines()
+        self.picking.write({
+            'move_line_ids': [
+                (1, line_without_lot.id, {
+                    'manual_lot_id': line_with_lot.manual_lot_id.id,
+                }),
+                # this is what the webclient sends when we don't change
+                # the line
+                (4, line_with_lot.id, False),
+            ],
+        })
+        self.assertEqual(line_without_lot.lot_id, self.lot1)
+        other_line = self.picking.move_line_ids - line_without_lot
+        self.assertTrue(other_line.lot_id)
+        self.assertFalse(other_line.manual_lot_id)
+        self.assertEqual(other_line.product_qty, 1)
+
+    def test_06_multiple_lines_delete(self):
+        """
+        Test that reassigning a manual lot from one line to the other works
+        when deleting the first one
+        """
+        line_with_lot, line_without_lot = self._setup_multiple_lines()
+        self.picking.write({
+            'move_line_ids': [
+                (1, line_without_lot.id, {
+                    'manual_lot_id': line_with_lot.manual_lot_id.id,
+                }),
+                (2, line_with_lot.id, False),
+            ],
+        })
+        self.assertEqual(line_without_lot.lot_id, self.lot1)
+        self.assertFalse(line_with_lot.exists())
+
+    def test_07_serial_not_in_stock(self):
+        """It is not allowed to assign a serial that is not in stock"""
+        lot3 = self.env["stock.production.lot"].create({
+            "name": "lot3",
+            "product_id": self.product.id,
+        })
+        with self.assertRaisesRegex(UserError, "than you have in stock"):
+            self.picking.move_line_ids.manual_lot_id = lot3
+
+    def test_08_backorder(self):
+        """An assigned move line on a picking can be left untransferred."""
+        self.picking.action_cancel()
+        picking = self.picking.copy()
+        line = picking.move_lines
+        # Create up to 4 lines
+        line.copy()
+        line.copy()
+        line.copy()
+        self._create_quant(self._create_lot())
+        picking.action_assign()
+        # Of the 4 lines, 3 are assigned.
+        ml1, ml2, ml3 = picking.move_line_ids
+        # We're transferring only the first move line
+        ml1.qty_done = ml1.product_qty
+        ml1.manual_lot_id = ml1.lot_id
+        # 2nd move line is assigned a manual lot, but the 3rd one is not
+        ml2.manual_lot_id = ml2.lot_id
+        res = picking.button_validate()
+        self.env[res["res_model"]].browse(res["res_id"]).process()
+        backorder = self.env["stock.picking"].search(
+            [("backorder_id", "=", picking.id)])
+        self.assertEqual(backorder.move_lines.product_uom_qty, 3)
+        self.assertEqual(backorder.move_lines.reserved_availability, 2)
+
+    def test_09_non_tracked_product(self):
+        """Non tracked product, but having lots in stock
+
+        Currently, no manual lot is required even if the picking type is marked
+        for manual lots and the reservation has a lot.
+        """
+        self.product.tracking = 'none'
+        self.picking.move_line_ids.qty_done = (
+            self.picking.move_line_ids.product_qty
+        )
+        self.picking.button_validate()
+        self.assertEqual(self.picking.move_line_ids.manual_lot_id, self.lot1)
+
+    def test_10_unset_manual_lot(self):
+        """Unsetting a manual lot does not unreserve the move line."""
+        ml = self.picking.move_line_ids
+        ml.qty_done = ml.product_qty
+        self.picking.move_line_ids.manual_lot_id = self.lot1
+        self.picking.move_line_ids.manual_lot_id = False
+        self.assertEqual(ml.product_qty, 1)
+        with self.assertRaisesRegex(
+                UserError, "Serial"
+        ), self.env.clear_upon_failure(), self.env.cr.savepoint():
+            self.picking.button_validate()
+        self.picking.move_line_ids.manual_lot_id = self.lot1
+        self.picking.button_validate()
+        self.assertEqual(self.picking.state, "done")
+
+    def test_11_no_manual_selection(self):
+        """Manual lot is kept in sync with lot.
+
+        Also, picking can be validated if manual lot is not set.
+        """
+        self.picking.picking_type_id.use_manual_lot_selection = False
+        ml = self.picking.move_line_ids
+        ml.qty_done = ml.product_qty
+        self.picking.move_line_ids.lot_id = self.lot2
+        self.assertEqual(self.picking.move_line_ids.manual_lot_id, self.lot2)
+        self.picking.move_line_ids.manual_lot_id = False
+        self.assertEqual(self.picking.move_line_ids.lot_id, self.lot2)
+        self.assertFalse(self.picking.move_line_ids.manual_lot_id)
+        self.assertEqual(self.picking.move_line_ids.lot_id, self.lot2)
+        self.picking.move_line_ids.qty_done = (
+            self.picking.move_line_ids.product_qty)
+        self.picking.button_validate()
+        self.assertEqual(self.picking.state, "done")
+        self.assertEqual(self.picking.move_line_ids.manual_lot_id, self.lot2)


### PR DESCRIPTION
The original module submitted by our team in https://github.com/OCA/stock-logistics-workflow/pull/833 has some severe issues, mainly with regards to swapping serials between move lines within the same picking. This PR is a rebase of our accumulative fixes and is what is currently running on our relatively large production setup. It is a collaborative effort between @hbrunn and myself

Fixes #905
