### PR TITLE
[12.0] [ADD] `stock_production_lot_traceability`

### DIFF
--- a/setup/stock_production_lot_traceability/odoo/addons/stock_production_lot_traceability
+++ b/setup/stock_production_lot_traceability/odoo/addons/stock_production_lot_traceability
@@ -1,0 +1,1 @@
+../../../../stock_production_lot_traceability

--- a/setup/stock_production_lot_traceability/setup.py
+++ b/setup/stock_production_lot_traceability/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_production_lot_traceability/__init__.py
+++ b/stock_production_lot_traceability/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_production_lot_traceability/__manifest__.py
+++ b/stock_production_lot_traceability/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Stock Production Lot Traceability",
+    "summary": "Drill down/up the lots produced or consumed",
+    "version": "12.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "license": "AGPL-3",
+    "category": "Stock",
+    "depends": ["stock"],
+    "data": ["views/stock_production_lot.xml"],
+}

--- a/stock_production_lot_traceability/models/__init__.py
+++ b/stock_production_lot_traceability/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_move_line
+from . import stock_production_lot

--- a/stock_production_lot_traceability/models/stock_move_line.py
+++ b/stock_production_lot_traceability/models/stock_move_line.py
@@ -1,0 +1,36 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, api
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def write(self, vals):
+        # OVERRIDE to invalidate the cache of the lots' produce/consume fields,
+        # as they're computed from the move lines that consume/produce them.
+        self.env["stock.production.lot"].invalidate_cache(
+            [
+                "produce_lot_ids",
+                "consume_lot_ids",
+                "produce_lot_count",
+                "consume_lot_count",
+            ]
+        )
+        return super().write(vals)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # OVERRIDE to invalidate the cache of the lots' produce/consume fields,
+        # as they're computed from the move lines that consume/produce them.
+        self.env["stock.production.lot"].invalidate_cache(
+            [
+                "produce_lot_ids",
+                "consume_lot_ids",
+                "produce_lot_count",
+                "consume_lot_count",
+            ]
+        )
+        return super().create(vals_list)

