### PR TITLE
[14.0][ADD] stock_move_forced_lot

### DIFF
--- a/setup/stock_move_forced_lot/odoo/addons/stock_move_forced_lot
+++ b/setup/stock_move_forced_lot/odoo/addons/stock_move_forced_lot
@@ -1,0 +1,1 @@
+../../../../stock_move_forced_lot

--- a/setup/stock_move_forced_lot/setup.py
+++ b/setup/stock_move_forced_lot/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_move_forced_lot/__init__.py
+++ b/stock_move_forced_lot/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_move_forced_lot/__manifest__.py
+++ b/stock_move_forced_lot/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2022 ForgeFlow S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Stock Move Forced Lot",
+    "summary": """
+        This module allows you to set a lot_id in a procurement
+         to force the stock move generated to only reserve the selected lot.
+    """,
+    "version": "14.0.1.0.0",
+    "license": "LGPL-3",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "depends": ["stock"],
+}

--- a/stock_move_forced_lot/models/__init__.py
+++ b/stock_move_forced_lot/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_move
+from . import stock_rule

--- a/stock_move_forced_lot/models/stock_move.py
+++ b/stock_move_forced_lot/models/stock_move.py
@@ -1,0 +1,57 @@
+# Copyright 2022 ForgeFlow S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    forced_lot_id = fields.Many2one("stock.production.lot")
+
+    def _get_available_quantity(
+        self,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+        allow_negative=False,
+    ):
+        if not lot_id and self.forced_lot_id and self.location_id.usage == "internal":
+            lot_id = self.forced_lot_id
+        return super()._get_available_quantity(
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+            allow_negative=allow_negative,
+        )
+
+    def _update_reserved_quantity(
+        self,
+        need,
+        available_quantity,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=True,
+    ):
+        if not lot_id and self.forced_lot_id and self.location_id.usage == "internal":
+            lot_id = self.forced_lot_id
+        return super()._update_reserved_quantity(
+            need,
+            available_quantity,
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
+
+    @api.model
+    def _prepare_merge_moves_distinct_fields(self):
+        res = super()._prepare_merge_moves_distinct_fields()
+        return res + ["forced_lot_id"]

--- a/stock_move_forced_lot/models/stock_rule.py
+++ b/stock_move_forced_lot/models/stock_rule.py
@@ -1,0 +1,33 @@
+# Copyright 2022 ForgeFlow S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _get_stock_move_values(
+        self,
+        product_id,
+        product_qty,
+        product_uom,
+        location_id,
+        name,
+        origin,
+        company_id,
+        values,
+    ):
+        res = super()._get_stock_move_values(
+            product_id,
+            product_qty,
+            product_uom,
+            location_id,
+            name,
+            origin,
+            company_id,
+            values,
+        )
+        if "lot_id" in values:
+            res["forced_lot_id"] = values["lot_id"]
+        return res

--- a/stock_move_forced_lot/readme/CONTRIBUTORS.rst
+++ b/stock_move_forced_lot/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* David Jiménez <david.jimenez@forgeflow.com>

--- a/stock_move_forced_lot/readme/DESCRIPTION.rst
+++ b/stock_move_forced_lot/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module allows you to set a lot_id in a procurement to force the stock move generated to only reserve the selected lot.

--- a/stock_move_forced_lot/tests/__init__.py
+++ b/stock_move_forced_lot/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_move_forced_lot

--- a/stock_move_forced_lot/tests/test_stock_move_forced_lot.py
+++ b/stock_move_forced_lot/tests/test_stock_move_forced_lot.py
@@ -1,0 +1,80 @@
+# Copyright 2022 ForgeFlow S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests import SavepointCase
+
+
+class TestStockMoveForcedLot(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.StockMove = cls.env["stock.move"]
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.location1 = cls.env.ref("stock.stock_location_stock")
+        cls.location2 = cls.env.ref("stock.stock_location_components")
+        cls.picking_type = cls.env.ref("stock.picking_type_internal")
+        cls.partner = cls.env["res.partner"].create({"name": "Partner"})
+        route_auto = cls.env["stock.location.route"].create(
+            {"name": "Auto Create Group"}
+        )
+        cls.rule_1 = cls.env["stock.rule"].create(
+            {
+                "name": "rule with autocreate",
+                "route_id": route_auto.id,
+                "action": "pull_push",
+                "warehouse_id": cls.warehouse.id,
+                "picking_type_id": cls.picking_type.id,
+                "location_id": cls.location1.id,
+                "location_src_id": cls.location2.id,
+                "partner_address_id": cls.partner.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product 1",
+                "type": "product",
+                "tracking": "serial",
+                "route_ids": [(6, 0, [route_auto.id])],
+            }
+        )
+
+    def test_01_create_procurement_with_fixed_lot(self):
+        nb_product_todo = 5
+        serials = []
+        for i in range(nb_product_todo):
+            serials.append(
+                self.env["stock.production.lot"].create(
+                    {
+                        "name": f"lot_consumed_{i}",
+                        "product_id": self.product.id,
+                        "company_id": self.env.company.id,
+                    }
+                )
+            )
+            self.env["stock.quant"]._update_available_quantity(
+                self.product, self.location2, 1, lot_id=serials[-1]
+            )
+        move = self.StockMove.search([("product_id", "=", self.product.id)])
+        self.assertFalse(move)
+        self.env["procurement.group"].run(
+            [
+                self.env["procurement.group"].Procurement(
+                    self.product,
+                    1.0,
+                    self.product.uom_id,
+                    self.location1,
+                    "Test",
+                    "Odoo test",
+                    self.env.company,
+                    {
+                        "lot_id": serials[3].id,
+                    },
+                )
+            ]
+        )
+        move = self.StockMove.search([("product_id", "=", self.product.id)])
+        self.assertTrue(move)
+        self.assertEqual(move.forced_lot_id, serials[3])
+        move._action_assign()
+        self.assertEqual(move.move_line_ids.lot_id, serials[3])


### PR DESCRIPTION
This module allows you to set a lot_id in a procurement to force the stock move generated to only reserve the selected lot.


@ForgeFlow