### PR TITLE
[12.0][IMP] stock_picking_product_link: Return a list of product templates when product variants are not enabled

### DIFF
--- a/stock_picking_product_link/models/stock_picking.py
+++ b/stock_picking_product_link/models/stock_picking.py
@@ -12,9 +12,16 @@ class StockPicking(models.Model):
         comodel_name="product.product",
         compute="_compute_product_ids",
     )
+    product_template_ids = fields.Many2many(
+        string="Products",
+        comodel_name="product.template",
+        compute="_compute_product_ids",
+    )
     product_count = fields.Integer(
         string="Number of Products",
         compute="_compute_product_ids",
+        help="""This displays the amount of products (variants) in the stock transfer.
+            The amount of product templates may be lower."""
     )
 
     @api.depends("move_line_ids", "move_line_ids.product_id")
@@ -28,14 +35,28 @@ class StockPicking(models.Model):
             products = move_products + move_wo_package_products
             picking.product_count = len(set(products.ids))
             picking.product_ids = products
+            picking.product_template_ids = products.mapped("product_tmpl_id")
 
     @api.multi
     def action_view_products(self):
         self.ensure_one()
-        return {
-            "name": _("Products"),
-            "view_mode": "tree,form",
-            "res_model": "product.product",
-            "type": "ir.actions.act_window",
-            "domain": [("id", "in", self.product_ids.ids)],
-        }
+        if self.env.user.has_group("product.group_product_variant"):
+            return {
+                "name": _("Products"),
+                "view_mode": "tree,form",
+                "res_model": "product.product",
+                "type": "ir.actions.act_window",
+                "domain": [("id", "in", self.product_ids.ids)],
+            }
+        # The use case for returning a list of product templates here is that
+        # clients who have not enabled product variants are not
+        # functionality-wise familiar with product variants. The fields and
+        # available interactions are slightly different.
+        else:
+            return {
+                "name": _("Products"),
+                "view_mode": "tree,form",
+                "res_model": "product.template",
+                "type": "ir.actions.act_window",
+                "domain": [("id", "in", self.product_template_ids.ids)],
+            }

--- a/stock_picking_product_link/readme/ROADMAP.rst
+++ b/stock_picking_product_link/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+- Move the fields on stock.picking (and their compute functions) out of this
+  module and into a separate stand-alone module.

--- a/stock_picking_product_link/views/stock_picking_views.xml
+++ b/stock_picking_product_link/views/stock_picking_views.xml
@@ -11,6 +11,11 @@
                     icon="fa-list"
                     type="object"
                     name="action_view_products"
+                    help="This displays the amount of products (variants) in the
+                    stock transfer. If you do not have product variants enabled, but
+                    somehow someone else did, there exists a rare case where the
+                    amount displayed is higher than the amount of products you see
+                    when clicking on this button."
                 >
                     <field string="Products" name="product_count" widget="statinfo" />
                 </button>


### PR DESCRIPTION
Small usability improvement.

Internal task: https://gestion.coopiteasy.be/web#id=9583&action=475&active_id=221&model=project.task&view_type=form&menu_id=

