### PR TITLE
[FIX] Permit autofill when avoid_lot_assignment is TRUE on picking_type

### DIFF
--- a/stock_move_line_auto_fill/models/stock_picking.py
+++ b/stock_move_line_auto_fill/models/stock_picking.py
@@ -54,7 +54,7 @@ class StockPicking(models.Model):
                 and not op.qty_done
                 and (
                     not op.lots_visible
-                    or not op.picking_id.picking_type_id.avoid_lot_assignment
+                    or op.picking_id.picking_type_id.avoid_lot_assignment
                 )
             )
         )


### PR DESCRIPTION
Problem: auto_fill doesn't work when products are tracked (lot) and _avoid_lot_assignment_ is TRUE on picking_type.
If I understand well, I propose this fix