### PR TITLE
[13.0][FIX] stock_picking_import_serial_number: Be more resilient in tests

### DIFF
--- a/stock_picking_import_serial_number/tests/common.py
+++ b/stock_picking_import_serial_number/tests/common.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Tecnativa - Sergio Teruel
+# Copyright 2022 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 
@@ -26,14 +27,14 @@ class CommonStockPickingImportSerial(object):
     @classmethod
     def _create_product(cls, tracking="lot", reference=None):
         name = "{tracking}".format(tracking=tracking)
-        return cls.env["product.product"].create(
-            {
-                "name": name,
-                "type": "product",
-                "tracking": tracking,
-                "default_code": reference,
-            }
-        )
+        vals = {
+            "name": name,
+            "type": "product",
+            "tracking": tracking,
+        }
+        if reference:
+            vals["default_code"] = reference
+        return cls.env["product.product"].create(vals)
 
     @classmethod
     def _create_picking(cls):


### PR DESCRIPTION
Don't pass `default_code` in vals if no reference is provided, for letting other modules to work properly in integration tests like `product_code_mandatory` + `product_sequence`.

@Tecnativa