### PR TITLE
[16][stock_restrict_lot] Add Restrict lot in move list views

### DIFF
--- a/stock_restrict_lot/__manifest__.py
+++ b/stock_restrict_lot/__manifest__.py
@@ -9,4 +9,5 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["stock"],
+    "data": ["views/stock_move_views.xml", "views/stock_picking.xml"],
 }

--- a/stock_restrict_lot/models/__init__.py
+++ b/stock_restrict_lot/models/__init__.py
@@ -1,2 +1,3 @@
 from . import stock_move
 from . import stock_rule
+from . import stock_picking

--- a/stock_restrict_lot/models/stock_picking.py
+++ b/stock_restrict_lot/models/stock_picking.py
@@ -1,0 +1,12 @@
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    # this is a technical field, making possible to search a picking by any restrict lot
+    # defined on its line, from the web search bar.
+    restrict_lot_id = fields.Many2one(
+        related="move_ids.restrict_lot_id", string="Restrict Lot"
+    )

--- a/stock_restrict_lot/views/stock_move_views.xml
+++ b/stock_restrict_lot/views/stock_move_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+        <record id="stock_move_pick_tree_view" model="ir.ui.view">
+            <field name="model">stock.move</field>
+            <field name="inherit_id" ref="stock.view_picking_move_tree" />
+            <field name="arch" type="xml">
+                <field name="product_id" position="after">
+                    <field
+                    name="restrict_lot_id"
+                    readonly="1"
+                    optional="show"
+                    groups="stock.group_production_lot"
+                />
+                </field>
+            </field>
+        </record>
+
+        <record id="stock_move_tree_view" model="ir.ui.view">
+            <field name="model">stock.move</field>
+            <field name="inherit_id" ref="stock.view_move_tree" />
+            <field name="arch" type="xml">
+                <field name="product_id" position="after">
+                    <field
+                    name="restrict_lot_id"
+                    readonly="1"
+                    optional="show"
+                    groups="stock.group_production_lot"
+                />
+                </field>
+            </field>
+        </record>
+
+</odoo>

--- a/stock_restrict_lot/views/stock_picking.xml
+++ b/stock_restrict_lot/views/stock_picking.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+        <record id="custom_main_stock_picking_form_view" model="ir.ui.view">
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_form" />
+            <field name="arch" type="xml">
+                <xpath
+                expr="//field[@name='move_ids_without_package']/tree/field[@name='product_id']"
+                position="after"
+            >
+                    <field
+                    name="restrict_lot_id"
+                    readonly="1"
+                    optional="show"
+                    groups="stock.group_production_lot"
+                />
+                </xpath>
+            </field>
+        </record>
+
+        <record id="custom_stock_picking_search_view" model="ir.ui.view">
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_internal_search" />
+            <field name="arch" type="xml">
+                <field name="product_id" position="after">
+                    <field
+                    name="restrict_lot_id"
+                    string="Lot"
+                    groups="stock.group_production_lot"
+                />
+                </field>
+            </field>
+        </record>
+
+</odoo>


### PR DESCRIPTION
Since the field restricts the reservation, I guess it is good to be displayed to help the user understand what's going on.
It is still optional though.
Also added a way to search picking depending on its lots which can be really helpfull when using this module