### PR TITLE
[14.0] [FIX] delivery_total_weight_from_packaging: keep package weight on picking transfer

### DIFF
--- a/delivery_total_weight_from_packaging/README.rst
+++ b/delivery_total_weight_from_packaging/README.rst
@@ -57,6 +57,7 @@ Contributors
 * Sébastien Alix <sebastien.alix@camptocamp.com>
 * `Trobz <https://trobz.com>`_:
 * Nguyen Hoang Hiep <hiepnh@trobz.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/delivery_total_weight_from_packaging/models/stock_quant_package.py
+++ b/delivery_total_weight_from_packaging/models/stock_quant_package.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import api, fields, models
@@ -25,7 +26,11 @@ class StockQuantPackage(models.Model):
     @api.depends_context("picking_id")
     def _compute_shipping_weight(self):
         for package in self:
-            package.shipping_weight = package._get_weight_from_packaging()
+            # When you ship the parcel, the weight should not be erased and
+            # remain the one that was encoded during the packing step.
+            package.shipping_weight = (
+                package.shipping_weight or package._get_weight_from_packaging()
+            )
 
     def _get_weight_from_packaging(self):
         # NOTE: code copied/pasted and adapter from `delivery`

--- a/delivery_total_weight_from_packaging/readme/CONTRIBUTORS.rst
+++ b/delivery_total_weight_from_packaging/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Sébastien Alix <sebastien.alix@camptocamp.com>
 * `Trobz <https://trobz.com>`_:
 * Nguyen Hoang Hiep <hiepnh@trobz.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/delivery_total_weight_from_packaging/tests/test_weight_from_packaging.py
+++ b/delivery_total_weight_from_packaging/tests/test_weight_from_packaging.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from .common import TestShippingWeightCommon
 
@@ -55,6 +56,9 @@ class TestWeight(TestShippingWeightCommon):
         self.assertEqual(picking.shipping_weight, 16)
         pack.shipping_weight = 6
         picking.invalidate_cache(["shipping_weight"])
+        self.assertEqual(picking.shipping_weight, 15)
+        picking._action_done()
+        # Check the manualy set weight is not lost when quants are inserted in the package
         self.assertEqual(picking.shipping_weight, 15)
 
     def test_package_weight(self):


### PR DESCRIPTION
When a package weight is manually entered on a package, the value should not be lost when the package is transferred.

cc @sebalix @simahawk 