### PR TITLE
[13.0][IMP] stock_picking_import_serial_number: Allow import S/N from file in internal and outgoing operations

### DIFF
--- a/stock_picking_import_serial_number/README.rst
+++ b/stock_picking_import_serial_number/README.rst
@@ -39,9 +39,12 @@ Configuration
 To configure this module, you need to:
 
 #. Go to a *Inventory > Configuration > Settings*.
-#. Choose the product field which yo want to search products.
+#. Choose the product field which you want to search products.
 #. Choose the file column index where product reference is stored.
 #. Choose the file column index where serial number reference is stored.
+
+#. Go to a *Inventory > Operation types*.
+#. Check the field "Import lot from file" to allow to import S/N.
 
 Usage
 =====

--- a/stock_picking_import_serial_number/i18n/es.po
+++ b/stock_picking_import_serial_number/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-04 10:48+0000\n"
-"PO-Revision-Date: 2022-05-04 12:49+0200\n"
+"POT-Creation-Date: 2022-08-10 16:10+0000\n"
+"PO-Revision-Date: 2022-08-10 18:12+0200\n"
 "Last-Translator: Sergio Teruel <sergio.teruel@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -92,7 +92,13 @@ msgstr "Nombre de archivo"
 #. module: stock_picking_import_serial_number
 #: model:ir.model.fields,field_description:stock_picking_import_serial_number.field_stock_picking_import_serial_number_wiz__id
 msgid "ID"
-msgstr ""
+msgstr "ID (identificación)"
+
+#. module: stock_picking_import_serial_number
+#: model:ir.model.fields,field_description:stock_picking_import_serial_number.field_stock_picking__import_lot_from_file
+#: model:ir.model.fields,field_description:stock_picking_import_serial_number.field_stock_picking_type__import_lot_from_file
+msgid "Import Lot From File"
+msgstr "Importar lotes desde archivo"
 
 #. module: stock_picking_import_serial_number
 #: model:ir.actions.act_window,name:stock_picking_import_serial_number.action_import_serial_number
@@ -133,6 +139,11 @@ msgid "Picking"
 msgstr "Albarán"
 
 #. module: stock_picking_import_serial_number
+#: model:ir.model,name:stock_picking_import_serial_number.model_stock_picking_type
+msgid "Picking Type"
+msgstr "Tipo de operación"
+
+#. module: stock_picking_import_serial_number
 #: model:ir.model.fields.selection,name:stock_picking_import_serial_number.selection__res_config_settings__default_sn_search_product_by_field__default_code
 #: model:ir.model.fields.selection,name:stock_picking_import_serial_number.selection__stock_picking_import_serial_number_wiz__sn_search_product_by_field__default_code
 msgid "Reference"
@@ -163,6 +174,11 @@ msgstr ""
 "serie"
 
 #. module: stock_picking_import_serial_number
+#: model:ir.model,name:stock_picking_import_serial_number.model_stock_picking
+msgid "Transfer"
+msgstr "Albarán"
+
+#. module: stock_picking_import_serial_number
 #: code:addons/stock_picking_import_serial_number/wizard/import_serial_number_wizard.py:0
 #, python-format
 msgid "You must upload file to import records"
@@ -171,17 +187,13 @@ msgstr "Debe de subir un fichero para importar registros"
 #. module: stock_picking_import_serial_number
 #: code:addons/stock_picking_import_serial_number/wizard/import_serial_number_wizard.py:0
 #, python-format
-msgid "You only can import S/N for incoming moves"
-msgstr "Solo puede importar S/N para albaranes de entrada"
-
-#. module: stock_picking_import_serial_number
-#: code:addons/stock_picking_import_serial_number/wizard/import_serial_number_wizard.py:0
-#, python-format
-msgid ""
-"You only can import S/N for picking operations with creation lots checked"
-msgstr "Solo puede importar S/N para operaciones con creación de lotes marcado"
+msgid "You only can import S/N for picking operations with import lots checked"
+msgstr "Solo puede importar S/N para operaciones con importar lotes marcado"
 
 #. module: stock_picking_import_serial_number
 #: model_terms:ir.ui.view,arch_db:stock_picking_import_serial_number.stock_picking_import_serial_number_wiz
 msgid "_Cancel"
 msgstr "_Cancelar"
+
+#~ msgid "You only can import S/N for incoming moves"
+#~ msgstr "Solo puede importar S/N para albaranes de entrada"

