### PR TITLE
[15.0][FIX] stock_split_picking: 'done' mode

### DIFF
--- a/stock_split_picking/readme/CONTRIBUTORS.rst
+++ b/stock_split_picking/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Holger Brunn <mail@hunki-enterprises.com>
 * Rujia Liu <rujial@roof.co.nz>
 * Bernat Puig <bernat.puig@forgeflow.com>
+* Yoshi Tashiro <tashiro@quartile.co>


### PR DESCRIPTION
This commit fixes the handling of the split with 'Done quantities' for cases where there is a move with no qty_done such as below.

```
PICK_1
       product_uom_qty  qty_done
MOVE_1        3            0
MOVE_2        3            1
```

Before this commit, the result of splitting with mode 'Done quantities' would be as follows:

```
PICK_1
       product_uom_qty  qty_done
MOVE_1        3            0
MOVE_2        1            1

PICK_2 (newly created)
       product_uom_qty  qty_done
MOVE_3        2            0      <- split from MOVE_2
```

With ithis commit the result will be as follows:

```
PICK_1
       product_uom_qty  qty_done
MOVE_2        1            1

PICK_2 (newly created)
       product_uom_qty  qty_done
MOVE_1        3            0      <- moved from PICK_1
MOVE_3        2            0      <- split from MOVE_2
```
