### PR TITLE
[14.0] Add module stock_lot_on_hand_first

### DIFF
--- a/setup/stock_lot_on_hand_first/odoo/addons/stock_lot_on_hand_first
+++ b/setup/stock_lot_on_hand_first/odoo/addons/stock_lot_on_hand_first
@@ -1,0 +1,1 @@
+../../../../stock_lot_on_hand_first

--- a/setup/stock_lot_on_hand_first/setup.py
+++ b/setup/stock_lot_on_hand_first/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_lot_on_hand_first/README.rst
+++ b/stock_lot_on_hand_first/README.rst
@@ -1,0 +1,1 @@
+To be auto generated

--- a/stock_lot_on_hand_first/__init__.py
+++ b/stock_lot_on_hand_first/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_lot_on_hand_first/__manifest__.py
+++ b/stock_lot_on_hand_first/__manifest__.py
@@ -18,5 +18,6 @@
         "views/stock_move_line.xml",
         "views/stock_move.xml",
         "views/stock_picking_type.xml",
+        "views/stock_picking.xml",
     ],
 }

--- a/stock_lot_on_hand_first/__manifest__.py
+++ b/stock_lot_on_hand_first/__manifest__.py
@@ -11,9 +11,7 @@
     "maintainers": ["grindtildeath"],
     "license": "AGPL-3",
     "installable": True,
-    "depends": [
-        "stock_lot_product_qty_search",
-    ],
+    "depends": ["stock_lot_product_qty_search", "base_view_inheritance_extension"],
     "data": [
         "views/stock_move_line.xml",
         "views/stock_move.xml",

--- a/stock_lot_on_hand_first/__manifest__.py
+++ b/stock_lot_on_hand_first/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Lot On Hand First",
+    "summary": "Allows to display lots on hand first in M2o fields",
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Inventory/Inventory",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["grindtildeath"],
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "stock_lot_product_qty_search",
+    ],
+    "data": [
+        "views/stock_move_line.xml",
+        "views/stock_move.xml",
+        "views/stock_picking_type.xml",
+    ],
+}

--- a/stock_lot_on_hand_first/models/__init__.py
+++ b/stock_lot_on_hand_first/models/__init__.py
@@ -1,3 +1,4 @@
 from . import stock_move
+from . import stock_picking
 from . import stock_picking_type
 from . import stock_production_lot

--- a/stock_lot_on_hand_first/models/__init__.py
+++ b/stock_lot_on_hand_first/models/__init__.py
@@ -1,0 +1,3 @@
+from . import stock_move
+from . import stock_picking_type
+from . import stock_production_lot

--- a/stock_lot_on_hand_first/models/stock_move.py
+++ b/stock_lot_on_hand_first/models/stock_move.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+
+    _inherit = "stock.move"
+
+    display_lots_on_hand_first = fields.Boolean(
+        related="picking_type_id.display_lots_on_hand_first",
+        readonly=True,
+    )

--- a/stock_lot_on_hand_first/models/stock_picking.py
+++ b/stock_lot_on_hand_first/models/stock_picking.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+
+    _inherit = "stock.picking"
+
+    display_lots_on_hand_first = fields.Boolean(
+        related="picking_type_id.display_lots_on_hand_first",
+        readonly=True,
+    )

--- a/stock_lot_on_hand_first/models/stock_picking_type.py
+++ b/stock_lot_on_hand_first/models/stock_picking_type.py
@@ -1,0 +1,23 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class StockPickingType(models.Model):
+
+    _inherit = "stock.picking.type"
+
+    display_lots_on_hand_first = fields.Boolean(
+        compute="_compute_display_lots_on_hand_first",
+        store=True,
+        readonly=False,
+        help="When marked, lots that do not have a quantity in stock will be displayed"
+        " last in the selection",
+    )
+
+    @api.depends("use_existing_lots")
+    def _compute_display_lots_on_hand_first(self):
+        """Reset display_lots_on_hand_first if use_existing_lots is set to False"""
+        for picking_type in self:
+            if not picking_type.use_existing_lots:
+                picking_type.display_lots_on_hand_first = False