--- a/stock_picking_import_serial_number/i18n/es.po
+++ b/stock_picking_import_serial_number/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-10 16:10+0000\n"
-"PO-Revision-Date: 2022-08-10 18:12+0200\n"
+"POT-Creation-Date: 2022-08-14 19:01+0000\n"
+"PO-Revision-Date: 2022-08-14 21:02+0200\n"
 "Last-Translator: Sergio Teruel <sergio.teruel@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: stock_picking_import_serial_number
 #: model_terms:ir.ui.view,arch_db:stock_picking_import_serial_number.res_config_settings_view_form
@@ -142,6 +142,11 @@ msgstr "Albarán"
 #: model:ir.model,name:stock_picking_import_serial_number.model_stock_picking_type
 msgid "Picking Type"
 msgstr "Tipo de operación"
+
+#. module: stock_picking_import_serial_number
+#: model:ir.model.fields,field_description:stock_picking_import_serial_number.field_stock_picking_import_serial_number_wiz__process_only_lot_available
+msgid "Process Only Lot Available"
+msgstr "Procesar solo lotes disponibles"
 
 #. module: stock_picking_import_serial_number
 #: model:ir.model.fields.selection,name:stock_picking_import_serial_number.selection__res_config_settings__default_sn_search_product_by_field__default_code

--- a/stock_picking_import_serial_number/i18n/stock_picking_import_serial_number.pot
+++ b/stock_picking_import_serial_number/i18n/stock_picking_import_serial_number.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-08-10 16:10+0000\n"
+"PO-Revision-Date: 2022-08-10 16:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -87,6 +89,12 @@ msgid "ID"
 msgstr ""
 
 #. module: stock_picking_import_serial_number
+#: model:ir.model.fields,field_description:stock_picking_import_serial_number.field_stock_picking__import_lot_from_file
+#: model:ir.model.fields,field_description:stock_picking_import_serial_number.field_stock_picking_type__import_lot_from_file
+msgid "Import Lot From File"
+msgstr ""
+
+#. module: stock_picking_import_serial_number
 #: model:ir.actions.act_window,name:stock_picking_import_serial_number.action_import_serial_number
 #: model_terms:ir.ui.view,arch_db:stock_picking_import_serial_number.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:stock_picking_import_serial_number.stock_picking_import_serial_number_wiz
@@ -125,6 +133,11 @@ msgid "Picking"
 msgstr ""
 
 #. module: stock_picking_import_serial_number
+#: model:ir.model,name:stock_picking_import_serial_number.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: stock_picking_import_serial_number
 #: model:ir.model.fields.selection,name:stock_picking_import_serial_number.selection__res_config_settings__default_sn_search_product_by_field__default_code
 #: model:ir.model.fields.selection,name:stock_picking_import_serial_number.selection__stock_picking_import_serial_number_wiz__sn_search_product_by_field__default_code
 msgid "Reference"
@@ -152,6 +165,11 @@ msgid "Select the index file column which contains the serial numbers info"
 msgstr ""
 
 #. module: stock_picking_import_serial_number
+#: model:ir.model,name:stock_picking_import_serial_number.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: stock_picking_import_serial_number
 #: code:addons/stock_picking_import_serial_number/wizard/import_serial_number_wizard.py:0
 #, python-format
 msgid "You must upload file to import records"
@@ -161,7 +179,7 @@ msgstr ""
 #: code:addons/stock_picking_import_serial_number/wizard/import_serial_number_wizard.py:0
 #, python-format
 msgid ""
-"You only can import S/N for picking operations with creation lots checked"
+"You only can import S/N for picking operations with import lots checked"
 msgstr ""
 
 #. module: stock_picking_import_serial_number

--- a/stock_picking_import_serial_number/i18n/stock_picking_import_serial_number.pot
+++ b/stock_picking_import_serial_number/i18n/stock_picking_import_serial_number.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-10 16:10+0000\n"
-"PO-Revision-Date: 2022-08-10 16:10+0000\n"
+"POT-Creation-Date: 2022-08-14 19:01+0000\n"
+"PO-Revision-Date: 2022-08-14 19:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -135,6 +135,11 @@ msgstr ""
 #. module: stock_picking_import_serial_number
 #: model:ir.model,name:stock_picking_import_serial_number.model_stock_picking_type
 msgid "Picking Type"
+msgstr ""
+
+#. module: stock_picking_import_serial_number
+#: model:ir.model.fields,field_description:stock_picking_import_serial_number.field_stock_picking_import_serial_number_wiz__process_only_lot_available
+msgid "Process Only Lot Available"
 msgstr ""
 
 #. module: stock_picking_import_serial_number

--- a/stock_picking_import_serial_number/models/__init__.py
+++ b/stock_picking_import_serial_number/models/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2022 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import stock_picking
 from . import res_config_settings

