### PR TITLE
[15.0][FIX] stock_picking_filter_lot: Update location_ids correctly when creating a new inventory adjustment

### DIFF
--- a/stock_picking_filter_lot/models/stock_production_lot.py
+++ b/stock_picking_filter_lot/models/stock_production_lot.py
@@ -11,7 +11,7 @@ class StockProductionLot(models.Model):
         comodel_name="stock.location", compute="_compute_location_ids", store=True
     )
 
-    @api.depends("quant_ids", "quant_ids.location_id")
+    @api.depends("quant_ids", "quant_ids.location_id", "quant_ids.quantity")
     def _compute_location_ids(self):
         for lot in self:
             lot.location_ids = lot.quant_ids.filtered(lambda l: l.quantity > 0).mapped(


### PR DESCRIPTION
When we create a new inventory adjustment for a product/location/lot-serial number, if that Lot/Serial Number has never been at that location, it creates the Stock Quant but the Lot/Serial Number doesn't create the link to the location and subsequently, when it is needed in a picking, it cannot be located.

It is necessary to link each of the locations to the Lot/Serial Number for it to be accessible. To do so, we will recompute the location when we change quantity. Because when we firstly create the Stock Quant, quantity is 0 and it does not find that location.