### PR TITLE
[FIX] stock_split_picking: confirm moves before assigning

### DIFF
--- a/stock_split_picking/models/stock_picking.py
+++ b/stock_split_picking/models/stock_picking.py
@@ -59,6 +59,7 @@ class StockPicking(models.Model):
                 new_moves.mapped("move_line_ids").write(
                     {"picking_id": backorder_picking.id}
                 )
+                new_moves._action_confirm()
                 new_moves._action_assign()
 
     def _create_split_backorder(self, default=None):


### PR DESCRIPTION
as moves are copied they need to be confirmed first and then assigned, as on confirmation important steps that cannot be skipped