--- a/stock_picking_import_serial_number/models/stock_picking.py
+++ b/stock_picking_import_serial_number/models/stock_picking.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    import_lot_from_file = fields.Boolean(
+        compute="_compute_import_lot_from_file", store=True, readonly=False
+    )
+
+    @api.depends("use_create_lots")
+    def _compute_import_lot_from_file(self):
+        for rec in self:
+            if rec.use_create_lots:
+                rec.import_lot_from_file = True
+            else:
+                rec.import_lot_from_file = False
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    # To use in picking view to display import button
+    import_lot_from_file = fields.Boolean(
+        related="picking_type_id.import_lot_from_file"
+    )

--- a/stock_picking_import_serial_number/readme/CONFIGURE.rst
+++ b/stock_picking_import_serial_number/readme/CONFIGURE.rst
@@ -1,6 +1,9 @@
 To configure this module, you need to:
 
 #. Go to a *Inventory > Configuration > Settings*.
-#. Choose the product field which yo want to search products.
+#. Choose the product field which you want to search products.
 #. Choose the file column index where product reference is stored.
 #. Choose the file column index where serial number reference is stored.
+
+#. Go to a *Inventory > Operation types*.
+#. Check the field "Import lot from file" to allow to import S/N.

--- a/stock_picking_import_serial_number/static/description/index.html
+++ b/stock_picking_import_serial_number/static/description/index.html
@@ -389,9 +389,11 @@ from an excel file.</p>
 <p>To configure this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to a <em>Inventory &gt; Configuration &gt; Settings</em>.</li>
-<li>Choose the product field which yo want to search products.</li>
+<li>Choose the product field which you want to search products.</li>
 <li>Choose the file column index where product reference is stored.</li>
 <li>Choose the file column index where serial number reference is stored.</li>
+<li>Go to a <em>Inventory &gt; Operation types</em>.</li>
+<li>Check the field “Import lot from file” to allow to import S/N.</li>
 </ol>
 </div>
 <div class="section" id="usage">

--- a/stock_picking_import_serial_number/tests/common.py
+++ b/stock_picking_import_serial_number/tests/common.py
@@ -18,10 +18,23 @@ class CommonStockPickingImportSerial(object):
         cls.lot_obj = cls.env["stock.production.lot"]
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.picking_type_in = cls.env.ref("stock.picking_type_in")
+        cls.picking_type_int = cls.env.ref("stock.picking_type_internal")
+        cls.picking_type_out = cls.env.ref("stock.picking_type_out")
         cls.picking_type_in.use_create_lots = True
         cls.picking_type_in.show_reserved = True
+
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.stock_location = cls.warehouse.lot_stock_id
+        cls.shelf_location = cls.env["stock.location"].create(
+            {
+                "name": "shelf for tests",
+                "location_id": cls.stock_location.id,
+                "usage": "internal",
+            }
+        )
         cls.supplier = cls.env["res.partner"].create({"name": "Supplier - test"})
