### PR TITLE
[14.0][FIX] purchase_stock_picking_invoice_link: Incorrect relation when backorders

### DIFF
--- a/purchase_stock_picking_invoice_link/models/stock_move.py
+++ b/purchase_stock_picking_invoice_link/models/stock_move.py
@@ -15,7 +15,10 @@ class StockMove(models.Model):
         res = super().write(vals)
         if vals.get("state", "") == "done":
             stock_moves = self.get_moves_link_invoice()
-            for stock_move in stock_moves.filtered("purchase_line_id"):
+            for stock_move in stock_moves.filtered(
+                lambda sm: sm.purchase_line_id
+                and sm.product_id.purchase_method == "purchase"
+            ):
                 inv_type = stock_move.to_refund and "in_refund" or "in_invoice"
                 inv_line = self.env["account.move.line"].search(
                     [


### PR DESCRIPTION
cc @Tecnativa TT38840

Before this patch, when we receive products in a backorder and the other quantities received where invoiced yet, the picking of the backorder will be related to the invoice created for the other quantities.

With this patch, this situation will just happen when the invoicing policy of the product is based on quantities purchased.

Steps to reproduce the problem:

1. Create a purchase order buying 10 units of some stockable product
2. Receive 8 units of the product
3. Create back order
4. Invoice the received quantity (8 units)
5. Receive 2 units of the product in the created back order
6. You will see that the back order picking is related to the invoice with 8 units