### PR TITLE
[13.0][FIX] stock_picking_assign_serial_final: Hide final serial number field when product has not serial tracking

### DIFF
--- a/stock_picking_assign_serial_final/wizards/stock_assign_serial_views.xml
+++ b/stock_picking_assign_serial_final/wizards/stock_assign_serial_views.xml
@@ -14,7 +14,10 @@
         <field name="inherit_id" ref="stock.view_stock_move_operations" />
         <field name="arch" type="xml">
             <field name="next_serial" position="after">
-                <field name="final_serial_number" />
+                <field
+                    name="final_serial_number"
+                    attrs="{'invisible': [('display_assign_serial', '=', False)]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
cc @Tecnativa

ping @chienandalu @CarlosRoca13 