### PR TITLE
[14.0] Add stock_picking_progress

### DIFF
--- a/setup/stock_picking_progress/odoo/addons/stock_picking_progress
+++ b/setup/stock_picking_progress/odoo/addons/stock_picking_progress
@@ -1,0 +1,1 @@
+../../../../stock_picking_progress

--- a/setup/stock_picking_progress/setup.py
+++ b/setup/stock_picking_progress/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_picking_progress/README.rst
+++ b/stock_picking_progress/README.rst
@@ -1,0 +1,1 @@
+wait 4 da bot

--- a/stock_picking_progress/__init__.py
+++ b/stock_picking_progress/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from .hooks import pre_init_hook

--- a/stock_picking_progress/__manifest__.py
+++ b/stock_picking_progress/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Stock Picking Progress",
+    "summary": "Compute the stock.picking progression",
+    "version": "14.0.1.0.0",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "mmequignon, Camptocamp SA, Odoo Community Association (OCA)",
+    "maintainers": ["mmequignon"],
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": ["stock"],
+    "data": ["views/stock_picking.xml"],
+    "pre_init_hook": "pre_init_hook",
+}

--- a/stock_picking_progress/hooks.py
+++ b/stock_picking_progress/hooks.py
@@ -1,0 +1,57 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+
+from odoo.tools.sql import column_exists, create_column
+
+logger = logging.getLogger(__name__)
+
+
+def setup_move_line_progress(cr):
+    table = "stock_move_line"
+    column = "progress"
+    _type = "float"
+    if column_exists(cr, table, column):
+        logger.info("%s already exists on %s, skipping setup", column, table)
+        return
+    logger.info("creating %s on table %s", column, table)
+    create_column(cr, table, column, _type)
+    fill_column_query = """
+        UPDATE stock_move_line
+        SET progress = CASE
+            WHEN (state = 'done') THEN 100
+            WHEN (product_uom_qty IS NULL or product_uom_qty = 0.0) THEN 0.0
+            ELSE (qty_done / product_uom_qty) * 100
+        END;
+    """
+    logger.info("filling up %s on %s", column, table)
+    cr.execute(fill_column_query)
+
+
+def setup_picking_progress(cr):
+    table = "stock_picking"
+    column = "progress"
+    _type = "float"
+    if column_exists(cr, table, column):
+        logger.info("%s already exists on %s, skipping setup", column, table)
+        return
+    logger.info("creating %s on table %s", column, table)
+    create_column(cr, table, column, _type)
+    fill_column_query = """
+        UPDATE stock_picking p
+        SET progress = subquery.avg_progress
+        FROM (
+            SELECT sml.picking_id, avg(sml.progress) as avg_progress
+            FROM stock_move_line sml
+            GROUP BY sml.picking_id
+        ) as subquery
+        WHERE p.id = subquery.picking_id;
+    """
+    logger.info("filling up %s on %s", column, table)
+    cr.execute(fill_column_query)
+
+
+def pre_init_hook(cr):
+    setup_move_line_progress(cr)
+    setup_picking_progress(cr)

--- a/stock_picking_progress/models/__init__.py
+++ b/stock_picking_progress/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_move_line
+from . import stock_picking

--- a/stock_picking_progress/models/stock_move_line.py
+++ b/stock_picking_progress/models/stock_move_line.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import api, fields, models
+from odoo.tools.float_utils import float_is_zero
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    progress = fields.Float(
+        compute="_compute_progress", store=True, group_operator="avg"
+    )
+
+    @api.depends(
+        "product_uom_qty", "product_uom_id", "product_uom_id.rounding", "qty_done"
+    )
+    def _compute_progress(self):
+        for record in self:
+            if record.state == "done":
+                record.progress = 100
+                continue
+            rounding = record.product_uom_id.rounding
+            if float_is_zero(record.product_uom_qty, precision_rounding=rounding):
+                record.progress = 0
+            else:
+                record.progress = (record.qty_done / record.product_uom_qty) * 100

--- a/stock_picking_progress/models/stock_picking.py
+++ b/stock_picking_progress/models/stock_picking.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import api, fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    progress = fields.Float(
+        compute="_compute_progress", store=True, group_operator="avg"
+    )
+
+    @api.depends("move_line_ids", "move_line_ids.progress")
+    def _compute_progress(self):
+        for record in self:
+            if record.state == "done":
+                record.progress = 100
+                continue
+            lines_progress = record.move_line_ids.mapped("progress")
+            # Avoid dividing by 0
+            if lines_progress:
+                record.progress = sum(lines_progress) / len(lines_progress)
+            else:
+                record.progress = 0

