### PR TITLE
[14.0][ADD] Add stock_scheduler_assignation_horizon module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+pytz

--- a/setup/stock_scheduler_assignation_horizon/odoo/addons/stock_scheduler_assignation_horizon
+++ b/setup/stock_scheduler_assignation_horizon/odoo/addons/stock_scheduler_assignation_horizon
@@ -1,0 +1,1 @@
+../../../../stock_scheduler_assignation_horizon

--- a/setup/stock_scheduler_assignation_horizon/setup.py
+++ b/setup/stock_scheduler_assignation_horizon/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_scheduler_assignation_horizon/__init__.py
+++ b/stock_scheduler_assignation_horizon/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/stock_scheduler_assignation_horizon/__manifest__.py
+++ b/stock_scheduler_assignation_horizon/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Scheduler assignation horizon",
+    "summary": "Set a timeframe limit to the delivery scheduler",
+    "version": "14.0.1.0.0",
+    "category": "Inventory",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "depends": ["stock"],
+    "external_dependencies": {"python": ["pytz"]},
+    "data": [
+        "views/res_config_settings_views.xml",
+    ],
+}

--- a/stock_scheduler_assignation_horizon/models/__init__.py
+++ b/stock_scheduler_assignation_horizon/models/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import res_config_settings
+from . import res_company
+from . import procurement_group

--- a/stock_scheduler_assignation_horizon/models/procurement_group.py
+++ b/stock_scheduler_assignation_horizon/models/procurement_group.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime, timedelta
+
+import pytz
+
+from odoo import models
+from odoo.osv import expression
+
+
+class ProcurementGroup(models.Model):
+    _inherit = "procurement.group"
+
+    def _get_moves_to_assign_domain(self, company_id):
+        domain = super()._get_moves_to_assign_domain(company_id)
+        company = self.env["res.company"].browse(company_id)
+        if company.is_moves_assignation_limited:
+            domain = self._get_moves_to_assign_domain_assignation_limited(
+                domain, company
+            )
+        return domain
+
+    def _get_moves_to_assign_domain_assignation_limited(self, domain, company):
+        company_tz = pytz.timezone(company.partner_id.tz or "UTC")
+        max_date = (
+            datetime.combine(
+                datetime.now(company_tz)
+                + timedelta(days=company.moves_assignation_horizon),
+                datetime.max.time(),
+            )
+            .astimezone(pytz.utc)
+            .replace(tzinfo=None)
+        )
+        return expression.AND(
+            [
+                domain,
+                [("date", "<=", max_date)],
+            ]
+        )

--- a/stock_scheduler_assignation_horizon/models/res_company.py
+++ b/stock_scheduler_assignation_horizon/models/res_company.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    is_moves_assignation_limited = fields.Boolean()
+    moves_assignation_horizon = fields.Integer()

--- a/stock_scheduler_assignation_horizon/models/res_config_settings.py
+++ b/stock_scheduler_assignation_horizon/models/res_config_settings.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    is_moves_assignation_limited = fields.Boolean(
+        "Scheduler Assignation Limit",
+        related="company_id.is_moves_assignation_limited",
+        readonly=False,
+        help="Check this box to prevent the scheduler from "
+        "assigning moves before the horizon below",
+    )
+    moves_assignation_horizon = fields.Integer(
+        "Assignation Horizon",
+        related="company_id.moves_assignation_horizon",
+        readonly=False,
+        help="Only reserve moves that are scheduled within the specified number of days",
+    )
+
+    @api.constrains("moves_assignation_horizon")
+    def _check_moves_assignation_horizon(self):
+        for record in self:
+            if record.moves_assignation_horizon < 0:
+                raise ValidationError(_("The assignation horizon cannot be negative"))

--- a/stock_scheduler_assignation_horizon/readme/CONTRIBUTORS.rst
+++ b/stock_scheduler_assignation_horizon/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_scheduler_assignation_horizon/readme/DESCRIPTION.rst
+++ b/stock_scheduler_assignation_horizon/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module allows to set a time horizon that will prevent the scheduler from marking stock pickings as *ready* before the indicated number of days (horizon).

--- a/stock_scheduler_assignation_horizon/readme/ROADMAP.rst
+++ b/stock_scheduler_assignation_horizon/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+* This module only impacts the scheduler triggered by the cron, but you might still get automatic reservations in some other cases.
+* On most databases, picking automatic reservation will be enabled by default. This affects StockMove._trigger_assign, that's usually called when completing manufacturing orders or receptions.
+* There's also the procurement_jit module that's installed by default, and it will also attempt to reserve automatically upon SO confirmation.

