### PR TITLE
[FIX] stock_picking_purchase_order_link: remove read access to ir.actions

### DIFF
--- a/stock_picking_purchase_order_link/models/stock_picking.py
+++ b/stock_picking_purchase_order_link/models/stock_picking.py
@@ -12,7 +12,7 @@ class StockPicking(models.Model):
         of given picking.
         """
         self.ensure_one()
-        action = self.env.ref("purchase.purchase_form_action").read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id("purchase.purchase_form_action")
         form = self.env.ref("purchase.purchase_order_form")
         action["views"] = [(form.id, "form")]
         action["res_id"] = self.purchase_id.id

--- a/stock_picking_purchase_order_link/models/stock_picking.py
+++ b/stock_picking_purchase_order_link/models/stock_picking.py
@@ -12,7 +12,9 @@ class StockPicking(models.Model):
         of given picking.
         """
         self.ensure_one()
-        action = self.env["ir.actions.actions"]._for_xml_id("purchase.purchase_form_action")
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "purchase.purchase_form_action"
+        )
         form = self.env.ref("purchase.purchase_order_form")
         action["views"] = [(form.id, "form")]
         action["res_id"] = self.purchase_id.id


### PR DESCRIPTION
As odoo mentioned this changes here:
https://github.com/odoo/odoo/pull/53335