### PR TITLE
[16.0][IMP] add auto-create lot name expression

### DIFF
--- a/stock_picking_auto_create_lot/__manifest__.py
+++ b/stock_picking_auto_create_lot/__manifest__.py
@@ -6,12 +6,16 @@
     "summary": "Auto create lots for incoming pickings",
     "version": "16.0.1.0.0",
     "development_status": "Production/Stable",
-    "category": "stock",
+    "category": "Inventory",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "author": "ACSONE SA/NV, Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "installable": True,
-    "depends": ["stock"],
-    "data": ["views/product_views.xml", "views/stock_picking_type_views.xml"],
+    "depends": [
+        "stock",
+    ],
+    "data": [
+        "views/product_views.xml",
+        "views/stock_picking_type_views.xml",
+    ],
     "maintainers": ["sergio-teruel"],
 }

--- a/stock_picking_auto_create_lot/models/stock_move.py
+++ b/stock_picking_auto_create_lot/models/stock_move.py
@@ -10,6 +10,7 @@ class StockMove(models.Model):
     @api.depends(
         "has_tracking",
         "picking_type_id.auto_create_lot",
+        "picking_type_id.auto_create_lot_for_all_products",
         "product_id.auto_create_lot",
         "picking_type_id.use_existing_lots",
         "state",
@@ -17,7 +18,11 @@ class StockMove(models.Model):
     def _compute_display_assign_serial(self):
         super()._compute_display_assign_serial()
         moves_not_display = self.filtered(
-            lambda m: m.picking_type_id.auto_create_lot and m.product_id.auto_create_lot
+            lambda m: m.picking_type_id.auto_create_lot
+            and (
+                m.picking_type_id.auto_create_lot_for_all_products
+                or m.product_id.auto_create_lot
+            )
         )
         for move in moves_not_display:
             move.display_assign_serial = False

--- a/stock_picking_auto_create_lot/models/stock_move_line.py
+++ b/stock_picking_auto_create_lot/models/stock_move_line.py
@@ -2,6 +2,11 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 from odoo.fields import first
+from odoo.tools.rendering_tools import (
+    parse_inline_template,
+    render_inline_template,
+    template_env_globals,
+)
 
 
 class StockMoveLine(models.Model):
@@ -13,20 +18,50 @@ class StockMoveLine(models.Model):
         Prepare multi valued lots per line to use multi creation.
         """
         self.ensure_one()
-        return {"product_id": self.product_id.id, "company_id": self.company_id.id}
+        vals = {"product_id": self.product_id.id, "company_id": self.company_id.id}
+        if self.product_id.tracking == "lot":
+            expression = self.picking_type_id.auto_create_lot_name_expression
+            if expression:
+                template_instructions = parse_inline_template(expression)
+                variables = {"stock_move_line": self}
+                variables.update(template_env_globals)
+                vals["name"] = render_inline_template(template_instructions, variables)
+        return vals
+
+    def _get_and_create_lots(self):
+        """
+        Get existing lots and create missing ones.
+        """
+        vals_list = []
+        stock_lot_obj = self.env["stock.lot"]
+        lots = stock_lot_obj.browse()
+        for line in self:
+            vals = line._prepare_auto_lot_values()
+            if line.picking_id.use_existing_lots and vals.get("name"):
+                lot = stock_lot_obj.search(
+                    [
+                        (key, "=", vals[key])
+                        for key in ("product_id", "company_id", "name")
+                    ]
+                )
+                if lot:
+                    lots |= lot
+                else:
+                    vals_list.append(vals)
+            else:
+                vals_list.append(vals)
+        # Lots are created using create_multi to avoid too much queries.
+        lots |= stock_lot_obj.create(vals_list)
+        return lots
 
     def set_lot_auto(self):
         """
-        Create lots using create_multi to avoid too much queries
-        As move lines were created by product or by tracked 'serial'
-        products, we apply the lot with both different approaches.
+        Create lots and assign them. As move lines were created by product or
+        by tracked 'serial' products, we apply the lot with both different
+        approaches.
         """
-        values = []
-        stock_lot_obj = self.env["stock.lot"]
+        lots = self._get_and_create_lots()
         lots_by_product = dict()
-        for line in self:
-            values.append(line._prepare_auto_lot_values())
-        lots = stock_lot_obj.create(values)
         for lot in lots:
             if lot.product_id.id not in lots_by_product:
                 lots_by_product[lot.product_id.id] = lot

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -17,7 +17,10 @@ class StockPicking(models.Model):
                 not x.lot_id
                 and not x.lot_name
                 and x.product_id.tracking != "none"
-                and x.product_id.auto_create_lot
+                and (
+                    x.product_id.auto_create_lot
+                    or x.picking_type_id.auto_create_lot_for_all_products
+                )
             )
         )
         lines.set_lot_auto()

--- a/stock_picking_auto_create_lot/models/stock_picking_type.py
+++ b/stock_picking_auto_create_lot/models/stock_picking_type.py
@@ -7,3 +7,13 @@ class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
     auto_create_lot = fields.Boolean()
+    auto_create_lot_name_expression = fields.Char(
+        "Lot Name Expression",
+        help="Expression to use for auto-created lot names; leave empty to "
+        "use the default name",
+    )
+    auto_create_lot_for_all_products = fields.Boolean(
+        "Auto Create Lots for All Products",
+        help="Auto-create lots for all products, ignoring their Auto Create "
+        "Lot property",
+    )

--- a/stock_picking_auto_create_lot/readme/DESCRIPTION.rst
+++ b/stock_picking_auto_create_lot/readme/DESCRIPTION.rst
@@ -1,2 +1,25 @@
 This module extends the functionality of stock module to allow auto create
 lots for incoming pickings.
+
+The lot names are generated from a configurable expression that uses the
+inline template syntax. It is configured in on the operation type
+(``stock.picking.type``) (Lot Name Expression field).
+
+The expression has access to some default variables provided by inline
+templates (like ``datetime``), as well as the product move (stock move line)
+as ``stock_move_line``.
+
+If empty, the default value for lot names is used.
+
+Here is an example of an expression that uses the supplier's name and the
+date (this will result in the same lot being used for multiple stock moves):
+
+.. code-block::
+
+    {{stock_move_line.picking_id.partner_id.name}}/{{datetime.date.today().isoformat()}}
+
+Here is an example using the default sequence directly:
+
+.. code-block::
+
+    {{stock_move_line.env["ir.sequence"].next_by_code("stock.lot.serial")}}

--- a/stock_picking_auto_create_lot/tests/common.py
+++ b/stock_picking_auto_create_lot/tests/common.py
@@ -35,7 +35,7 @@ class CommonStockPickingAutoCreateLot(object):
 
     @classmethod
     def _create_picking(cls):
-        cls.picking = (
+        return (
             cls.env["stock.picking"]
             .with_context(default_picking_type_id=cls.picking_type_in.id)
             .create(
@@ -48,14 +48,16 @@ class CommonStockPickingAutoCreateLot(object):
         )
 
     @classmethod
-    def _create_move(cls, product=None, qty=1.0):
-        location_dest = cls.picking.picking_type_id.default_location_dest_id
-        cls.move = cls.env["stock.move"].create(
+    def _create_move(cls, product=None, qty=1.0, picking=None):
+        if picking is None:
+            picking = cls.picking
+        location_dest = picking.picking_type_id.default_location_dest_id
+        return cls.env["stock.move"].create(
             {
                 "name": "test-{product}".format(product=product.name),
                 "product_id": product.id,
-                "picking_id": cls.picking.id,
-                "picking_type_id": cls.picking.picking_type_id.id,
+                "picking_id": picking.id,
+                "picking_type_id": picking.picking_type_id.id,
                 "product_uom_qty": qty,
                 "product_uom": product.uom_id.id,
                 "location_id": cls.supplier_location.id,

--- a/stock_picking_auto_create_lot/views/stock_picking_type_views.xml
+++ b/stock_picking_auto_create_lot/views/stock_picking_type_views.xml
@@ -9,6 +9,15 @@
         <field name="arch" type="xml">
             <field name="use_existing_lots" position="after">
                 <field name="auto_create_lot" />
+                <field
+                    name="auto_create_lot_name_expression"
+                    attrs="{'readonly': [('auto_create_lot', '=', False)]}"
+                    style="overflow-wrap: anywhere"
+                />
+                <field
+                    name="auto_create_lot_for_all_products"
+                    attrs="{'readonly': [('auto_create_lot', '=', False)]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
* allow to control the name of auto-created lots using an expression.
* allow to auto-create lots for all products without needing to enable it for each.
* fix global variables in tests.