+        cls.customer = cls.env["res.partner"].create({"name": "Customer - test"})
         cls.file = b"0M8R4KGxGuEAAAAAAAAAAAAAAAAAAAAAOwADAP7/CQAGAAAAAAAAAAAAAAABAAAACQAAAAAAAAAAEAAAAgAAAAEAAAD+////AAAAAAAAAAD////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////9//////////7///8EAAAABQAAAAYAAAAHAAAACAAAAP7///8KAAAA/v///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////1IAbwBvAHQAIABFAG4AdAByAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAUA////////////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/v///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///////////////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD+////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP///////////////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP7///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA////////////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/v///wAAAAAAAAAAAQAAAAIAAAADAAAABAAAAAUAAAAGAAAABwAAAAgAAAAJAAAACgAAAAsAAAAMAAAADQAAAA4AAAAPAAAAEAAAABEAAAASAAAAEwAAABQAAAAVAAAAFgAAABcAAAAYAAAAGQAAABoAAAAbAAAAHAAAAB0AAAAeAAAAHwAAACAAAAAhAAAAIgAAACMAAAAkAAAAJQAAACYAAAAnAAAA/v///ykAAAD+/////v///ywAAAAtAAAA/v///y8AAAD+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8JCBAAAAYFALsNzAcAAAAABgAAAOEAAgCwBMEAAgAAAOIAAABcAHAABAAAQ2FsYyAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEIAAgCwBGEBAgAAAMABAAA9AQIAAQCcAAIADgCvAQIAAAC8AQIAAAA9ABIAAAAAAABAACA4AAAAAAABAPQBQAACAAAAjQACAAAAIgACAAAADgACAAEAtwECAAAA2gACAAAAMQAaAMgAAAD/f5ABAAAAAgAABQFBAHIAaQBhAGwAMQAaAMgAAAD/f5ABAAAAAAAABQFBAHIAaQBhAGwAMQAaAMgAAAD/f5ABAAAAAAAABQFBAHIAaQBhAGwAMQAaAMgAAAD/f5ABAAAAAAAABQFBAHIAaQBhAGwAMQAuAMgAAAD/f5ABAAAAAQAADwFUAGkAbQBlAHMAIABOAGUAdwAgAFIAbwBtAGEAbgAeBAwApAAHAABHZW5lcmFs4AAUAAAApAD1/yAAAAAAAAAAAAAAAMAg4AAUAAEAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAEAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAIAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAIAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAAAAD1/yAAAPQAAAAAAAAAAMAg4AAUAAAApAABACAAAAAAAAAAAAAAAMAg4AAUAAEAKwD1/yAAAPAAAAAAAAAAAMAg4AAUAAEAKQD1/yAAAPAAAAAAAAAAAMAg4AAUAAEALAD1/yAAAPAAAAAAAAAAAMAg4AAUAAEAKgD1/yAAAPAAAAAAAAAAAMAg4AAUAAEACQD1/yAAAPAAAAAAAAAAAMAg4AAUAAUApAABACgAABgAAAAAAAAAAMAgkwIEAACAAP+TAgQAEIAD/5MCBAARgAb/kwIEABKABP+TAgQAE4AH/5MCBAAUgAX/YAECAAAAhQANADUFAAAAAAUASG9qYTGMAAQAIgAiAMEBCADBAQAAVI0BAOsAWgAPAADwUgAAAAAABvAYAAAAAAQAAAIAAAABAAAAAQAAAAEAAAABAAAAMwAL8BIAAAC/AAgACACBAQkAAAjAAUAAAAhAAB7xEAAAAA0AAAgMAAAIFwAACPcAABD8AIkAHAAAABIAAAADAABTS1UDAABTL04EAAAxMjM0BAAAWFgwMQQAAFhYMDIEAABYWDAzBQAAOTk5OTkEAABZWTAxBAAAWVkwMgQAAFlZMDMIAAAnOTk5OTlYWAQAAFBQOTkEAABZWTA0BAAAWVkwNQQAAFlZMDYEAABYWDA0BAAAWFgwNQQAAFhYMDb/AAoAEgCJBAAADAAAAGMIFQBjCAAAAAAAAAAAAAAVAAAAAAAAAAIKAAAACQgQAAAGEAC7DcwHAAAAAAYAAAAMAAIAZAAPAAIAAQARAAIAAAAQAAgA/Knx0k1iUD9fAAIAAQCAAAgAAAAAAAAAAAAlAgQAAAAAAYEAAgDBBCoAAgAAACsAAgAAAIIAAgABABQAIwAgAAAmQyYiVGltZXMgTmV3IFJvbWFuLE5vcm1hbCImMTImQRUAKgAnAAAmQyYiVGltZXMgTmV3IFJvbWFuLE5vcm1hbCImMTJQ4WdpbmEgJlCDAAIAAACEAAIAAAAmAAgAMzMzMzMz6T8nAAgAMzMzMzMz6T8oAAgAgy3Ygi3Y8D8pAAgAgy3Ygi3Y8D+hACIACQBkAAEAAQABAIIALAEsATMzMzMzM+k/MzMzMzMz6T8BAFUAAgAIAH0ADAAAAAAAYhYPAAAAAAB9AAwAAQABAIkLDwAAAAAAfQAMAAIAAgCuPA8AAAAAAH0ADAADAAABiQsPAAAAAAAAAg4AAAAAAA4AAAAAAAIAAAAIAhAAAAAAAAIAAAEAAAAAAAEPAAgCEAABAAAAAgAEAQAAAAAAAQ8ACAIQAAIAAAACAAQBAAAAAAABDwAIAhAAAwAAAAIABAEAAAAAAAEPAAgCEAAEAAAAAgAEAQAAAAAAAQ8ACAIQAAUAAAACAAQBAAAAAAABDwAIAhAABgAAAAIABAEAAAAAAAEPAAgCEAAHAAAAAgAEAQAAAAAAAQ8ACAIQAAgAAAACAAQBAAAAAAABDwAIAhAACQAAAAIABAEAAAAAAAEPAAgCEAAKAAAAAgAEAQAAAAAAAQ8ACAIQAAsAAAACAAQBAAAAAAABDwAIAhAADAAAAAIABAEAAAAAAAEPAAgCEAANAAAAAgAEAQAAAAAAAQ8A/QAKAAAAAAAPAAAAAAD9AAoAAAABAA8AAQAAAP0ACgABAAAAFQACAAAA/QAKAAEAAQAPAAMAAAD9AAoAAgAAABUAAgAAAP0ACgACAAEADwAEAAAA/QAKAAMAAAAVAAIAAAD9AAoAAwABAA8ABQAAAP0ACgAEAAAAFQAGAAAA/QAKAAQAAQAPAAcAAAD9AAoABQAAABUABgAAAP0ACgAFAAEADwAIAAAA/QAKAAYAAAAVAAYAAAD9AAoABgABAA8ACQAAAP0ACgAHAAAAFQAKAAAA/QAKAAcAAQAPAAsAAAD9AAoACAAAABUABgAAAP0ACgAIAAEADwAMAAAA/QAKAAkAAAAVAAYAAAD9AAoACQABAA8ADQAAAP0ACgAKAAAAFQAGAAAA/QAKAAoAAQAPAA4AAAD9AAoACwAAABUAAgAAAP0ACgALAAEADwAPAAAA/QAKAAwAAAAVAAIAAAD9AAoADAABAA8AEAAAAP0ACgANAAAAFQACAAAA/QAKAA0AAQAPABEAAADsAFAADwAC8EgAAAAQAAjwCAAAAAEAAAAABAAADwAD8DAAAAAPAATwKAAAAAEACfAQAAAAAAAAAAAAAAAAAAAAAAAAAAIACvAIAAAAAAQAAAUAAAA+AhIAtgYAAAAAQAAAAAAAAAAAAAAAHQAPAAMKAAAAAAABAAoACgAAAGcIFwBnCAAAAAAAAAAAAAACAAH/////AAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQD+/wMKAAD/////EAgCAAAAAADAAAAAAAAARhsAAABNaWNyb3NvZnQgRXhjZWwgOTctVGFiZWxsZQAGAAAAQmlmZjgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/v8AAAEAAgAAAAAAAAAAAAAAAAAAAAAAAQAAAOCFn/L5T2gQq5EIACsns9kwAAAAfAAAAAYAAAABAAAAOAAAAAkAAABAAAAACgAAAEwAAAALAAAAWAAAAAwAAABkAAAADQAAAHAAAAACAAAA6f0AAB4AAAACAAAANAAAAEAAAACAZkDOCgAAAEAAAAAAAAAAAAAAAEAAAAA24NEQLl/YAUAAAACiSFjgOF/YAQAAAAAAAAAAAAAAAAAAAAAAAAAA/v8AAAEAAgAAAAAAAAAAAAAAAAAAAAAAAgAAAALVzdWcLhsQk5cIACss+a5EAAAABdXN1ZwuGxCTlwgAKyz5rlwAAAAYAAAAAQAAAAEAAAAQAAAAAgAAAOn9AAAYAAAAAQAAAAEAAAAQAAAAAgAAAOn9AAAAAAAAAAAAAAAAAABSAG8AbwB0ACAARQBuAHQAcgB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAFAP//////////AQAAABAIAgAAAAAAwAAAAAAAAEYAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAADAAAAAAAAFcAbwByAGsAYgBvAG8AawAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAIAAgAAAAQAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQJAAAAAAAAAQBDAG8AbQBwAE8AYgBqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABIAAgADAAAA//////////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAASQAAAAAAAAABAE8AbABlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgACAP///////////////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoAAAAUAAAAAAAAAAUAUwB1AG0AbQBhAHIAeQBJAG4AZgBvAHIAbQBhAHQAaQBvAG4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAIA/////wUAAAD/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAKwAAAAAAAAABQBEAG8AYwB1AG0AZQBuAHQAUwB1AG0AbQBhAHIAeQBJAG4AZgBvAHIAbQBhAHQAaQBvAG4AAAAAAAAAAAAAADgAAgD///////////////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuAAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP///////////////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP7///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA////////////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/v///wAAAAAAAAAA"  # noqa: B950
 
     @classmethod
