### PR TITLE
[13.0][ADD] stock_picking_batch_extended_account_sale_type: New module to create invoices from batch pickings setting by sale order type

### DIFF
--- a/setup/stock_picking_batch_extended_account_sale_type/odoo/addons/stock_picking_batch_extended_account_sale_type
+++ b/setup/stock_picking_batch_extended_account_sale_type/odoo/addons/stock_picking_batch_extended_account_sale_type
@@ -1,0 +1,1 @@
+../../../../stock_picking_batch_extended_account_sale_type

--- a/setup/stock_picking_batch_extended_account_sale_type/setup.py
+++ b/setup/stock_picking_batch_extended_account_sale_type/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_picking_batch_extended_account_sale_type/__init__.py
+++ b/stock_picking_batch_extended_account_sale_type/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/stock_picking_batch_extended_account_sale_type/__manifest__.py
+++ b/stock_picking_batch_extended_account_sale_type/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Tecnativa - Ernesto Tejeda
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Stock batch picking extended account sale type",
+    "summary": "Generates invoices when batch is set to Done state",
+    "version": "13.0.1.0.0",
+    "author": "Tecnativa, Odoo Community Association (OCA)",
+    "maintainers": ["ernestotejeda"],
+    "development_status": "Beta",
+    "category": "Warehouse Management",
+    "depends": ["stock_picking_batch_extended_account", "sale_order_type"],
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "data": ["views/sale_order_type_views.xml"],
+    "installable": True,
+    "license": "AGPL-3",
+}

--- a/stock_picking_batch_extended_account_sale_type/i18n/es.po
+++ b/stock_picking_batch_extended_account_sale_type/i18n/es.po
@@ -1,0 +1,54 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_picking_batch_extended_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-31 17:29+0000\n"
+"PO-Revision-Date: 2022-07-31 19:31+0200\n"
+"Last-Translator: Sergio Teruel <sergio.teruel@tecnativa.com>\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 2.3\n"
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model.fields,field_description:stock_picking_batch_extended_account_sale_type.field_res_partner__batch_picking_auto_invoice
+#: model:ir.model.fields,field_description:stock_picking_batch_extended_account_sale_type.field_res_users__batch_picking_auto_invoice
+#: model:ir.model.fields,field_description:stock_picking_batch_extended_account_sale_type.field_sale_order_type__batch_picking_auto_invoice
+msgid "Batch Picking Auto Invoice"
+msgstr "Facturación automática en agrupación de albaranes"
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model,name:stock_picking_batch_extended_account_sale_type.model_stock_picking_batch
+msgid "Batch Transfer"
+msgstr "Agrupación de albaranes"
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model.fields.selection,name:stock_picking_batch_extended_account_sale_type.selection__res_partner__batch_picking_auto_invoice__sale_type
+msgid "By sale type"
+msgstr "Por tipo de venta"
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model,name:stock_picking_batch_extended_account_sale_type.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model,name:stock_picking_batch_extended_account_sale_type.model_sale_order_type
+msgid "Type of sale order"
+msgstr "Tipo de pedido de venta"
+
+#~ msgid "Nothing to print."
+#~ msgstr "Nada para imprimir."
+
+#~ msgid "Print Invoices"
+#~ msgstr "Imprimir facturas"
+
+#~ msgid "Transfer"
+#~ msgstr "Albarán"

--- a/stock_picking_batch_extended_account_sale_type/i18n/stock_picking_batch_extended_account_sale_type.pot
+++ b/stock_picking_batch_extended_account_sale_type/i18n/stock_picking_batch_extended_account_sale_type.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_picking_batch_extended_account_sale_type
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-31 17:29+0000\n"
+"PO-Revision-Date: 2022-07-31 17:29+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model.fields,field_description:stock_picking_batch_extended_account_sale_type.field_res_partner__batch_picking_auto_invoice
+#: model:ir.model.fields,field_description:stock_picking_batch_extended_account_sale_type.field_res_users__batch_picking_auto_invoice
+#: model:ir.model.fields,field_description:stock_picking_batch_extended_account_sale_type.field_sale_order_type__batch_picking_auto_invoice
+msgid "Batch Picking Auto Invoice"
+msgstr ""
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model,name:stock_picking_batch_extended_account_sale_type.model_stock_picking_batch
+msgid "Batch Transfer"
+msgstr ""
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model.fields.selection,name:stock_picking_batch_extended_account_sale_type.selection__res_partner__batch_picking_auto_invoice__sale_type
+msgid "By sale type"
+msgstr ""
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model,name:stock_picking_batch_extended_account_sale_type.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: stock_picking_batch_extended_account_sale_type
+#: model:ir.model,name:stock_picking_batch_extended_account_sale_type.model_sale_order_type
+msgid "Type of sale order"
+msgstr ""