--- a/stock_production_lot_traceability/models/stock_production_lot.py
+++ b/stock_production_lot_traceability/models/stock_production_lot.py
@@ -1,0 +1,168 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, _
+
+
+class StockProductionLot(models.Model):
+    _inherit = "stock.production.lot"
+
+    produce_lot_ids = fields.Many2many(
+        string="Produced Lots/Serial Numbers",
+        comodel_name="stock.production.lot",
+        compute="_compute_produce_lot_ids",
+        help="Lots that were directly or indirectly produced from this lot",
+    )
+    produce_lot_count = fields.Integer(
+        string="Produced Lots/Serial Numbers Count",
+        compute="_compute_produce_lot_ids",
+    )
+    consume_lot_ids = fields.Many2many(
+        string="Consumed Lots/Serial Numbers",
+        comodel_name="stock.production.lot",
+        compute="_compute_consume_lot_ids",
+        help="Lots that were directly or indirectly consumed to produce this lot",
+    )
+    consume_lot_count = fields.Integer(
+        string="Consumed Lots/Serial Numbers Count",
+        compute="_compute_consume_lot_ids",
+    )
+
+    def _compute_produce_lot_ids(self):
+        """Compute the lots that were produced from this lot."""
+        data = {}
+        if self.ids:
+            self.env.cr.execute(
+                """
+                    WITH RECURSIVE produce_lots AS (
+                        SELECT
+                            consume_line.lot_id AS lot_id,
+                            consume_line.lot_id AS consume_lot_id,
+                            produce_line.lot_id AS produce_lot_id
+                        FROM stock_move_line_consume_rel rel
+                        INNER JOIN stock_move_line
+                            AS consume_line
+                            ON rel.produce_line_id = consume_line.id
+                        INNER JOIN stock_move_line
+                            AS produce_line
+                            ON rel.consume_line_id = produce_line.id
+                        WHERE consume_line.lot_id IN %s
+                        AND   produce_line.lot_id IS NOT NULL
+                        AND   consume_line.state = 'done'
+                        AND   produce_line.state = 'done'
+                        GROUP BY
+                            consume_line.lot_id,
+                            produce_line.lot_id
+                    UNION
+                        SELECT
+                            produce_lots.lot_id AS lot_id,
+                            consume_line.lot_id AS consume_lot_id,
+                            produce_line.lot_id AS produce_lot_id
+                        FROM stock_move_line_consume_rel rel
+                        INNER JOIN stock_move_line
+                            AS consume_line
+                            ON rel.produce_line_id = consume_line.id
+                        INNER JOIN stock_move_line
+                            AS produce_line
+                            ON rel.consume_line_id = produce_line.id
+                        JOIN produce_lots
+                            ON consume_line.lot_id = produce_lots.produce_lot_id
+                        WHERE consume_line.lot_id IS NOT NULL
+                        AND   produce_line.lot_id IS NOT NULL
+                        AND   consume_line.state = 'done'
+                        AND   produce_line.state = 'done'
+                        GROUP BY
+                            consume_line.lot_id,
+                            produce_line.lot_id,
+                            produce_lots.lot_id
+                    )
+                    SELECT lot_id, ARRAY_AGG(produce_lot_id) AS produce_lot_ids
+                    FROM produce_lots
+                    GROUP BY lot_id
+                """,
+                (tuple(self.ids),),
+            )
+            data = dict(self.env.cr.fetchall())
+        for rec in self:
+            produce_lot_ids = data.get(rec.id, [])
+            rec.produce_lot_ids = [(6, 0, produce_lot_ids)]
+            rec.produce_lot_count = len(produce_lot_ids)
+
+    def _compute_consume_lot_ids(self):
+        """Compute the lots that were consumed to produce this lot."""
+        data = {}
+        if self.ids:
+            self.env.cr.execute(
+                """
+                    WITH RECURSIVE consume_lots AS (
+                        SELECT
+                            produce_line.lot_id AS lot_id,
+                            produce_line.lot_id AS produce_lot_id,
+                            consume_line.lot_id AS consume_lot_id
+                        FROM stock_move_line_consume_rel rel
+                        INNER JOIN stock_move_line
+                            AS consume_line
+                            ON rel.produce_line_id = consume_line.id
+                        INNER JOIN stock_move_line
+                            AS produce_line
+                            ON rel.consume_line_id = produce_line.id
+                        WHERE produce_line.lot_id IN %s
+                        AND   consume_line.lot_id IS NOT NULL
+                        AND   produce_line.state = 'done'
+                        AND   consume_line.state = 'done'
+                        GROUP BY
+                            produce_line.lot_id,
+                            consume_line.lot_id
+                    UNION
+                        SELECT
+                            consume_lots.lot_id AS lot_id,
+                            produce_line.lot_id AS produce_lot_id,
+                            consume_line.lot_id AS consume_lot_id
+                        FROM stock_move_line_consume_rel rel
+                        INNER JOIN stock_move_line
+                            AS consume_line
+                            ON rel.produce_line_id = consume_line.id
+                        INNER JOIN stock_move_line
+                            AS produce_line
+                            ON rel.consume_line_id = produce_line.id
+                        JOIN consume_Lots
+                            ON produce_line.lot_id = consume_lots.consume_lot_id
+                        WHERE consume_line.lot_id IS NOT NULL
+                        AND   produce_line.lot_id IS NOT NULL
+                        AND   consume_line.state = 'done'
+                        AND   produce_line.state = 'done'
+                        GROUP BY
+                            consume_line.lot_id,
+                            produce_line.lot_id,
+                            consume_lots.lot_id
+                    )
+                    SELECT lot_id, ARRAY_AGG(consume_lot_id) AS consume_lot_ids
+                    FROM consume_lots
+                    GROUP BY lot_id
+                """,
+                (tuple(self.ids),),
+            )
+            data = dict(self.env.cr.fetchall())
+        for rec in self:
+            consume_lot_ids = data.get(rec.id, [])
+            rec.consume_lot_ids = [(6, 0, consume_lot_ids)]
+            rec.consume_lot_count = len(consume_lot_ids)
+
+    def action_view_produce_lots(self):
+        action = self.env["ir.actions.act_window"].for_xml_id(
+            "stock", "action_production_lot_form"
+        )
+        action["context"] = {}
+        action["domain"] = [("id", "in", self.produce_lot_ids.ids)]
+        action["name"] = _("Produced Lots")
+        return action
+
+    def action_view_consume_lots(self):
+        action = self.env["ir.actions.act_window"].for_xml_id(
+            "stock", "action_production_lot_form"
+        )
+        action["context"] = {}
+        action["domain"] = [("id", "in", self.consume_lot_ids.ids)]
+        action["name"] = _("Consumed Lots")
+        return action

--- a/stock_production_lot_traceability/readme/CONTRIBUTORS.rst
+++ b/stock_production_lot_traceability/readme/CONTRIBUTORS.rst
@@ -1,0 +1,4 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Damien Crier <damien.crier@camptocamp.com>
+  * Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/stock_production_lot_traceability/readme/DESCRIPTION.rst
+++ b/stock_production_lot_traceability/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Easily see which Lots/Serial Numbers were consumed or produced by/from another one.

--- a/stock_production_lot_traceability/readme/USAGE.rst
+++ b/stock_production_lot_traceability/readme/USAGE.rst
@@ -1,0 +1,4 @@
+Go to the form view of any Lot/Serial Number that has either been consumed or that has
+produced other Lots/Serial Numbers, and click on the "Consumed" or "Produced" smart
+buttons to navigate to these records. It will show all records, directly or indirectly
+consumed or produced by it.

