### PR TITLE
[13.0][IMP] stock_landed_costs_security: restrict actions

### DIFF
--- a/stock_landed_costs_security/views/stock_landed_costs_view.xml
+++ b/stock_landed_costs_security/views/stock_landed_costs_view.xml
@@ -13,6 +13,34 @@
             </button>
         </field>
     </record>
+    <record id="stock_landed_costs.account_view_move_form_inherited" model="ir.ui.view">
+        <field
+            name="groups_id"
+            eval="[(4, ref('stock_landed_costs_security.group_stock_landed_costs_security_user'))]"
+        />
+    </record>
+    <record id="account_view_move_form_inherited" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field
+            name="inherit_id"
+            ref="stock_landed_costs.account_view_move_form_inherited"
+        />
+        <field name="arch" type="xml">
+            <button name="action_view_landed_costs" position="attributes">
+                <attribute
+                    name="groups"
+                >stock_landed_costs_security.group_stock_landed_costs_security_user
+                </attribute>
+            </button>
+            <button name="button_create_landed_costs" position="attributes">
+                <attribute
+                    name="groups"
+                    add="stock_landed_costs_security.group_stock_landed_costs_security_user"
+                    separator=","
+                />
+            </button>
+        </field>
+    </record>
 
     <menuitem
         name="Landed Costs"


### PR DESCRIPTION
- From the invoice only landed costs user will be able to see them.
- Ensure that landed costs users can create landed costs from the invoice.

cc @Tecnativa TT38065

please review @pedrobaeza @victoralmau 