### PR TITLE
[14.0] stock_picking_send_by_mail: able to send the email directly

### DIFF
--- a/stock_picking_send_by_mail/README.rst
+++ b/stock_picking_send_by_mail/README.rst
@@ -73,6 +73,9 @@ Contributors
 
   * Vicent Cubells
   * Carlos Roca
+* Camptocamp <https://www.camptocamp.com>:
+
+  * Sébastien Alix
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_send_by_mail/__manifest__.py
+++ b/stock_picking_send_by_mail/__manifest__.py
@@ -13,6 +13,6 @@
     "category": "Warehouse Management",
     "license": "AGPL-3",
     "depends": ["stock", "mail"],
-    "data": ["views/stock_picking_view.xml"],
+    "data": ["views/stock_picking_view.xml", "views/stock_picking_type.xml"],
     "installable": True,
 }

--- a/stock_picking_send_by_mail/models/__init__.py
+++ b/stock_picking_send_by_mail/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import stock_picking
+from . import stock_picking_type

--- a/stock_picking_send_by_mail/models/stock_picking.py
+++ b/stock_picking_send_by_mail/models/stock_picking.py
@@ -8,9 +8,12 @@ from odoo import _, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
+    def _get_picking_send_email_template(self):
+        return self.company_id.stock_mail_confirmation_template_id
+
     def action_picking_send(self):
         self.ensure_one()
