### PR TITLE
[14.0][IMP] stock_owner_restriction: Partner or unassigned stock option

### DIFF
--- a/stock_owner_restriction/models/stock_move.py
+++ b/stock_owner_restriction/models/stock_move.py
@@ -27,6 +27,22 @@ class StockMove(models.Model):
                 StockMove,
                 moves_to_assign.with_context(force_restricted_owner_id=owner_id),
             )._action_assign()
+            if (
+                owner_id
+                and moves_to_assign.picking_type_id.owner_restriction
+                == "partner_or_unassigned"
+                and sum(
+                    [
+                        move.reserved_availability - move.product_uom_qty
+                        for move in moves_to_assign
+                    ]
+                )
+                < 0
+            ):
+                super(
+                    StockMove,
+                    moves_to_assign.with_context(force_restricted_owner_id=False),
+                )._action_assign()
 
     def _update_reserved_quantity(
         self,

--- a/stock_owner_restriction/models/stock_picking_type.py
+++ b/stock_owner_restriction/models/stock_picking_type.py
@@ -12,6 +12,7 @@ class StockPickingType(models.Model):
             ("standard_behavior", "Standard behavior"),
             ("unassigned_owner", "Unassigned owner"),
             ("picking_partner", "Picking partner"),
+            ("partner_or_unassigned", "Picking partner or unassigned owner"),
         ],
         string="Owner restriction",
         default="standard_behavior",


### PR DESCRIPTION
This PR adds a new option to the owner restriction field which allows the reservation of the picking partner's stock, and if that isn't enough, it reserves the stock without any owner assigned.