### PR TITLE
[13.0][FIX] stock_picking_invoice_link: inventory users cannot validate picking

### DIFF
--- a/stock_picking_invoice_link/models/stock_move.py
+++ b/stock_picking_invoice_link/models/stock_move.py
@@ -40,11 +40,15 @@ class StockMove(models.Model):
                 lambda sm: sm.sale_line_id and sm.product_id.invoice_policy == "order"
             ):
                 inv_type = stock_move.to_refund and "out_refund" or "out_invoice"
-                inv_line = self.env["account.move.line"].search(
-                    [
-                        ("sale_line_ids", "=", stock_move.sale_line_id.id),
-                        ("move_id.type", "=", inv_type),
-                    ]
+                inv_line = (
+                    self.env["account.move.line"]
+                    .sudo()
+                    .search(
+                        [
+                            ("sale_line_ids", "=", stock_move.sale_line_id.id),
+                            ("move_id.type", "=", inv_type),
+                        ]
+                    )
                 )
                 if inv_line:
                     stock_move.invoice_line_ids = [(4, m.id) for m in inv_line]


### PR DESCRIPTION
Due to #1128 an user with only inventory permissions cannot validate a picking

Steps to reproduce error:
- Create a sale order with a product (should set invoice policy: ordered quantities)
- Confirm the order and invoiced it
- With a user that only have "User" permission on Inventory, try to validate the transfer.