### PR TITLE
[14.0][IMP] stock_picking_warn_message: show blocking messages in red

### DIFF
--- a/stock_picking_warn_message/README.rst
+++ b/stock_picking_warn_message/README.rst
@@ -55,6 +55,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Héctor Villarreal <hector.villarreal@forgeflow.com>
+* Daniel Haag <dev.x@dhx.at>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_warn_message/models/stock_picking.py
+++ b/stock_picking_warn_message/models/stock_picking.py
@@ -8,7 +8,27 @@ class StockPicking(models.Model):
 
     _inherit = "stock.picking"
 
+    picking_warn = fields.Text(compute="_compute_picking_warn")
     picking_warn_msg = fields.Text(compute="_compute_picking_warn_msg")
+
+    @api.depends(
+        "state",
+        "partner_id.picking_warn",
+        "partner_id.commercial_partner_id.picking_warn",
+    )
+    def _compute_picking_warn(self):
+        for rec in self:
+            picking_warn = "no-message"
+            if rec.state not in ["done", "cancel"] and rec.partner_id:
+                p = rec.partner_id.commercial_partner_id
+                if p.picking_warn == "block" or rec.partner_id.picking_warn == "block":
+                    picking_warn = "block"
+                elif (
+                    p.picking_warn == "warning"
+                    or rec.partner_id.picking_warn == "warning"
+                ):
+                    picking_warn = "warning"
+            rec.picking_warn = picking_warn
 
     @api.depends(
         "state",
@@ -21,9 +41,9 @@ class StockPicking(models.Model):
             if rec.state not in ["done", "cancel"] and rec.partner_id:
                 p = rec.partner_id.commercial_partner_id
                 separator = ""
-                if p.picking_warn == "warning":
+                if p.picking_warn != "no-message":
                     separator = "\n"
                     picking_warn_msg += p.picking_warn_msg
-                if p != rec.partner_id and rec.partner_id.picking_warn == "warning":
+                if p != rec.partner_id and rec.partner_id.picking_warn != "no-message":
                     picking_warn_msg += separator + rec.partner_id.picking_warn_msg
             rec.picking_warn_msg = picking_warn_msg or False

--- a/stock_picking_warn_message/readme/CONTRIBUTORS.rst
+++ b/stock_picking_warn_message/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Héctor Villarreal <hector.villarreal@forgeflow.com>
+* Daniel Haag <dev.x@dhx.at>

--- a/stock_picking_warn_message/views/stock_picking_views.xml
+++ b/stock_picking_warn_message/views/stock_picking_views.xml
@@ -8,14 +8,27 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <header position="after">
+                <field name="picking_warn" invisible="1" />
                 <div
                     class="alert alert-warning"
                     role="alert"
-                    attrs="{'invisible': [('picking_warn_msg', '=', False)]}"
+                    attrs="{'invisible': [('picking_warn', '!=', 'warning')]}"
                     style="margin-bottom:0px;"
                 >
                     <p>
                         <i class="fa fa-info-circle" />
+                        &amp;nbsp;
+                        <field name="picking_warn_msg" class="oe_inline" />
+                    </p>
+                </div>
+                <div
+                    class="alert alert-danger"
+                    role="alert"
+                    attrs="{'invisible': [('picking_warn', '!=', 'block')]}"
+                    style="margin-bottom:0px;"
+                >
+                    <p>
+                        <i class="fa fa-warning" />
                         &amp;nbsp;
                         <field name="picking_warn_msg" class="oe_inline" />
                     </p>


### PR DESCRIPTION
 This allows the distinction between warn and block to be visible in the
 stock picking dialog by adding the additional picking_warn field to the
 stock.picking model containing what kind of message is to be shown.