### PR TITLE
[FIX][15.0] stock_picking_mass_action - missing button_validate_picking_ids context

### DIFF
--- a/stock_picking_mass_action/wizard/mass_action.py
+++ b/stock_picking_mass_action/wizard/mass_action.py
@@ -74,6 +74,9 @@ class StockPickingMassAction(TransientModel):
                     lambda m: m.state not in ("done", "cancel")
                 )
             )
+            assigned_picking_lst = assigned_picking_lst.with_context(
+                button_validate_picking_ids=assigned_picking_lst.ids
+            )
             if not quantities_done:
                 return assigned_picking_lst.action_immediate_transfer_wizard()
             if any([pick._check_backorder() for pick in assigned_picking_lst]):


### PR DESCRIPTION
Missing `button_validate_picking_ids` context means pickings aren't actually transferred if action_immediate_transfer_wizard or _action_generate_backorder_wizard is called.

Validation is gated by the context: https://github.com/odoo/odoo/blob/15.0/addons/stock/wizard/stock_backorder_confirmation.py#L58

And as part of the standard process of `button_validate` added here: https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_picking.py#L1012-L1014

@GlodoUK GH105825