--- a/stock_picking_batch_extended_account_sale_type/models/__init__.py
+++ b/stock_picking_batch_extended_account_sale_type/models/__init__.py
@@ -1,0 +1,5 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import res_partner
+from . import sale_order_type
+from . import stock_batch_picking

--- a/stock_picking_batch_extended_account_sale_type/models/res_partner.py
+++ b/stock_picking_batch_extended_account_sale_type/models/res_partner.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Tecnativa - Ernesto Tejeda
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    batch_picking_auto_invoice = fields.Selection(
+        selection_add=[("sale_type", "By sale type")]
+    )

--- a/stock_picking_batch_extended_account_sale_type/models/sale_order_type.py
+++ b/stock_picking_batch_extended_account_sale_type/models/sale_order_type.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Tecnativa - Ernesto Tejeda
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleOrderType(models.Model):
+    _inherit = "sale.order.type"
+
+    batch_picking_auto_invoice = fields.Boolean()

--- a/stock_picking_batch_extended_account_sale_type/models/stock_batch_picking.py
+++ b/stock_picking_batch_extended_account_sale_type/models/stock_batch_picking.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Tecnativa - Ernesto Tejeda
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockBatchPicking(models.Model):
+    _inherit = "stock.picking.batch"
+
+    def _get_domain_picking_to_invoice(self):
+        domain = super(StockBatchPicking, self)._get_domain_picking_to_invoice()
+        return [
+            "|",
+            "&",
+            ("partner_id.batch_picking_auto_invoice", "=", "sale_type"),
+            ("sale_id.type_id.batch_picking_auto_invoice", "=", True),
+        ] + domain

--- a/stock_picking_batch_extended_account_sale_type/tests/__init__.py
+++ b/stock_picking_batch_extended_account_sale_type/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2022 Sergio Teruel - Tecnativa <sergio.teruel@tecnativa.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import test_stock_picking_batch_extended_account_sale_type

--- a/stock_picking_batch_extended_account_sale_type/tests/test_stock_picking_batch_extended_account_sale_type.py
+++ b/stock_picking_batch_extended_account_sale_type/tests/test_stock_picking_batch_extended_account_sale_type.py
@@ -1,0 +1,36 @@
+# Copyright 2019 Sergio Teruel - Tecnativa <sergio.teruel@tecnativa.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.addons.stock_picking_batch_extended_account.tests import (
+    test_stock_picking_batch_extended_account as test_bp_account,
+)
+
+
+class TestStockPickingBatchExtendedAccountSaleType(
+    test_bp_account.TestStockPickingBatchExtendedAccount
+):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sale_type = cls.env["sale.order.type"].create(
+            {"name": "sale type for tests", "batch_picking_auto_invoice": True}
+        )
+        cls.partner.write(
+            {"sale_type": cls.sale_type.id, "batch_picking_auto_invoice": "no"}
+        )
+        cls.partner2.write(
+            {"sale_type": cls.sale_type.id, "batch_picking_auto_invoice": "sale_type"}
+        )
+
+    def test_create_invoice_from_bp_sale_type(self):
+        self.order1 = self._create_sale_order(self.partner)
+        self.order2 = self._create_sale_order(self.partner2)
+        self.order1.action_confirm()
+        self.order2.action_confirm()
+        pickings = self.order1.picking_ids + self.order2.picking_ids
+        move_lines = pickings.mapped("move_line_ids")
+        move_lines.qty_done = 1.0
+        bp = self._create_batch_picking(pickings)
+        bp.action_assign()
+        bp.action_transfer()
+        self.assertFalse(self.order1.invoice_ids)
+        self.assertTrue(self.order2.invoice_ids)

--- a/stock_picking_batch_extended_account_sale_type/views/sale_order_type_views.xml
+++ b/stock_picking_batch_extended_account_sale_type/views/sale_order_type_views.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="sot_sale_order_type_form_view" model="ir.ui.view">
+        <field name="model">sale.order.type</field>
+        <field name="inherit_id" ref="sale_order_type.sot_sale_order_type_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='warehouse_id']/..">
+                <field name="batch_picking_auto_invoice" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
cc @Tecnativa TT36237

ping @carlosdauden @ernestotejeda 

Depends on:
- [x] https://github.com/OCA/stock-logistics-workflow/pull/1052