### PR TITLE
[16.0][FIX] stock_picking_start: Allows picking manual creation

### DIFF
--- a/stock_picking_start/tests/test_stock_picking_start.py
+++ b/stock_picking_start/tests/test_stock_picking_start.py
@@ -169,3 +169,30 @@ class TestStockPickinStart(TransactionCase):
             self.assigned_picking.action_cancel_start()
         self.assigned_picking.action_start()
         self.assertTrue(self.assigned_picking.action_cancel_start_allowed)
+
+    def test_create_picking_started_false(self):
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type.id,
+                "location_id": self.loc_stock.id,
+                "location_dest_id": self.loc_customer.id,
+                "started": False,
+            }
+        )
+        self.assertFalse(picking.printed)
+
+    def test_create_picking_started_true(self):
+        with self.assertRaisesRegex(UserError, "can't be started"):
+            self.env["stock.picking"].create(
+                {
+                    "picking_type_id": self.picking_type.id,
+                    "location_id": self.loc_stock.id,
+                    "location_dest_id": self.loc_customer.id,
+                    "started": True,
+                }
+            )
+
+    def test_copy_picking_started(self):
+        self.assigned_picking.action_start()
+        new_picking = self.assigned_picking.copy()
+        self.assertFalse(new_picking.started)


### PR DESCRIPTION
Before this change it was no more possible to create a picking from the UI since the 'start' field is provided into the dict of values and a check was done to determine is this value could be set to False. The problem was that the check didn't take into account the original value to detect if the provided value will update the record...

ping @jbaudoux ping @rousseldenis 