### PR TITLE
[13.0][FIX] stock_lot_scrap: scraps with no lot

### DIFF
--- a/stock_lot_scrap/models/stock_scrap.py
+++ b/stock_lot_scrap/models/stock_scrap.py
@@ -11,7 +11,8 @@ class StockScrap(models.Model):
 
     def action_validate(self):
         self.ensure_one()
-        self.lot_id.message_post(
-            body=_("Lot was scrapped by <b>%s</b>.") % self.env.user.name
-        )
+        if self.lot_id:
+            self.lot_id.message_post(
+                body=_("Lot was scrapped by <b>%s</b>.") % self.env.user.name
+            )
         return super().action_validate()


### PR DESCRIPTION
If a scrap has no lot, the action will fail as message_post ensures that
at least one record is provided.

cc @Tecnativa

ping @CarlosRoca13 @victoralmau 