--- a/stock_scheduler_assignation_horizon/readme/USAGE.rst
+++ b/stock_scheduler_assignation_horizon/readme/USAGE.rst
@@ -1,0 +1,3 @@
+#. Go to **Inventory > Operations > Reservation > Horizon Assignation**.
+#. Activate **Scheduler Assignation Limit**.
+#. Select the desired **Assignation Horizon** (in days).

--- a/stock_scheduler_assignation_horizon/tests/__init__.py
+++ b/stock_scheduler_assignation_horizon/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_config_settings

--- a/stock_scheduler_assignation_horizon/tests/test_res_config_settings.py
+++ b/stock_scheduler_assignation_horizon/tests/test_res_config_settings.py
@@ -1,0 +1,74 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date, timedelta
+
+from odoo.exceptions import ValidationError
+
+from .test_res_config_settings_common import ResConfigSettingsCase
+
+
+class DeliverySchedulerLimitCase(ResConfigSettingsCase):
+    def test_settings_applied_to_company(self):
+        self.assertEqual(self.company.is_moves_assignation_limited, True)
+        self.assertEqual(self.company.moves_assignation_horizon, 2)
+
+    def test_assignation_horizon_negative_value(self):
+        with self.assertRaises(ValidationError) as context:
+            self.settings.moves_assignation_horizon = -3
+        self.assertEqual(
+            "The assignation horizon cannot be negative", str(context.exception)
+        )
+
+    def test_delivery_scheduler_horizon_limit(self):
+        self.location = self.env.ref("stock.stock_location_stock")
+        self.location_dest = self.env.ref("stock.stock_location_customers")
+
+        self.product_1 = self.env["product.product"].create(
+            {
+                "name": "Test Product 1",
+                "type": "product",
+            }
+        )
+        self.env["stock.quant"].with_context(inventory_mode=True).create(
+            {
+                "product_id": self.product_1.id,
+                "location_id": self.location.id,
+                "inventory_quantity": 100,
+            }
+        )
+
+        picking_1 = self._create_picking(days_horizon=1)
+        picking_2 = self._create_picking(days_horizon=3)
+        picking_1.action_confirm()
+        picking_2.action_confirm()
+
+        self.env["procurement.group"].run_scheduler(company_id=self.company.id)
+
+        self.assertEqual(picking_1.state, "assigned")
+        self.assertEqual(picking_2.state, "confirmed")
+
+    def _create_picking(self, days_horizon=0):
+        scheduled_date = date.today() + timedelta(days=days_horizon)
+        operation_type = self.env.ref("stock.picking_type_out")
+
+        return self.env["stock.picking"].create(
+            {
+                "scheduled_date": scheduled_date,
+                "location_id": self.location.id,
+                "location_dest_id": self.location_dest.id,
+                "picking_type_id": operation_type.id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product_1.name,
+                            "product_id": self.product_1.id,
+                            "product_uom": self.product_1.uom_id.id,
+                            "product_uom_qty": 10,
+                        },
+                    )
+                ],
+            }
+        )

--- a/stock_scheduler_assignation_horizon/tests/test_res_config_settings_common.py
+++ b/stock_scheduler_assignation_horizon/tests/test_res_config_settings_common.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo.tests.common import SavepointCase
+
+
+class ResConfigSettingsCase(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.company
+
+        cls.settings = cls.env["res.config.settings"].create(
+            {"is_moves_assignation_limited": True, "moves_assignation_horizon": 2}
+        )

--- a/stock_scheduler_assignation_horizon/views/res_config_settings_views.xml
+++ b/stock_scheduler_assignation_horizon/views/res_config_settings_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="res_config_settings_view_form_stock" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div name="operations_setting_container" position="after">
+                <h2>Shipping Scheduler</h2>
+                <div
+                    class="row mt16 o_settings_container"
+                    name="shipping_schedule_setting_container"
+                >
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="is_moves_assignation_limited" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="is_moves_assignation_limited" />
+                            <span
+                                class="fa fa-lg fa-building-o"
+                                title="Values set here are company-specific."
+                                aria-label="Values set here are company-specific."
+                                groups="base.group_multi_company"
+                                role="img"
+                            />
+                            <div class="text-muted">
+                                Do not schedule delivery before horizon timeframe
+                            </div>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="moves_assignation_horizon" />
+                            <div class="text-muted">
+                                Horizon timeframe (in days)
+                            </div>
+                            <field name="moves_assignation_horizon" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module allows to set a time horizon that will prevent the scheduler from marking stock pickings as *ready* before the indicated number of days (horizon).

![image](https://user-images.githubusercontent.com/77412816/178959039-255a53bd-1504-4d1c-a2da-a8fe133f5362.png)
