### PR TITLE
[FIX] stock_production_lot_active: prevent duplicating lots

### DIFF
--- a/stock_production_lot_active/models/stock_production_lot.py
+++ b/stock_production_lot_active/models/stock_production_lot.py
@@ -1,10 +1,21 @@
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockProductionLot(models.Model):
     _inherit = "stock.production.lot"
 
     active = fields.Boolean(string="Active", default=True)
+
+    @api.constrains("name", "product_id", "company_id")
+    def _check_unique_lot(self):
+        """Check that there is no other lot with the same name, company and product
+
+        To avoid allowing duplicate lot/company/name combinations when there is
+        another inactive entry we have to set the active_test flag to False.
+        """
+        return super(
+            StockProductionLot, self.with_context(active_test=False)
+        )._check_unique_lot()

--- a/stock_production_lot_active/readme/CONTRIBUTORS.rst
+++ b/stock_production_lot_active/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Thomas Binsfeld <thomas.binsfeld@acsone.eu>
 * Janik von Rotz <janik.vonrotz@mint-system.ch>
+* Daniel Haag <dh.oca.dev@dhx.at>

--- a/stock_production_lot_active/tests/__init__.py
+++ b/stock_production_lot_active/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_lot_active

--- a/stock_production_lot_active/tests/test_lot_active.py
+++ b/stock_production_lot_active/tests/test_lot_active.py
@@ -1,0 +1,34 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import SavepointCase
+
+
+class TestLotActive(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env.ref("product.product_product_16")
+        cls.product.write({"tracking": "lot"})
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+
+    def test_duplicate_inactive_lot(self):
+        self.env["stock.production.lot"].create(
+            {
+                "name": "stock_production_lot_active lot",
+                "product_id": self.product.id,
+                "company_id": self.warehouse.company_id.id,
+                "active": False,
+            }
+        )
+        # it should not be possible to create a new lot with the same name and company
+        # for the same product even when the first lot is inactive
+        with self.assertRaises(ValidationError):
+            self.env["stock.production.lot"].create(
+                {
+                    "name": "stock_production_lot_active lot",
+                    "product_id": self.product.id,
+                    "company_id": self.warehouse.company_id.id,
+                    "active": True,
+                }
+            )


### PR DESCRIPTION
When a lot is archived it is currently possible to create a new lot with the same name/product_id/company_id combination as the _check_unique_lot function does not take inactive entries into account. This PR solves this issue by overriding this function and setting the active_test=False context.