### PR TITLE
stock_partner_delivery_window: Make delivery windows inclusive

### DIFF
--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -94,7 +94,7 @@ class ResPartner(models.Model):
                 else:
                     utc_start = start_time
                     utc_end = end_time
-                if utc_start <= date_time.time() < utc_end:
+                if utc_start <= date_time.time() <= utc_end:
                     return True
         return False
 

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -118,8 +118,13 @@ class TestPartnerDeliveryWindow(SavepointCase):
         onchange_res = picking._onchange_scheduled_date()
         self.assertIsNone(onchange_res)
         # Scheduled date is in UTC so 2020-04-02 14:00:00 == 2020-04-02 16:00:00
-        #  in Brussels which is not preferred
+        #  in Brussels which is preferred
         picking.scheduled_date = "2020-04-02 14:00:00"
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertIsNone(onchange_res)
+        # Scheduled date is in UTC so 2020-04-02 14:00:01 == 2020-04-02 16:00:01
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-04-02 14:00:01"
         onchange_res = picking._onchange_scheduled_date()
         self.assertTrue(
             isinstance(onchange_res, dict) and "warning" in onchange_res.keys()
@@ -157,6 +162,11 @@ class TestPartnerDeliveryWindow(SavepointCase):
         # Scheduled date is in UTC so 2020-03-26 15:00:00 == 2020-04-02 16:00:00
         #  in Brussels which is preferred
         picking.scheduled_date = "2020-03-26 15:00:00"
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertIsNone(onchange_res)
+        # Scheduled date is in UTC so 2020-03-26 15:00:01 == 2020-04-02 16:00:01
+        #  in Brussels which is not preferred
+        picking.scheduled_date = "2020-03-26 15:00:01"
         onchange_res = picking._onchange_scheduled_date()
         self.assertTrue(
             isinstance(onchange_res, dict) and "warning" in onchange_res.keys()


### PR DESCRIPTION
If a datetime with the same hour as a the end of a time window is checked, it is considered as not part of the time window.