--- a/stock_lot_on_hand_first/models/stock_production_lot.py
+++ b/stock_lot_on_hand_first/models/stock_production_lot.py
@@ -1,0 +1,21 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class ProductionLot(models.Model):
+    _inherit = "stock.production.lot"
+
+    def name_get(self):
+        """Move lots without a qty on hand at the end of the list"""
+        res = super().name_get()
+        if self.env.context.get("name_search_qty_on_hand_first"):
+            no_qty_lot_ids = self.search([("product_qty", "=", 0)]).ids
+            res_copy = res.copy()
+            to_reorder = []
+            for pos, lot_id_name in enumerate(res):
+                if lot_id_name[0] in no_qty_lot_ids:
+                    to_reorder.append(res_copy.pop(pos - len(to_reorder)))
+            res_copy += to_reorder
+            res = res_copy
+        return res

--- a/stock_lot_on_hand_first/models/stock_production_lot.py
+++ b/stock_lot_on_hand_first/models/stock_production_lot.py
@@ -1,21 +1,46 @@
 # Copyright 2022 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo import models
+from odoo import api, models
+from odoo.osv.expression import AND
 
 
 class ProductionLot(models.Model):
     _inherit = "stock.production.lot"
 
-    def name_get(self):
+    @api.model
+    def _name_search(self, name="", args=None, operator="ilike", limit=80):
         """Move lots without a qty on hand at the end of the list"""
-        res = super().name_get()
+
         if self.env.context.get("name_search_qty_on_hand_first"):
-            no_qty_lot_ids = self.search([("product_qty", "=", 0)]).ids
-            res_copy = res.copy()
-            to_reorder = []
-            for pos, lot_id_name in enumerate(res):
-                if lot_id_name[0] in no_qty_lot_ids:
-                    to_reorder.append(res_copy.pop(pos - len(to_reorder)))
-            res_copy += to_reorder
-            res = res_copy
-        return res
+            args = list(args or [])
+
+            with_quantity_domain = AND([args, [("product_qty", ">", 0)]])
+            with_quantity_count = self.env["stock.production.lot"].search_count(
+                with_quantity_domain
+            )
+
+            if with_quantity_count >= limit:
+                args = with_quantity_domain
+            else:
+                with_quantity_ids = super()._name_search(
+                    name=name, args=with_quantity_domain, operator=operator, limit=limit
+                )
+                without_quantity_ids = super()._name_search(
+                    name=name,
+                    args=AND([args, [("product_qty", "=", 0)]]),
+                    operator=operator,
+                    limit=limit - with_quantity_count,
+                )
+                # _name_search is supposed to return a odoo.osv.query.Query object
+                # that will be evaluated as a list of ids when used in the browse function.
+                # Since we cannot merge the Query objects to respect the intended order
+                # in which we want to display the results,  we return the list of ids
+                # that will be used by browse in the name_search implementation.
+                return (
+                    self.browse(with_quantity_ids).ids
+                    + self.browse(without_quantity_ids).ids
+                )
+
+        return super()._name_search(
+            name=name, args=args, operator=operator, limit=limit
+        )

--- a/stock_lot_on_hand_first/readme/CONFIGURATION.rst
+++ b/stock_lot_on_hand_first/readme/CONFIGURATION.rst
@@ -1,0 +1,3 @@
+On the Operations types (`stock.picking.type`) an extra checkbox will appear if
+Use Existing Lots/Serial Numbers is selected, to allow reordering the results
+appearing in the selection.

--- a/stock_lot_on_hand_first/readme/CONTRIBUTORS.rst
+++ b/stock_lot_on_hand_first/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>
+* Ricardo Almeida Soares <ricardo.almeidasoares@camptocamp.com>

--- a/stock_lot_on_hand_first/readme/DESCRIPTION.rst
+++ b/stock_lot_on_hand_first/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module allows to display lots with a quantity on hand as first results
+in the selection field of Detailed Operations (`stock.move.line`) in order
+to avoid displaying old lots that are not in stock anymore.

