### PR TITLE
[13.0][FIX] purchase_stock_picking_invoice_link: Consider DS pickings

### DIFF
--- a/purchase_stock_picking_invoice_link/models/purchase_order.py
+++ b/purchase_stock_picking_invoice_link/models/purchase_order.py
@@ -14,9 +14,9 @@ class SaleOrderLine(models.Model):
                 stock_move.state != "done"
                 or stock_move.scrapped
                 or (
-                    stock_move.location_dest_id.usage != "internal"
+                    stock_move.location_id.usage != "supplier"
                     and (
-                        stock_move.location_id.usage != "internal"
+                        stock_move.location_dest_id.usage != "supplier"
                         or not stock_move.to_refund
                     )
                 )
@@ -24,6 +24,7 @@ class SaleOrderLine(models.Model):
                 continue
             invoice_lines = stock_move.invoice_line_ids.filtered(
                 lambda invl: invl.move_id.state != "cancel"
+                and invl.move_id.type in {"in_invoice", "in_refund"}
             )
             invoiced_qty = 0
             for inv_line in invoice_lines:


### PR DESCRIPTION
**Steps to reproduce the problem:**

- Create a sales order with Dropshipping route.
- Confirm the sale order.
- Confirm the purchase order and validate the DS picking.
- Invoice the sales order.
- Invoice the purchase order.

**Current behavior:**

The vendor bill is not linked to the DS picking

**Expected behavior:**

It's linked.

That's because 2 problems:

- Current algorithm looks for existing invoices linked to the picking for discarding double links, but it's not having into account that such invoices can be customer ones.

  We simply filter for vendor bills in the algorithm to fix it. Twin for the customer part already done in #1036.

- The location filter must use the supplier location as reference, not the internal one, as in DS, there's no internal location.

@Tecnativa TT38628