### PR TITLE
[14.0] stock_picking_group_by_partner_by_carrier: deliveryslip report - fix SO sections

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -52,6 +52,12 @@
         >
             <attribute name="t-foreach">o.get_delivery_report_lines()</attribute>
         </xpath>
+        <xpath
+            expr="//tbody/t[@t-else='']//tr[@t-as='move_line']"
+            position="attributes"
+        >
+            <attribute name="t-foreach">o.get_delivery_report_lines()</attribute>
+        </xpath>
 
         <xpath
             expr="//table[@name='stock_backorder_table']/../p[last()]"
@@ -111,6 +117,18 @@
         id="stock_report_delivery_has_serial_move_line_inherit"
         inherit_id="stock.stock_report_delivery_has_serial_move_line"
     >
+        <!-- Odoo tries to display both description and product name.
+        When the line is a SO section, we only want to display a description.
+        Enable default behavior when line has an id, only display the description otherwise. -->
+        <xpath expr="//span[@t-field='move_line.product_id']/.." position="attributes">
+            <attribute name="t-if">move_line.id</attribute>
+        </xpath>
+        <xpath expr="//span[@t-field='move_line.product_id']/.." position="after">
+            <td t-else="">
+                <span t-field="move_line.description_picking" />
+            </td>
+        </xpath>
+        <!-- Disable the rest, when line doesn't have an id -->
         <xpath expr='//span[@t-field="move_line.lot_id.name"]' position="attributes">
             <attribute name="t-if">move_line.id</attribute>
         </xpath>


### PR DESCRIPTION
https://github.com/odoo/odoo/blob/ef0320b82e679f2f6eb4b2ba8aa4530cda9a98a9/addons/stock/report/report_deliveryslip.xml#L77-L124

There's 4 different cases for the deliveryslip report:
 1) package and serial number
 2) package and no serial number
 3) no package but serial number
 4) no package and no serial number

For the 2nd an 4th case, odoo tries to aggregate the lines and therefore
shouldn't be groupped by SO, no fix needed here.

However, when there's serial numbers, we can group lines by SO, and we
should use `picking.get_delivery_report_lines()` to get the lines to
display. The 3rd case wasn't handled yet.

Also, when groupping by SO, the `get_delivery_report_lines` creates fake
`stock.move.line` for each SO section, with product_id = 1.
However, odoo tries to display the product, which is wrong for the 
SO sections. In such case, display the SO name instead.