### PR TITLE
[14.0][FIX] stock_picking_invoice_link: test needs post install decorator + fix in test

### DIFF
--- a/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -4,12 +4,14 @@
 # Copyright 2021 Tecnativa - João Marques
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import odoo
 from odoo.exceptions import UserError
 from odoo.tests import Form
 
 from odoo.addons.sale.tests.common import TestSaleCommon
 
 
+@odoo.tests.tagged("-at_install", "post_install")
 class TestStockPickingInvoiceLink(TestSaleCommon):
     def _update_product_qty(self, product):
 
@@ -91,7 +93,7 @@ class TestStockPickingInvoiceLink(TestSaleCommon):
         )
         pick_1 = self.so.picking_ids.filtered(
             lambda x: x.picking_type_code == "outgoing"
-            and x.state in ("confirmed", "assigned", "partially_available")
+            and x.state in ("confirmed", "assigned")
         )
         pick_1.move_line_ids.write({"qty_done": 1})
         pick_1._action_done()
@@ -116,7 +118,7 @@ class TestStockPickingInvoiceLink(TestSaleCommon):
 
         pick_2 = self.so.picking_ids.filtered(
             lambda x: x.picking_type_code == "outgoing"
-            and x.state in ("confirmed", "assigned", "partially_available")
+            and x.state in ("confirmed", "assigned")
         )
         pick_2.move_line_ids.write({"qty_done": 1})
         pick_2._action_done()
@@ -195,7 +197,7 @@ class TestStockPickingInvoiceLink(TestSaleCommon):
     def test_return_picking_to_refund(self):
         pick_1 = self.so.picking_ids.filtered(
             lambda x: x.picking_type_code == "outgoing"
-            and x.state in ("confirmed", "assigned", "partially_available")
+            and x.state in ("confirmed", "assigned")
         )
         pick_1.move_line_ids.write({"qty_done": 2})
         pick_1._action_done()
@@ -234,7 +236,7 @@ class TestStockPickingInvoiceLink(TestSaleCommon):
     def test_invoice_refund(self):
         pick_1 = self.so.picking_ids.filtered(
             lambda x: x.picking_type_code == "outgoing"
-            and x.state in ("confirmed", "assigned", "partially_available")
+            and x.state in ("confirmed", "assigned")
         )
         pick_1.move_line_ids.write({"qty_done": 2})
         pick_1._action_done()


### PR DESCRIPTION
Fixes 14.0 branch

Extracted from: https://github.com/OCA/stock-logistics-workflow/pull/992

Also the "partially_available" status does not exist in v14 in the picking: https://github.com/odoo/odoo/blob/14.0/addons/stock/models/stock_picking.py#L265 it only exists in the stock moves. So a comparison in the test to that state makes no sense.