--- a/stock_picking_progress/readme/CONTRIBUTORS.rst
+++ b/stock_picking_progress/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Matthieu Méquignon <matthieu.mequignon@camptocamp.com>

--- a/stock_picking_progress/readme/DESCRIPTION.rst
+++ b/stock_picking_progress/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module adds a new `progress` field on `stock.picking` and `stock.move.line`.
+
+On `stock.move.line`, this field represents the percentage of `qty_done` compared to
+the `product_uom_qty`.
+On `stock.picking`, this field is the average progress of all move lines.

--- a/stock_picking_progress/tests/__init__.py
+++ b/stock_picking_progress/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_progress

--- a/stock_picking_progress/tests/test_progress.py
+++ b/stock_picking_progress/tests/test_progress.py
@@ -1,0 +1,79 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests.common import SavepointCase
+
+
+class TestPickingProgress(SavepointCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        picking = cls.env.ref("stock.outgoing_shipment_main_warehouse")
+        cls.picking = picking.copy({"move_lines": [], "move_line_ids": []})
+        cls.product = cls.env.ref("product.consu_delivery_01")
+        cls.uom = cls.product.uom_id
+        cls.move_line_model = cls.env["stock.move.line"]
+
+    def add_line(self):
+        data = {
+            "product_id": self.product.id,
+            "product_uom_qty": 10,
+            "picking_id": self.picking.id,
+            "product_uom_id": self.uom.id,
+            "location_id": self.picking.location_id.id,
+            "location_dest_id": self.picking.location_dest_id.id,
+        }
+        return self.move_line_model.create(data)
+
+    def set_qty_done(self, move_lines, qty=None):
+        for move_line in move_lines:
+            if qty is None:
+                qty_done = move_line.product_uom_qty
+            else:
+                qty_done = qty
+            move_line.qty_done = qty_done
+
+    def test_progress(self):
+        # No line, progress is 0%
+        self.assertEqual(self.picking.progress, 0.0)
+        # Add a new line, no qty done: progress 0%
+        line1 = self.add_line()
+        self.assertEqual(self.picking.progress, 0.0)
+        # Set qty_done to 5.0 (half done), both line and picking are 50% done
+        self.set_qty_done(line1, 5.0)
+        self.assertEqual(self.picking.progress, 50.0)
+        self.assertEqual(line1.progress, 50.0)
+        # Add a new line:
+        # line1 progress is still 50%
+        # line2 progress is 0%
+        # picking progress is 25%
+        line2 = self.add_line()
+        self.assertEqual(self.picking.progress, 25.0)
+        self.assertEqual(line1.progress, 50.0)
+        self.assertEqual(line2.progress, 0.0)
+        # Set qty_done = 10.0 on line 2
+        # line1 progress is still 50%
+        # line2 progress is 100%
+        # picking progress is 75%
+        self.set_qty_done(line2)
+        self.assertEqual(self.picking.progress, 75.0)
+        self.assertEqual(line2.progress, 100.0)
+        # Set qty_done = 10.0 on line 1
+        # line1 progress is 100%
+        # line2 progress is still 100%
+        # picking progress is 100%
+        self.set_qty_done(line1)
+        self.assertEqual(self.picking.progress, 100.0)
+        self.assertEqual(line1.progress, 100.0)
+        # Set qty_done = 0.0 on both lines
+        # line1 progress is 0%
+        # line2 progress is still 0%
+        # picking progress is 0%
+        self.set_qty_done(self.picking.move_line_ids, 0.0)
+        self.assertEqual(line1.progress, 0.0)
+        self.assertEqual(line2.progress, 0.0)
+        self.assertEqual(self.picking.progress, 0.0)

--- a/stock_picking_progress/views/stock_picking.xml
+++ b/stock_picking_progress/views/stock_picking.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="vpicktree" model="ir.ui.view">
+      <field name="name">stock.picking.tree.inherit</field>
+      <field name="model">stock.picking</field>
+      <field name="inherit_id" ref="stock.vpicktree" />
+      <field name="arch" type="xml">
+          <field name="state" position="before">
+              <field name="progress" widget="progressbar" optional="show" />
+          </field>
+      </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module adds a new `progress` field on `stock.picking` and `stock.move.line`.

On `stock.move.line`, this field represents the percentage of `qty_done` compared to the `product_uom_qty`.
On `stock.picking`, this field is the average progress of all move lines.
![image](https://user-images.githubusercontent.com/13200247/203564711-8c642c1d-dc33-46cc-b553-f14362dd990b.png)

ref: rau-49