### PR TITLE
[FIX] stock_picking_invoice_link: Fix Invoice Group on Stock.Picking

### DIFF
--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -5,9 +5,13 @@
         <field name="name">stock_picking_invoice_link.stock.picking.form</field>
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
+        <field
+            name="groups_id"
+            eval="[(6, 0, [ref('account.group_account_invoice')])]"
+        />
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
-                <field name="invoice_ids" invisible="1" />
+              <field name="invoice_ids" invisible="1" />
                 <button
                     name="action_view_invoice"
                     class="oe_stat_button"


### PR DESCRIPTION
This PR adds the accounting group to the `stock.picking` form view. 

Without the group attribute you can get an ACL error when trying to access a picking with linked invoices without having access to the invoices. 