### PR TITLE
[14.0][ADD] stock_picking_invoice_link: add context key to get_stock_moves_link_invoice in order to allow to use it from external script

### DIFF
--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -10,11 +10,15 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     def get_stock_moves_link_invoice(self):
+        skip_check_invoice_state = self.env.context.get(
+            "skip_check_invoice_state", False
+        )
         return self.mapped("move_ids").filtered(
             lambda mv: (
                 mv.state == "done"
                 and not (
-                    any(
+                    not skip_check_invoice_state
+                    and any(
                         inv.state != "cancel"
                         for inv in mv.invoice_line_ids.mapped("move_id")
                     )


### PR DESCRIPTION
This is useful when the module is installed in a database already containing invoices not in state cancel. In this way the method `get_stock_moves_link_invoice` can be also used from an external script in order to fill missing data useful i.e from https://github.com/OCA/account-invoice-reporting/tree/14.0/account_invoice_production_lot to show on their invoice lines the delivered production lots.