### PR TITLE
[14.0][FIX] stock_restrict_lot: do not merge stock move with different restrict_lot_id

### DIFF
--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -1,6 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, exceptions, fields, models
+from odoo import _, api, exceptions, fields, models
 
 
 class StockMove(models.Model):
@@ -17,6 +17,12 @@ class StockMove(models.Model):
         vals = super()._prepare_procurement_values()
         vals["restrict_lot_id"] = self.restrict_lot_id.id
         return vals
+
+    @api.model
+    def _prepare_merge_moves_distinct_fields(self):
+        distinct_fields = super()._prepare_merge_moves_distinct_fields()
+        distinct_fields.append("restrict_lot_id")
+        return distinct_fields
 
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
         vals = super()._prepare_move_line_vals(


### PR DESCRIPTION
Odoo tries to avoid extra stock.move while generating stock.picking from
pull/push rules. We must tell odoo to not merge stock.move if they are restricted
different lot.

To reproduce this behaviour using sale_order_lot_selection you have to:
* setup inventory with multi-step routes
* setup warehouse with two steps outgoing shipments
* receive products with different lot
* create a sale order with different quantities per lot
* validate the sale order

Before this PR stock.move in the internal stock.picking pick order are merged

After this PR we have one line per selected lot in internal stock.picking pick order