### PR TITLE
[14.0][FIX] stock_picking_filter_lot: if quantity changes location ids are not computed

### DIFF
--- a/stock_picking_filter_lot/models/stock_production_lot.py
+++ b/stock_picking_filter_lot/models/stock_production_lot.py
@@ -11,7 +11,7 @@ class StockProductionLot(models.Model):
         comodel_name="stock.location", compute="_compute_location_ids", store=True
     )
 
-    @api.depends("quant_ids", "quant_ids.location_id")
+    @api.depends("quant_ids", "quant_ids.location_id", "quant_ids.quantity")
     def _compute_location_ids(self):
         for lot in self:
             lot.location_ids = lot.quant_ids.filtered(lambda l: l.quantity > 0).mapped(


### PR DESCRIPTION
We had quantities in a location and weren't able to select it and we traced the problem to be this missing dependency.