### PR TITLE
[14.0][IMP] stock_picking_progress: calculate picking progress from moves

### DIFF
--- a/stock_picking_progress/__manifest__.py
+++ b/stock_picking_progress/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Picking Progress",
     "summary": "Compute the stock.picking progression",
-    "version": "14.0.1.1.0",
+    "version": "14.0.1.2.0",
     "category": "Inventory",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "author": "mmequignon, Camptocamp SA, Odoo Community Association (OCA)",

--- a/stock_picking_progress/hooks.py
+++ b/stock_picking_progress/hooks.py
@@ -23,7 +23,7 @@ def setup_move_line_progress(cr):
         UPDATE stock_move_line
         SET progress = CASE
             WHEN (state = 'done') THEN 100
-            WHEN (product_uom_qty IS NULL or product_uom_qty = 0.0) THEN 0.0
+            WHEN (product_uom_qty IS NULL or product_uom_qty = 0.0) THEN 100.0
             ELSE (qty_done / product_uom_qty) * 100
         END;
     """
@@ -47,7 +47,7 @@ def setup_move_progress(cr):
         SET progress = CASE
             WHEN (state = 'done') THEN 100
             WHEN (state in ('draft', 'confirmed')) THEN 0.0
-            WHEN (product_uom_qty IS NULL or product_uom_qty = 0.0) THEN 0.0
+            WHEN (product_uom_qty IS NULL or product_uom_qty = 0.0) THEN 100.0
         END;
     """
     logger.info("filling up %s on %s", column, table)

--- a/stock_picking_progress/hooks.py
+++ b/stock_picking_progress/hooks.py
@@ -79,9 +79,9 @@ def setup_picking_progress(cr):
         UPDATE stock_picking p
         SET progress = subquery.avg_progress
         FROM (
-            SELECT sml.picking_id, avg(sml.progress) as avg_progress
-            FROM stock_move_line sml
-            GROUP BY sml.picking_id
+            SELECT sm.picking_id, avg(sm.progress) as avg_progress
+            FROM stock_move sm
+            GROUP BY sm.picking_id
         ) as subquery
         WHERE p.id = subquery.picking_id;
     """

--- a/stock_picking_progress/migrations/14.0.1.2.0/post-migrate.py
+++ b/stock_picking_progress/migrations/14.0.1.2.0/post-migrate.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import SUPERUSER_ID, api
+
+from odoo.addons.stock_picking_progress.hooks import setup_move_progress_post
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    setup_move_progress_post(env)

--- a/stock_picking_progress/migrations/14.0.1.2.0/pre-migrate.py
+++ b/stock_picking_progress/migrations/14.0.1.2.0/pre-migrate.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.addons.stock_picking_progress.hooks import setup_move_progress
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    setup_move_progress(cr)

--- a/stock_picking_progress/models/stock_move.py
+++ b/stock_picking_progress/models/stock_move.py
@@ -26,6 +26,6 @@ class StockMove(models.Model):
                 continue
             rounding = record.product_uom.rounding
             if float_is_zero(record.product_uom_qty, precision_rounding=rounding):
-                record.progress = 0
+                record.progress = 100
             else:
                 record.progress = (record.quantity_done / record.product_uom_qty) * 100

--- a/stock_picking_progress/models/stock_move_line.py
+++ b/stock_picking_progress/models/stock_move_line.py
@@ -26,6 +26,6 @@ class StockMoveLine(models.Model):
                 continue
             rounding = record.product_uom_id.rounding
             if float_is_zero(record.product_uom_qty, precision_rounding=rounding):
-                record.progress = 0
+                record.progress = 100
             else:
                 record.progress = (record.qty_done / record.product_uom_qty) * 100

--- a/stock_picking_progress/models/stock_picking.py
+++ b/stock_picking_progress/models/stock_picking.py
@@ -22,4 +22,4 @@ class StockPicking(models.Model):
             if lines_progress:
                 record.progress = sum(lines_progress) / len(lines_progress)
             else:
-                record.progress = 0
+                record.progress = 100

--- a/stock_picking_progress/models/stock_picking.py
+++ b/stock_picking_progress/models/stock_picking.py
@@ -11,15 +11,15 @@ class StockPicking(models.Model):
         compute="_compute_progress", store=True, group_operator="avg"
     )
 
-    @api.depends("move_line_ids", "move_line_ids.progress")
+    @api.depends("move_lines", "move_lines.progress")
     def _compute_progress(self):
         for record in self:
             if record.state == "done":
                 record.progress = 100
                 continue
-            lines_progress = record.move_line_ids.mapped("progress")
+            moves_progress = record.move_lines.mapped("progress")
             # Avoid dividing by 0
-            if lines_progress:
-                record.progress = sum(lines_progress) / len(lines_progress)
+            if moves_progress:
+                record.progress = sum(moves_progress) / len(moves_progress)
             else:
                 record.progress = 100

--- a/stock_picking_progress/readme/CONTRIBUTORS.rst
+++ b/stock_picking_progress/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
+* Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>

--- a/stock_picking_progress/readme/DESCRIPTION.rst
+++ b/stock_picking_progress/readme/DESCRIPTION.rst
@@ -1,5 +1,5 @@
-This module adds a new `progress` field on `stock.picking` and `stock.move.line`.
+This module adds a new `progress` field on `stock.picking`, `stock.move` and `stock.move.line`.
 
-On `stock.move.line`, this field represents the percentage of `qty_done` compared to
+On `stock.move` and `stock.move.line`, this field represents the percentage of `qty_done` compared to
 the `product_uom_qty`.
-On `stock.picking`, this field is the average progress of all move lines.
+On `stock.picking`, this field is the average progress of all moves.


### PR DESCRIPTION
With this PR:

- The picking progress is calculated from the moves. This is done to avoid issues with transfers which include moves at different states, as the lines won't be available for some.
- The progress is set to 100 (instead of 0) if there is nothing left to do.