### PR TITLE
[FIX] delete reserved move lines with qty done = 0 from source picking

### DIFF
--- a/stock_split_picking/models/stock_picking.py
+++ b/stock_split_picking/models/stock_picking.py
@@ -51,6 +51,8 @@ class StockPicking(models.Model):
                                     {'product_uom_qty': move_line.qty_done})
                             except UserError:
                                 pass
+                        elif not move_line.qty_done:
+                            move_line.unlink()
                     new_moves |= self.env['stock.move'].browse(new_move_id)
 
             # If we have new moves to move, create the backorder picking


### PR DESCRIPTION
When splitting a move with many reserved quantity has many move lines (e.g. different locations) by mode qty_done the move lines with qty done = 0 will not be removed from source picking, which will lead to an overshippment. 

How to reproduce:
1. Configure warehouse having different locations
2. Create a product, update stock quantity at different locations loc1 -> quantity =1, loc2 -> quantity =1, loc3 -> quantity =1
3. Create an sales order add a line with quantity 3 of the product and confirm
4. Go to picking, you will see 3 move lines with the ordered product, one per location
5. Edit picking and set quantity done = 1 at first move line
![image](https://user-images.githubusercontent.com/24382867/151869611-0ce56889-3db1-488c-82ce-dd24e0c97dbd.png)
6. Click on split and choose mode "Done quantites" and click split
![image](https://user-images.githubusercontent.com/24382867/151870007-78651a06-5395-49cf-b365-766e96d4a1f7.png)
7. Check source picking: the second and third line with quantity done zero will be kept and reservation will not be cancelled 
![image](https://user-images.githubusercontent.com/24382867/151870418-0dff5d54-9118-4b3f-b2ca-16765683e295.png)
![image](https://user-images.githubusercontent.com/24382867/151870368-ce4533ca-b326-40c8-8de7-a3cc08218a8c.png)
8. New picking with initial demand of 2 will be created, which will lead to an overshipment.
![image](https://user-images.githubusercontent.com/24382867/151870673-5b692e41-15f1-4968-bb81-dcdd57b66604.png)




