### PR TITLE
[10.0] stock_no_negative: backport allow_negative_stock on stock.location

### DIFF
--- a/stock_no_negative/__manifest__.py
+++ b/stock_no_negative/__manifest__.py
@@ -13,6 +13,6 @@
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'http://www.akretion.com',
     'depends': ['stock'],
-    'data': ['views/product.xml'],
+    'data': ['views/product.xml', 'views/stock_location.xml'],
     'installable': True,
 }

--- a/stock_no_negative/models/__init__.py
+++ b/stock_no_negative/models/__init__.py
@@ -4,4 +4,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import product
+from . import stock_location
 from . import stock_quant

--- a/stock_no_negative/models/stock_location.py
+++ b/stock_no_negative/models/stock_location.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2022 ForgeFlow (https://www.forgeflow.com)
+# @author Jordi Ballester <jordi.ballester@forgeflow.com.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    allow_negative_stock = fields.Boolean(
+        help="Allow negative stock levels for the stockable products "
+        "attached to this location.",
+    )

--- a/stock_no_negative/tests/test_stock_no_negative.py
+++ b/stock_no_negative/tests/test_stock_no_negative.py
@@ -19,9 +19,9 @@ class TestStockNoNegative(common.TransactionCase):
         super(TestStockNoNegative, self).setUp()
         self.product_model = self.env['product.product']
         self.product_ctg_model = self.env['product.category']
-        self.picking_type_id = self.env.ref('stock.picking_type_out')
-        self.location_id = self.env.ref('stock.stock_location_stock')
-        self.location_dest_id = self.env.ref('stock.stock_location_customers')
+        self.picking_type = self.env.ref('stock.picking_type_out')
+        self.location = self.env.ref('stock.stock_location_stock')
+        self.location_dest = self.env.ref('stock.stock_location_customers')
         # Create product category
         self.product_ctg = self._create_product_category()
         # Create a Product
@@ -44,10 +44,10 @@ class TestStockNoNegative(common.TransactionCase):
 
     def _create_picking(self):
         self.stock_picking = self.env['stock.picking'].create({
-            'picking_type_id': self.picking_type_id.id,
+            'picking_type_id': self.picking_type.id,
             'move_type': 'direct',
-            'location_id': self.location_id.id,
-            'location_dest_id': self.location_dest_id.id
+            'location_id': self.location.id,
+            'location_dest_id': self.location_dest.id
         })
 
         self.stock_move = self.env['stock.move'].create({
@@ -57,14 +57,16 @@ class TestStockNoNegative(common.TransactionCase):
             'product_uom': self.product.uom_id.id,
             'picking_id': self.stock_picking.id,
             'state': 'draft',
-            'location_id': self.location_id.id,
-            'location_dest_id': self.location_dest_id.id
+            'location_id': self.location.id,
+            'location_dest_id': self.location_dest.id
         })
 
     def test_check_constrains(self):
         """Assert that constraint is raised when user
         tries to validate the stock operation which would
         make the stock level of the product negative """
+        self.product.product_tmpl_id.write({'allow_negative_stock': False})
+        self.location.write({'allow_negative_stock': False})
         self.stock_picking.action_confirm()
         self.stock_picking.action_assign()
         self.stock_picking.force_assign()
@@ -75,10 +77,11 @@ class TestStockNoNegative(common.TransactionCase):
             self.stock_immediate_transfer.with_context(
                 test_stock_no_negative=True).process()
 
-    def test_true_allow_negative_stock(self):
+    def test_true_allow_negative_stock_product(self):
         """Assert that negative stock levels are allowed when
         the allow_negative_stock is set active in the product"""
         self.product.product_tmpl_id.write({'allow_negative_stock': True})
+        self.location.write({'allow_negative_stock': False})
         self.stock_picking.action_confirm()
         self.stock_picking.action_assign()
         self.stock_picking.force_assign()
@@ -87,9 +90,25 @@ class TestStockNoNegative(common.TransactionCase):
             create({'pick_id': self.stock_picking.id})
         self.stock_immediate_transfer.with_context(
             test_stock_no_negative=True).process()
-        quant = self.env['stock.quant'].search([('product_id', '=',
-                                                 self.product.id),
-                                                ('location_id', '=',
-                                                 self.location_id.id)])
-        self.assertEqual(quant.qty,
-                         -self.stock_move.product_uom_qty)
+        quant = self.env['stock.quant'].search([
+            ('product_id', '=', self.product.id),
+            ('location_id', '=', self.location.id)])
+        self.assertEqual(quant.qty, -self.stock_move.product_uom_qty)
+
+    def test_true_allow_negative_stock_location(self):
+        """Assert that negative stock levels are allowed when
+        the allow_negative_stock is set active in the location"""
+        self.product.product_tmpl_id.write({'allow_negative_stock': False})
+        self.location.write({'allow_negative_stock': True})
+        self.stock_picking.action_confirm()
+        self.stock_picking.action_assign()
+        self.stock_picking.force_assign()
+        self.stock_picking.do_new_transfer()
+        self.stock_immediate_transfer = self.env['stock.immediate.transfer'].\
+            create({'pick_id': self.stock_picking.id})
+        self.stock_immediate_transfer.with_context(
+            test_stock_no_negative=True).process()
+        quant = self.env['stock.quant'].search([
+            ('product_id', '=', self.product.id),
+            ('location_id', '=', self.location.id)])
+        self.assertEqual(quant.qty, -self.stock_move.product_uom_qty)

--- a/stock_no_negative/views/stock_location.xml
+++ b/stock_no_negative/views/stock_location.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2018 Akretion (http://www.akretion.com/)
+  @author Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="view_location_form" model="ir.ui.view">
+        <field name="name">stock.location.form.allow_negative_stock</field>
+        <field name="model">stock.location</field>
+        <field name="inherit_id" ref="stock.view_location_form" />
+        <field name="arch" type="xml">
+            <field name="usage" position="after">
+                <field
+                    name="allow_negative_stock"
+                    attrs="{'invisible': [('usage', 'not in', ['internal', 'transit'])]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Rename variables in test: a recordset should not be designated by a variable that ends with "_id"!