@@ -37,22 +50,41 @@ class CommonStockPickingImportSerial(object):
         return cls.env["product.product"].create(vals)
 
     @classmethod
-    def _create_picking(cls):
-        return (
-            cls.env["stock.picking"]
-            .with_context(default_picking_type_id=cls.picking_type_in.id)
-            .create(
+    def _create_picking(cls, picking_type):
+        vals = {}
+        if picking_type.code == "incoming":
+            vals.update(
                 {
                     "partner_id": cls.supplier.id,
                     "picking_type_id": cls.picking_type_in.id,
                     "location_id": cls.supplier_location.id,
                 }
             )
+        if picking_type.code == "internal":
+            vals.update(
+                {
+                    "picking_type_id": cls.picking_type_int.id,
+                    "location_id": cls.stock_location.id,
+                    "location_dest_id": cls.shelf_location.id,
+                }
+            )
+        if picking_type.code == "outgoing":
+            vals.update(
+                {
+                    "partner_id": cls.customer.id,
+                    "picking_type_id": cls.picking_type_customer.id,
+                    "location_id": cls.stock_location.id,
+                    "location_dest_id": cls.customer_location.id,
+                }
+            )
+        return (
+            cls.env["stock.picking"]
+            .with_context(default_picking_type_id=picking_type.id)
+            .create(vals)
         )
 
     @classmethod
     def _create_move(cls, picking, product=None, qty=1.0):
-        location_dest = picking.picking_type_id.default_location_dest_id
         cls.move = cls.env["stock.move"].create(
             {
                 "name": "test-{product}".format(product=product.name),
@@ -61,7 +93,28 @@ class CommonStockPickingImportSerial(object):
                 "picking_type_id": picking.picking_type_id.id,
                 "product_uom_qty": qty,
                 "product_uom": product.uom_id.id,
-                "location_id": cls.supplier_location.id,
-                "location_dest_id": location_dest.id,
+                "location_id": picking.location_id.id,
+                "location_dest_id": picking.location_dest_id.id,
             }
         )
+
+    @classmethod
+    def _create_lots_for_product(cls, product, lots_name):
+        vals_list = [
+            {"product_id": product.id, "name": x, "company_id": cls.env.company.id}
+            for x in lots_name
+        ]
+        return cls.env["stock.production.lot"].create(vals_list)
+
+    @classmethod
+    def _create_quant_for_lot(cls, lots):
+        vals_list = [
+            {
+                "product_id": x.product_id.id,
+                "location_id": cls.stock_location.id,
+                "quantity": 1.0,
+                "lot_id": x.id,
+            }
+            for x in lots
+        ]
+        return cls.env["stock.quant"].create(vals_list)

--- a/stock_picking_import_serial_number/tests/test_stock_picking_import_serial_number.py
+++ b/stock_picking_import_serial_number/tests/test_stock_picking_import_serial_number.py
@@ -15,7 +15,7 @@ class TestStockPickingImportSN(CommonStockPickingImportSerial, SavepointCase):
         cls.product_serial = cls._create_product(tracking="serial", reference="1234")
         cls.product_no_tracking = cls._create_product(tracking="none")
 
-        cls.picking_in_01 = cls._create_picking()
+        cls.picking_in_01 = cls._create_picking(cls.picking_type_in)
         cls._create_move(picking=cls.picking_in_01, product=cls.product_lot, qty=2.0)
         cls._create_move(picking=cls.picking_in_01, product=cls.product_serial, qty=3.0)
         cls._create_move(
@@ -24,7 +24,7 @@ class TestStockPickingImportSN(CommonStockPickingImportSerial, SavepointCase):
 
         cls.picking_in_01.action_assign()
 
-        cls.picking_in_02 = cls._create_picking()
+        cls.picking_in_02 = cls._create_picking(cls.picking_type_in)
         cls._create_move(picking=cls.picking_in_02, product=cls.product_lot, qty=2.0)
         cls._create_move(picking=cls.picking_in_02, product=cls.product_serial, qty=3.0)
         cls._create_move(
@@ -72,3 +72,26 @@ class TestStockPickingImportSN(CommonStockPickingImportSerial, SavepointCase):
         wiz.action_import()
         smls = picking.move_line_nosuggest_ids.filtered("lot_name")
         self.assertEqual(len(smls), 6)
+
+    def test_import_serial_number_internal_transfer(self):
+        # Create an internal transfer
+        self.picking_type_int.import_lot_from_file = True
+        picking_int = self._create_picking(self.picking_type_int)
+        self._create_move(picking=picking_int, product=self.product_serial, qty=3.0)
+        lots = self._create_lots_for_product(
+            self.product_serial, ["XX01_1", "XX02_1", "XX03"]
+        )
+        self._create_quant_for_lot(lots)
+        picking_int.action_assign()
+
+        # Create the file lot to avoid error
+        file_lots = self._create_lots_for_product(self.product_serial, ["XX01", "XX02"])
+        wiz = self._create_wizard(pickings=picking_int)
+        wiz.action_import()
+        # Initial sml = 3 (XX01_1 ==> 0.0, XX02_1 ==> 0.0, XX03 ==> 0.0)
+        # After import file with S/N sml = 5
+        # (XX01_1 ==> 0.0, XX02_1 ==> 0.0, XX03 ==> 1.0, XX01 ==> 1.0, XX02 ==> 1.0)
+        self.assertEqual(len(picking_int.move_line_ids), 5)
+        # sml with lot XX01 is new
+        self.assertEqual(picking_int.move_line_ids[3].lot_id, file_lots[0])
+        self.assertEqual(picking_int.move_line_ids[3].qty_done, 1.0)

--- a/stock_picking_import_serial_number/tests/test_stock_picking_import_serial_number.py
+++ b/stock_picking_import_serial_number/tests/test_stock_picking_import_serial_number.py
@@ -87,6 +87,7 @@ class TestStockPickingImportSN(CommonStockPickingImportSerial, SavepointCase):
         # Create the file lot to avoid error
         file_lots = self._create_lots_for_product(self.product_serial, ["XX01", "XX02"])
         wiz = self._create_wizard(pickings=picking_int)
+        wiz.process_only_lot_available = False
         wiz.action_import()
         # Initial sml = 3 (XX01_1 ==> 0.0, XX02_1 ==> 0.0, XX03 ==> 0.0)
         # After import file with S/N sml = 5
@@ -95,3 +96,23 @@ class TestStockPickingImportSN(CommonStockPickingImportSerial, SavepointCase):
         # sml with lot XX01 is new
         self.assertEqual(picking_int.move_line_ids[3].lot_id, file_lots[0])
         self.assertEqual(picking_int.move_line_ids[3].qty_done, 1.0)
+
+    def test_import_serial_number_internal_transfer_qty_available(self):
+        # Create an internal transfer
+        self.picking_type_int.import_lot_from_file = True
+        picking_int = self._create_picking(self.picking_type_int)
+        self._create_move(picking=picking_int, product=self.product_serial, qty=3.0)
+        lots = self._create_lots_for_product(
+            self.product_serial, ["XX01_1", "XX02_1", "XX03"]
+        )
+        self._create_quant_for_lot(lots)
+        picking_int.action_assign()
+
+        # Create the file lot to avoid error
+        file_lots = self._create_lots_for_product(self.product_serial, ["XX01", "XX02"])
+        wiz = self._create_wizard(pickings=picking_int)
+        wiz.process_only_lot_available = True
+        # There are not quantity available for lot XX01. So not must be any sml line
+        # with lot XX01
+        smls = picking_int.move_line_ids.filtered(lambda ln: ln.lot_id == file_lots[0])
+        self.assertFalse(smls)

--- a/stock_picking_import_serial_number/views/stock_picking.xml
+++ b/stock_picking_import_serial_number/views/stock_picking.xml
@@ -1,13 +1,23 @@
 <odoo>
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='stock_picking_type_lot']" position="inside">
+                <field name="import_lot_from_file" />
+            </xpath>
+        </field>
+    </record>
     <record id="view_picking_form" model="ir.ui.view">
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <button name="action_toggle_is_locked" position="after">
+                <field name="import_lot_from_file" invisible="1" />
                 <button
                     name="%(action_import_serial_number)d"
                     string="Import S/N"
-                    attrs="{'invisible': ['|', ('state', '!=', 'assigned'), ('picking_type_code', '!=', 'incoming')]}"
+                    attrs="{'invisible': ['|', ('state', '!=', 'assigned'), ('import_lot_from_file', '=', False)]}"
                     type="action"
                     groups="base.group_user"
                 />

--- a/stock_picking_import_serial_number/wizard/import_serial_number_view.xml
+++ b/stock_picking_import_serial_number/wizard/import_serial_number_view.xml
@@ -13,6 +13,7 @@
                             placeholder="Choose a file to import..."
                         />
                         <field name="overwrite_serial" />
+                        <field name="process_only_lot_available" />
                         <field name="filename" invisible="1" />
                     </group>
                     <field name="picking_ids" invisible="1" />

--- a/stock_picking_import_serial_number/wizard/import_serial_number_wizard.py
+++ b/stock_picking_import_serial_number/wizard/import_serial_number_wizard.py
@@ -42,11 +42,13 @@ class StockPickingImportSerialNumber(models.TransientModel):
     sn_serial_column_index = fields.Integer(string="Column index for S/N", default="1")
 
     def action_import(self):
-        if self.picking_ids.filtered(lambda p: not p.picking_type_id.use_create_lots):
+        if self.picking_ids.filtered(
+            lambda p: not p.picking_type_id.import_lot_from_file
+        ):
             raise UserError(
                 _(
                     "You only can import S/N for picking operations with"
-                    " creation lots checked"
+                    " import lots checked"
                 )
             )
         if not self.data_file:
@@ -61,7 +63,7 @@ class StockPickingImportSerialNumber(models.TransientModel):
             for picking in self.picking_ids:
                 move_lines = picking.mapped("move_line_ids").filtered(
                     lambda ln: ln.product_id.tracking == "serial"
-                    and ln.picking_id.picking_type_id.use_create_lots
+                    and ln.picking_id.picking_type_id.import_lot_from_file
                 )
                 self._import_serial_number(xl_sheet, move_lines, picking)
         self.data_file = False
@@ -78,30 +80,81 @@ class StockPickingImportSerialNumber(models.TransientModel):
         products = self.env["product.product"].search(
             [(self.sn_search_product_by_field, "in", list(product_file_set))]
         )
+        assigned_sml = set()
         for item in serial_list:
+            lot_name = item[1]
             product = products.filtered(
                 lambda p: p[self.sn_search_product_by_field] == item[0]
             )
-            if picking.picking_type_id.show_reserved:
-                smls = stock_move_lines.filtered(lambda ln: ln.product_id == product)
-                for sml in smls:
-                    if not sml.lot_name or self.overwrite_serial:
-                        sml.lot_name = item[1]
-                        sml.qty_done = 1.0
-                        # Only assign one serial
-                        break
-            # TODO: Check if product is present on initial demand??
-            # elif product and picking.move_lines.filtered(lambda ln: ln.product_id == product)
-            elif product:
-                self.env["stock.move.line"].create(
-                    {
-                        "picking_id": picking.id,
-                        "location_id": picking.location_id.id,
-                        "location_dest_id": picking.location_dest_id.id,
-                        "product_id": product.id,
-                        "product_uom_id": product.uom_id.id,
-                        "lot_name": item[1],
-                        "product_uom_qty": 0.0,
-                        "qty_done": 1.0,
-                    }
+            if picking.import_lot_from_file:
+                self._assign_lot(
+                    picking, product, lot_name, stock_move_lines, assigned_sml
                 )
+
+    def _assign_lot(self, picking, product, lot_name, stock_move_lines, assigned_sml):
+        # Exclude smls with a lot_name assigned
+        domain = [("product_id", "=", product.id), ("lot_name", "=", False)]
+        if self.overwrite_serial:
+            domain.remove(("lot_name", "=", False))
+        smls = stock_move_lines.filtered_domain(domain)
+
+        if picking.picking_type_code == "incoming":
+            if picking.picking_type_id.show_reserved:
+                for sml in smls:
+                    if not sml.lot_name or (
+                        self.overwrite_serial and sml.id not in assigned_sml
+                    ):
+                        sml.lot_name = lot_name
+                        sml.qty_done = 1.0
+                        assigned_sml.add(sml.id)
+                        break
+            elif product:
+                self._create_new_stock_move_line(
+                    picking, product, lot_name, assigned_sml
+                )
+        else:
+            # Internal transfers or outgoing pickings
+            sml = smls.filtered(
+                lambda ln: ln.product_id == product and ln.lot_id.name == lot_name
+            )
+            if sml:
+                sml.qty_done = 1.0
+                assigned_sml.add(sml.id)
+            else:
+                self._create_new_stock_move_line(
+                    picking, product, lot_name, assigned_sml, search_lot=True
+                )
+
+    def _create_new_stock_move_line(
+        self, picking, product, lot_name, assigned_sml, search_lot=False
+    ):
+        lot = False
+        if search_lot:
+            # For use case of internal transfers or outgoing picking the lots of file
+            # must be exists
+            lot = self.env["stock.production.lot"].search(
+                [("product_id", "=", product.id), ("name", "=", lot_name)]
+            )
+            if not lot:
+                # TODO: What to do in this case.
+                # Raise an error or continue
+                # raise UserError(_("Lots not found"))
+                return False
+        move = picking.move_lines.filtered(lambda ln: ln.product_id == product)
+        vals = {
+            "picking_id": picking.id,
+            "location_id": picking.location_id.id,
+            "location_dest_id": picking.location_dest_id.id,
+            "product_id": product.id,
+            "product_uom_id": product.uom_id.id,
+            "lot_name": lot_name,
+            "qty_done": 1.0,
+            "move_id": move[:1].id,
+        }
+        # To display in suggested move lines
+        if not picking.picking_type_id.show_reserved:
+            vals["product_uom_qty"] = 0.0
+        if lot:
+            vals["lot_id"] = lot.id
+        sml = self.env["stock.move.line"].create(vals)
+        assigned_sml.add(sml.id)


### PR DESCRIPTION
cc @Tecnativa TT38516

ping @pedrobaeza @chienandalu 

I have some doubt regarding internal pickings and ougoing...
At the moment, if the lot exists and not in sml reserved, the stock move line is created, but I don't check if there is availability...

@ryanc-me https://github.com/OCA/stock-logistics-workflow/pull/1062 fixed here