-        template = self.company_id.stock_mail_confirmation_template_id
+        template = self._get_picking_send_email_template()
         compose_form = self.env.ref(
             "mail.email_compose_message_wizard_form",
             False,

--- a/stock_picking_send_by_mail/models/stock_picking.py
+++ b/stock_picking_send_by_mail/models/stock_picking.py
@@ -2,30 +2,39 @@
 # Copyright 2017 Tecnativa - Vicent Cubells
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, models
+from odoo import _, fields, models
 
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
+    delivery_email_sent = fields.Boolean()
+
     def _get_picking_send_email_template(self):
         return self.company_id.stock_mail_confirmation_template_id
 
+    def _get_picking_send_composer_context(self, template_id):
+        return dict(
+            default_model=self._name,
+            default_res_id=self.id,
+            default_use_template=bool(template_id),
+            default_template_id=template_id,
+            default_composition_mode="comment",
+            user_id=self.env.user.id,
+        )
+
     def action_picking_send(self):
+        """Send the shipping e-mail notification to the customer."""
         self.ensure_one()
         template = self._get_picking_send_email_template()
         compose_form = self.env.ref(
             "mail.email_compose_message_wizard_form",
             False,
         )
-        ctx = dict(
-            default_model="stock.picking",
-            default_res_id=self.id,
-            default_use_template=bool(template),
-            default_template_id=template and template.id or False,
-            default_composition_mode="comment",
-            user_id=self.env.user.id,
-        )
+        template_id = template.id if template else False
+        if self._check_send_delivery_email():
+            return self._send_delivery_email(template_id)
+        ctx = self._get_picking_send_composer_context(template_id)
         return {
             "name": _("Compose Email"),
             "type": "ir.actions.act_window",
@@ -37,3 +46,22 @@ class StockPicking(models.Model):
             "target": "new",
             "context": ctx,
         }
+
+    def _check_send_delivery_email(self):
+        return (
+            self.partner_id.email
+            and self.picking_type_id.send_delivery_email
+            and not self.delivery_email_sent
+        )
+
+    def _send_delivery_email(self, template_id):
+        """Send directly the notification e-mail to the customer."""
+        ctx = self._get_picking_send_composer_context(template_id)
+        wiz = self.env["mail.compose.message"].with_context(**ctx).create({})
+        values = wiz.onchange_template_id(template_id, "comment", self._name, self.id)[
+            "value"
+        ]
+        wiz.write(values)
+        wiz.send_mail()
+        self.delivery_email_sent = True
+        return True

--- a/stock_picking_send_by_mail/models/stock_picking_type.py
+++ b/stock_picking_send_by_mail/models/stock_picking_type.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    send_delivery_email = fields.Boolean(
+        string="Send Delivery E-mail",
+        help="Send an e-mail on validation to the customer with the delivery slip.",
+        default=False,
+    )

--- a/stock_picking_send_by_mail/readme/CONTRIBUTORS.rst
+++ b/stock_picking_send_by_mail/readme/CONTRIBUTORS.rst
@@ -3,3 +3,6 @@
 
   * Vicent Cubells
   * Carlos Roca
+* Camptocamp <https://www.camptocamp.com>:
+
+  * Sébastien Alix

--- a/stock_picking_send_by_mail/readme/USAGE.rst
+++ b/stock_picking_send_by_mail/readme/USAGE.rst
@@ -3,3 +3,10 @@ To use this module, you need to:
 * Go to a Delivery Order.
 * Click on the button Send by Email.
 * And finally click on the button Send.
+
+An option is available on the delivery operation type to automatically send
+this e-mail when the delivery order is validated:
+
+* Go to *Inventory / Configuration / Operation Types*
+* Select your delivery operation type
+* Enable the option *Send Delivery E-mail*

--- a/stock_picking_send_by_mail/static/description/index.html
+++ b/stock_picking_send_by_mail/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>README.rst</title>
 <style type="text/css">
 
@@ -421,6 +421,10 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Tecnativa &lt;<a class="reference external" href="https://www.tecnativa.com">https://www.tecnativa.com</a>&gt;:<ul>
 <li>Vicent Cubells</li>
 <li>Carlos Roca</li>
+</ul>
+</li>
+<li>Camptocamp &lt;<a class="reference external" href="https://www.camptocamp.com">https://www.camptocamp.com</a>&gt;:<ul>
+<li>Sébastien Alix</li>
 </ul>
 </li>
 </ul>

--- a/stock_picking_send_by_mail/tests/test_stock_picking_send_by_mail.py
+++ b/stock_picking_send_by_mail/tests/test_stock_picking_send_by_mail.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Tecnativa <vicent.cubells@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo import fields
 from odoo.tests import common
 
 
@@ -10,8 +11,12 @@ class TestStockPickingSendByMail(common.SavepointCase):
         super(TestStockPickingSendByMail, cls).setUpClass()
         cls.product = cls.env["product.product"].create({"name": "Test product"})
         cls.picking_type = cls.env.ref("stock.picking_type_out")
+        cls.customer = cls.env["res.partner"].create(
+            {"name": "Test Shipping Contact", "email": "contact@example.com"}
+        )
         cls.picking = cls.env["stock.picking"].create(
             {
+                "partner_id": cls.customer.id,
                 "picking_type_id": cls.picking_type.id,
                 "location_id": cls.picking_type.default_location_src_id.id,
                 "location_dest_id": cls.picking_type.default_location_src_id.id,
@@ -29,8 +34,23 @@ class TestStockPickingSendByMail(common.SavepointCase):
             }
         )
 
-    def test_send_mail(self):
+    def test_send_mail_action(self):
         self.picking.action_confirm()
         self.picking.action_assign()
         result = self.picking.action_picking_send()
         self.assertEqual(result["name"], "Compose Email")
+
+    def test_send_mail_direct(self):
+        self.picking_type.send_delivery_email = True
+        self.picking.action_confirm()
+        self.picking.action_assign()
+        last_known_message = fields.first(self.picking.message_ids)
+        self.picking.action_picking_send()
+        picking_send_message = self.picking.message_ids[0]
+        self.assertNotEqual(last_known_message, picking_send_message)
+        self.assertTrue(picking_send_message.attachment_ids)
+        template_used = self.picking._get_picking_send_email_template()
+        expected_subject = template_used.generate_email(self.picking.id, ["subject"])[
+            "subject"
+        ]
+        self.assertEqual(picking_send_message.subject, expected_subject)

--- a/stock_picking_send_by_mail/views/stock_picking_type.xml
+++ b/stock_picking_send_by_mail/views/stock_picking_type.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+  <record id="view_picking_type_form" model="ir.ui.view">
+    <field name="model">stock.picking.type</field>
+    <field name="inherit_id" ref="stock.view_picking_type_form" />
+    <field name="arch" type="xml">
+      <field name="show_reserved" position="after">
+        <field
+                    name="send_delivery_email"
+                    attrs="{'invisible': [('code', '!=', 'outgoing')]}"
+                />
+      </field>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
Add a new option on delivery operation types to send automatically an e-mail to the customer's shipping contact:
![image](https://user-images.githubusercontent.com/5315285/223736266-a2f1f2f6-48bc-4985-910e-ac7565483a0c.png)

And add a hook to override the template used.