--- a/stock_lot_on_hand_first/tests/__init__.py
+++ b/stock_lot_on_hand_first/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_lot_on_hand_first

--- a/stock_lot_on_hand_first/tests/test_lot_on_hand_first.py
+++ b/stock_lot_on_hand_first/tests/test_lot_on_hand_first.py
@@ -39,12 +39,13 @@ class TestLotOnHandFirst(SavepointCase):
         lot_3 = self._create_lot(self.product, "LOT-000003", 2)
         lot_4 = self._create_lot(self.product, "LOT-000004", 0)
         lot_5 = self._create_lot(self.product, "LOT-000005", 1)
-        all_product_lots = self.env["stock.production.lot"].search(
-            [("product_id", "=", self.product.id)]
+
+        name_get_res = (
+            self.env["stock.production.lot"]
+            .with_context(name_search_qty_on_hand_first=True)
+            .name_search(args=[("product_id", "=", self.product.id)])
         )
-        name_get_res = all_product_lots.with_context(
-            name_search_qty_on_hand_first=True
-        ).name_get()
+
         expected_res = [
             (lot_2.id, lot_2.name),
             (lot_3.id, lot_3.name),
@@ -60,12 +61,12 @@ class TestLotOnHandFirst(SavepointCase):
         lot_1 = self._create_lot(self.product, "LOT-000001", 0)
         lot_2 = self._create_lot(self.product, "LOT-000002", 0)
         lot_3 = self._create_lot(self.product, "LOT-000003", 0)
-        all_product_lots = self.env["stock.production.lot"].search(
-            [("product_id", "=", self.product.id)]
+
+        name_get_res = (
+            self.env["stock.production.lot"]
+            .with_context(name_search_qty_on_hand_first=True)
+            .name_search(args=[("product_id", "=", self.product.id)])
         )
-        name_get_res = all_product_lots.with_context(
-            name_search_qty_on_hand_first=True
-        ).name_get()
         expected_res = [
             (lot_1.id, lot_1.name),
             (lot_2.id, lot_2.name),
@@ -88,3 +89,34 @@ class TestLotOnHandFirst(SavepointCase):
         self.delivery_order_picking_type.use_existing_lots = True
         self.assertTrue(self.delivery_order_picking_type.use_existing_lots)
         self.assertFalse(self.delivery_order_picking_type.display_lots_on_hand_first)
+
+    def test_lot_on_hand_first_with_limit(self):
+        """Check lots without a qty are at the end of the list"""
+        # Create a few lots with quantities
+        lot_1 = self._create_lot(self.product, "LOT-000001", 0)
+        lot_2 = self._create_lot(self.product, "LOT-000002", 0)
+        lot_3 = self._create_lot(self.product, "LOT-000003", 0)
+        lot_4 = self._create_lot(self.product, "LOT-000004", 0)
+        lot_5 = self._create_lot(self.product, "LOT-000005", 0)
+        lot_6 = self._create_lot(self.product, "LOT-000006", 0)
+        self._create_lot(self.product, "LOT-000007", 0)
+        self._create_lot(self.product, "LOT-000008", 0)
+        lot_9 = self._create_lot(self.product, "LOT-000009", 5)
+        lot_10 = self._create_lot(self.product, "LOT-000010", 5)
+
+        name_get_res = (
+            self.env["stock.production.lot"]
+            .with_context(name_search_qty_on_hand_first=True)
+            .name_search(args=[("product_id", "=", self.product.id)], limit=8)
+        )
+        expected_res = [
+            (lot_9.id, lot_9.name),
+            (lot_10.id, lot_10.name),
+            (lot_1.id, lot_1.name),
+            (lot_2.id, lot_2.name),
+            (lot_3.id, lot_3.name),
+            (lot_4.id, lot_4.name),
+            (lot_5.id, lot_5.name),
+            (lot_6.id, lot_6.name),
+        ]
+        self.assertEqual(name_get_res, expected_res)

--- a/stock_lot_on_hand_first/tests/test_lot_on_hand_first.py
+++ b/stock_lot_on_hand_first/tests/test_lot_on_hand_first.py
@@ -1,0 +1,90 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo.tests import SavepointCase
+from odoo.tools import float_is_zero
+
+
+class TestLotOnHandFirst(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_precision = cls.env["decimal.precision"].precision_get(
+            "Product Unit of Measure"
+        )
+        cls.product = cls.env.ref("stock.product_cable_management_box").copy()
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.delivery_order_picking_type = cls.env.ref("stock.picking_type_out")
+
+    @classmethod
+    def _create_lot(cls, product, lot_name, qty=0):
+        lot = cls.env["stock.production.lot"].create(
+            {
+                "name": lot_name,
+                "product_id": product.id,
+                "company_id": cls.env.company.id,
+            }
+        )
+        if not float_is_zero(qty, precision_digits=cls.uom_precision):
+            cls.env["stock.quant"]._update_available_quantity(
+                product, cls.stock_location, qty, lot_id=lot
+            )
+        return lot
+
+    def test_lot_on_hand_first(self):
+        """Check lots without a qty are at the end of the list"""
+        # Create a few lots with quantities
+        lot_1 = self._create_lot(self.product, "LOT-000001", 0)
+        lot_2 = self._create_lot(self.product, "LOT-000002", 1)
+        lot_3 = self._create_lot(self.product, "LOT-000003", 2)
+        lot_4 = self._create_lot(self.product, "LOT-000004", 0)
+        lot_5 = self._create_lot(self.product, "LOT-000005", 1)
+        all_product_lots = self.env["stock.production.lot"].search(
+            [("product_id", "=", self.product.id)]
+        )
+        name_get_res = all_product_lots.with_context(
+            name_search_qty_on_hand_first=True
+        ).name_get()
+        expected_res = [
+            (lot_2.id, lot_2.name),
+            (lot_3.id, lot_3.name),
+            (lot_5.id, lot_5.name),
+            (lot_1.id, lot_1.name),
+            (lot_4.id, lot_4.name),
+        ]
+        self.assertEqual(name_get_res, expected_res)
+
+    def test_lot_on_hand_first_no_qty(self):
+        """Check name_get does not break if we do not have a lot with qty"""
+        # Create a few lots with quantities
+        lot_1 = self._create_lot(self.product, "LOT-000001", 0)
+        lot_2 = self._create_lot(self.product, "LOT-000002", 0)
+        lot_3 = self._create_lot(self.product, "LOT-000003", 0)
+        all_product_lots = self.env["stock.production.lot"].search(
+            [("product_id", "=", self.product.id)]
+        )
+        name_get_res = all_product_lots.with_context(
+            name_search_qty_on_hand_first=True
+        ).name_get()
+        expected_res = [
+            (lot_1.id, lot_1.name),
+            (lot_2.id, lot_2.name),
+            (lot_3.id, lot_3.name),
+        ]
+        self.assertEqual(name_get_res, expected_res)
+
+    def test_compute_display_lots_on_hand_first(self):
+        """Test computed stored field"""
+        self.assertTrue(self.delivery_order_picking_type.use_existing_lots)
+        # Set lots on hand=True is stored properly
+        self.delivery_order_picking_type.display_lots_on_hand_first = True
+        self.assertTrue(self.delivery_order_picking_type.display_lots_on_hand_first)
+        self.assertTrue(self.delivery_order_picking_type.use_existing_lots)
+        # Unmark use_existing_lots must unmark display_lots_on_hand_first
+        self.delivery_order_picking_type.use_existing_lots = False
+        self.assertFalse(self.delivery_order_picking_type.use_existing_lots)
+        self.assertFalse(self.delivery_order_picking_type.display_lots_on_hand_first)
+        # Mark use_existing_lots should not change display_lots_on_hand_first
+        self.delivery_order_picking_type.use_existing_lots = True
+        self.assertTrue(self.delivery_order_picking_type.use_existing_lots)
+        self.assertFalse(self.delivery_order_picking_type.display_lots_on_hand_first)

--- a/stock_lot_on_hand_first/views/stock_move.xml
+++ b/stock_lot_on_hand_first/views/stock_move.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_stock_move_operations_inherit" model="ir.ui.view">
+        <field name="name">stock.move.operations.form</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_stock_move_operations" />
+        <field name="arch" type="xml">
+            <field name="picking_type_entire_packs" position="after">
+                <field name="display_lots_on_hand_first" invisible="1" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/stock_lot_on_hand_first/views/stock_move_line.xml
+++ b/stock_lot_on_hand_first/views/stock_move_line.xml
@@ -6,11 +6,11 @@
         <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lot_id']" position="attributes">
-                <attribute name="context">{
-                    'name_search_qty_on_hand_first': parent.display_lots_on_hand_first,
-                    'active_picking_id': picking_id,
-                    'default_company_id': parent.company_id,
-                    'default_product_id': parent.product_id,}</attribute>
+                <attribute
+                    name="context"
+                    operation="python_dict"
+                    key="name_search_qty_on_hand_first"
+                >parent.display_lots_on_hand_first</attribute>
             </xpath>
         </field>
     </record>
@@ -29,11 +29,11 @@
         />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lot_id']" position="attributes">
-                <attribute name="context">{
-                    'name_search_qty_on_hand_first': parent.display_lots_on_hand_first,
-                    'active_picking_id': picking_id,
-                    'default_company_id': company_id,
-                    'default_product_id': product_id,}</attribute>
+                <attribute
+                    name="context"
+                    operation="python_dict"
+                    key="name_search_qty_on_hand_first"
+                >parent.display_lots_on_hand_first</attribute>
             </xpath>
         </field>
     </record>

--- a/stock_lot_on_hand_first/views/stock_move_line.xml
+++ b/stock_lot_on_hand_first/views/stock_move_line.xml
@@ -14,4 +14,27 @@
             </xpath>
         </field>
     </record>
+
+    <record
+        id="view_stock_move_line_detailed_operation_tree_inherited"
+        model="ir.ui.view"
+    >
+        <field
+            name="name"
+        >view_stock_move_line_detailed_operation_tree_inherited</field>
+        <field name="model">stock.move.line</field>
+        <field
+            name="inherit_id"
+            ref="stock.view_stock_move_line_detailed_operation_tree"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='lot_id']" position="attributes">
+                <attribute name="context">{
+                    'name_search_qty_on_hand_first': parent.display_lots_on_hand_first,
+                    'active_picking_id': picking_id,
+                    'default_company_id': company_id,
+                    'default_product_id': product_id,}</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/stock_lot_on_hand_first/views/stock_move_line.xml
+++ b/stock_lot_on_hand_first/views/stock_move_line.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_stock_move_line_operation_tree_inherited" model="ir.ui.view">
+        <field name="name">view_stock_move_line_operation_tree_inherited</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='lot_id']" position="attributes">
+                <attribute name="context">{
+                    'name_search_qty_on_hand_first': parent.display_lots_on_hand_first,
+                    'active_picking_id': picking_id,
+                    'default_company_id': parent.company_id,
+                    'default_product_id': parent.product_id,}</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_lot_on_hand_first/views/stock_picking.xml
+++ b/stock_lot_on_hand_first/views/stock_picking.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_form_inherit" model="ir.ui.view">
+        <field name="name">stock.picking.form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <field name="use_create_lots" position="after">
+                <field name="display_lots_on_hand_first" invisible="1" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/stock_lot_on_hand_first/views/stock_picking_type.xml
+++ b/stock_lot_on_hand_first/views/stock_picking_type.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_picking_type_form_inherit">
+        <field name="name">Operation Types</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <field name="use_existing_lots" position="after">
+                <field
+                    name="display_lots_on_hand_first"
+                    attrs="{'invisible': [('use_existing_lots', '!=', True)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module allows to display lots with a quantity on hand as first results
in the selection field of Detailed Operations (`stock.move.line`) in order
to avoid displaying old lots that are not in stock anymore.

Depends on:
 - [x] #1096 