--- a/stock_production_lot_traceability/tests/__init__.py
+++ b/stock_production_lot_traceability/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_lot_traceability

--- a/stock_production_lot_traceability/tests/common.py
+++ b/stock_production_lot_traceability/tests/common.py
@@ -1,0 +1,145 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import SavepointCase
+
+
+class CommonStockLotTraceabilityCase(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product1, cls.product2, cls.product3 = cls.env["product.product"].create(
+            [
+                {"name": "Product 1", "type": "product", "tracking": "lot"},
+                {"name": "Product 2", "type": "product", "tracking": "lot"},
+                {"name": "Product 3", "type": "product", "tracking": "lot"},
+            ]
+        )
+        # Simulate a manufacture operation without any BoM nor mrp-like dependency
+        # In our example:
+        # - Product 1 is simply on stock
+        # - Product 2 is produced from Product 1
+        # - Product 3 is produced from Product 2
+        # - We have/produce two lots for each product
+        cls.product1_lot1, cls.product1_lot2 = cls.env["stock.production.lot"].create(
+            [
+                {"name": "Product 1 Lot 1", "product_id": cls.product1.id},
+                {"name": "Product 1 Lot 2", "product_id": cls.product1.id},
+            ]
+        )
+        cls.product2_lot1, cls.product2_lot2 = cls.env["stock.production.lot"].create(
+            [
+                {"name": "Product 2 Lot 1", "product_id": cls.product2.id},
+                {"name": "Product 2 Lot 2", "product_id": cls.product2.id},
+            ]
+        )
+        cls.product3_lot1, cls.product3_lot2 = cls.env["stock.production.lot"].create(
+            [
+                {"name": "Product 3 Lot 1", "product_id": cls.product3.id},
+                {"name": "Product 3 Lot 2", "product_id": cls.product3.id},
+            ]
+        )
+        cls.location_supplier = cls.env.ref("stock.stock_location_suppliers")
+        cls.location_stock = cls.env.ref("stock.stock_location_stock")
+        cls.location_production = cls.env.ref("stock.location_production")
+        cls._do_stock_move(
+            cls.product1,
+            cls.product1_lot1,
+            10,
+            cls.location_supplier,
+            cls.location_stock,
+        )
+        cls._do_stock_move(
+            cls.product1,
+            cls.product1_lot2,
+            10,
+            cls.location_supplier,
+            cls.location_stock,
+        )
+        # Product 2 Lot 1 manufactured from Product 1 Lot 1
+        cls._do_manufacture_move(
+            cls.product2,
+            cls.product2_lot1,
+            10,
+            [(cls.product1, cls.product1_lot1, 10)],
+        )
+        # Product 2 Lot 2 manufactured from Product 2 Lot 2
+        cls._do_manufacture_move(
+            cls.product2,
+            cls.product2_lot2,
+            10,
+            [(cls.product1, cls.product1_lot2, 10)],
+        )
+        # Product 3 Lot 1 manufactured from Product 2 Lot 1
+        cls._do_manufacture_move(
+            cls.product3,
+            cls.product3_lot1,
+            10,
+            [(cls.product2, cls.product2_lot1, 10)],
+        )
+        # Product 3 Lot 2 manufactured from Product 2 Lot 2
+        cls._do_manufacture_move(
+            cls.product3,
+            cls.product3_lot2,
+            10,
+            [(cls.product2, cls.product2_lot2, 10)],
+        )
+
+    @classmethod
+    def _do_stock_move(
+        cls, product, lot, qty, location_from, location_dest, validate=True
+    ):
+        move = cls.env["stock.move"].create(
+            {
+                "name": product.name,
+                "product_id": product.id,
+                "product_uom_qty": qty,
+                "product_uom": product.uom_id.id,
+                "location_id": location_from.id,
+                "location_dest_id": location_dest.id,
+                "move_line_ids": [
+                    (0, 0, {
+                        "product_id": product.id,
+                        "product_uom_id": product.uom_id.id,
+                        "qty_done": qty,
+                        "lot_id": lot.id,
+                        "location_id": location_from.id,
+                        "location_dest_id": location_dest.id,
+                    })
+                ]
+            }
+        )
+        if validate:
+            move._action_confirm()
+            move._action_done()
+        return move
+
+    @classmethod
+    def _do_manufacture_move(cls, product, lot, qty, consume_data, validate=True):
+        assert isinstance(consume_data, list)
+        # Consume data is a list of tuples (product, lot, qty)
+        consume_moves = cls.env["stock.move"]
+        for consume_product, consume_lot, consume_qty in consume_data:
+            consume_moves += cls._do_stock_move(
+                consume_product,
+                consume_lot,
+                consume_qty,
+                cls.location_stock,
+                cls.location_production,
+                validate=validate,
+            )
+        # Do the actual production
+        move = cls._do_stock_move(
+            product,
+            lot,
+            qty,
+            cls.location_production,
+            cls.location_stock,
+            validate=validate,
+        )
+        move.move_line_ids.consume_line_ids = [
+            (6, 0, consume_moves.mapped("move_line_ids").ids)
+        ]
+        return move + consume_moves

--- a/stock_production_lot_traceability/tests/test_stock_lot_traceability.py
+++ b/stock_production_lot_traceability/tests/test_stock_lot_traceability.py
@@ -1,0 +1,86 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from .common import CommonStockLotTraceabilityCase
+
+
+class TestStockLotTraceability(CommonStockLotTraceabilityCase):
+    def test_produce_lots(self):
+        """Test the Produced Lots/Serial Numbers field"""
+        self.assertEqual(
+            self.product1_lot1.produce_lot_ids,
+            self.product2_lot1 + self.product3_lot1
+        )
+        self.assertEqual(
+            self.product1_lot1.produce_lot_count,
+            2
+        )
+        self.assertEqual(
+            self.product2_lot1.produce_lot_ids,
+            self.product3_lot1
+        )
+        self.assertEqual(
+            self.product2_lot1.produce_lot_count,
+            1
+        )
+        self.assertFalse(self.product3_lot1.produce_lot_ids)
+        self.assertFalse(self.product3_lot1.produce_lot_count)
+
+    def test_consume_lots(self):
+        """Test the Consumed Lots/Serial Numbers field"""
+        self.assertFalse(self.product1_lot1.consume_lot_ids)
+        self.assertFalse(self.product1_lot1.consume_lot_count)
+        self.assertEqual(
+            self.product2_lot1.consume_lot_ids,
+            self.product1_lot1
+        )
+        self.assertEqual(
+            self.product2_lot1.consume_lot_count,
+            1
+        )
+        self.assertEqual(
+            self.product3_lot1.consume_lot_ids,
+            self.product1_lot1 + self.product2_lot1
+        )
+        self.assertEqual(
+            self.product3_lot1.consume_lot_count,
+            2
+        )
+
+    def test_cache_invalidation(self):
+        """Test that cache is invalidated when stock.move.line(s) are modified"""
+        self.assertEqual(
+            self.product1_lot1.produce_lot_ids,
+            self.product2_lot1 + self.product3_lot1
+        )
+        self._do_stock_move(
+            self.product2,
+            self.product2_lot1,
+            1,
+            self.location_supplier,
+            self.location_stock,
+        )
+        new_moves = self._do_manufacture_move(
+            self.product3,
+            self.product3_lot2,
+            1,
+            [(self.product2, self.product2_lot1, 10)],
+        )
+        self.assertEqual(
+            self.product1_lot1.produce_lot_ids,
+            self.product2_lot1 + self.product3_lot1 + self.product3_lot2
+        )
+        new_moves[0].move_line_ids.consume_line_ids = [(5,)]
+        self.assertEqual(
+            self.product1_lot1.produce_lot_ids,
+            self.product2_lot1 + self.product3_lot1
+        )
+
+    def test_action_view_produce_lots(self):
+        """Test that no error is raised when calling this action"""
+        self.assertIsInstance(self.product1_lot1.action_view_produce_lots(), dict)
+
+    def test_action_view_consume_lots(self):
+        """Test that no error is raised when calling this action"""
+        self.assertIsInstance(self.product1_lot1.action_view_consume_lots(), dict)

--- a/stock_production_lot_traceability/views/stock_production_lot.xml
+++ b/stock_production_lot_traceability/views/stock_production_lot.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record model="ir.ui.view" id="view_production_lot_form">
+        <field name="model">stock.production.lot</field>
+        <field name="inherit_id" ref="stock.view_production_lot_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button
+                    type="object"
+                    name="action_view_consume_lots"
+                    icon="fa-level-up"
+                    attrs="{'invisible': [('consume_lot_count', '=', 0)]}"
+                >
+                    <field
+                        string="Consumed"
+                        name="consume_lot_count"
+                        widget="statinfo"
+                    />
+                </button>
+                <button
+                    type="object"
+                    name="action_view_produce_lots"
+                    icon="fa-level-down"
+                    attrs="{'invisible': [('produce_lot_count', '=', 0)]}"
+                >
+                    <field
+                        string="Produced"
+                        name="produce_lot_count"
+                        widget="statinfo"
+                    />
+                </button>
+            </div>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
**Description**
Easily see which Lots/Serial Numbers were consumed or produced by/from another one.

**Usage**
Go to the form view of any Lot/Serial Number that has either been consumed or that has produced other Lots/Serial Numbers, and click on the "Consumed" or "Produced" smart buttons to navigate to these records. It will show all records, directly or indirectly consumed or produced by it.