### PR TITLE
[13.0][FIX] stock_picking_invoice_link: Consider DS pickings

### DIFF
--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -15,7 +15,9 @@ class SaleOrderLine(models.Model):
                 and not (
                     any(
                         inv.state != "cancel"
-                        for inv in mv.invoice_line_ids.mapped("move_id")
+                        for inv in mv.invoice_line_ids.mapped("move_id").filtered(
+                            lambda x: x.type in ("out_invoice", "out_refund")
+                        )
                     )
                 )
                 and not mv.scrapped


### PR DESCRIPTION
Steps to reproduce the problem:

- Create a sales order with Dropshipping route.
- Confirm the sale order and validate the DS picking.
- Invoice the purchase order.
- Invoice the sales order.

Current behavior:

The customer invoice is not linked to the DS picking

Expected behavior:

It's linked.

That's because current algorithm looks for existing invoices linked to the picking for discarding double links, but it's not having into
account that such invoices can be vendor ones.

We simply filter for customer invoices in the algorithm to fix it.

@Tecnativa TT37997