### PR TITLE
[13.0][FIX] stock_picking_invoice_link: Consider DS pickings

### DIFF
--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -25,6 +25,7 @@ class SaleOrderLine(models.Model):
                 continue
             invoice_lines = stock_move.invoice_line_ids.filtered(
                 lambda invl: invl.move_id.state != "cancel"
+                and invl.move_id.type in {"out_invoice", "out_refund"}
             )
             invoiced_qty = 0
             for inv_line in invoice_lines:


### PR DESCRIPTION
Steps to reproduce the problem:

- Create a sales order with Dropshipping route.
- Confirm the sale order and validate the DS picking.
- Invoice the purchase order.
- Invoice the sales order.

Current behavior:

The customer invoice is not linked to the DS picking

Expected behavior:

It's linked.

That's because current algorithm looks for existing invoices linked to
the picking for discarding double links, but it's not having into
account that such invoices can be vendor ones.

We simply filter for customer invoices in the algorithm to fix it.

TT37997

ping @pedrobaeza 