### PR TITLE
[14.0] [MIG] stock_picking_mass_action: Port PR form 12.0 to 14.0

### DIFF
--- a/stock_picking_mass_action/models/stock_picking.py
+++ b/stock_picking_mass_action/models/stock_picking.py
@@ -16,6 +16,30 @@ class StockPicking(Model):
         records = self.search(domain, order="scheduled_date")
         records.action_assign()
 
+    def _log_activity_get_documents(
+        self,
+        orig_obj_changes,
+        stream_field,
+        stream,
+        sorted_method=False,
+        groupby_method=False,
+    ):
+        """Avoid error in method:
+        env['stock.backorder.confirmation']._process(cancel_backorder=True)
+        if mixing complete picking with partial picking and select cancel
+        backorder
+        """
+        if not orig_obj_changes:
+            return {}
+        else:
+            return super()._log_activity_get_documents(
+                orig_obj_changes,
+                stream_field,
+                stream,
+                sorted_method=sorted_method,
+                groupby_method=groupby_method,
+            )
+
     def action_immediate_transfer_wizard(self):
         view = self.env.ref("stock.view_immediate_transfer")
         wiz = self.env["stock.immediate.transfer"].create(

--- a/stock_picking_mass_action/wizard/mass_action.py
+++ b/stock_picking_mass_action/wizard/mass_action.py
@@ -50,7 +50,6 @@ class StockPickingMassAction(TransientModel):
 
     def mass_action(self):
         self.ensure_one()
-
         # Get draft pickings and confirm them if asked
         if self.confirm:
             draft_picking_lst = self.picking_ids.filtered(
@@ -80,4 +79,4 @@ class StockPickingMassAction(TransientModel):
                 return assigned_picking_lst.action_immediate_transfer_wizard()
             if any([pick._check_backorder() for pick in assigned_picking_lst]):
                 return assigned_picking_lst._action_generate_backorder_wizard()
-            assigned_picking_lst.button_validate()
+            assigned_picking_lst._action_done()


### PR DESCRIPTION
Migrate 14.0:
* [[14.0][MIG] - stock_picking_mass_action](https://github.com/OCA/stock-logistics-workflow/pull/849)
Port PR from 12.0 to 14.0
* [[12.0][FIX] stock_picking_mass_action: Error mass picking transfer mixing](https://github.com/OCA/stock-logistics-workflow/pull/626)

