### PR TITLE
[16.0][FIX] stock_picking_auto_create_lot: immediate transfer with auto_create_lot option

### DIFF
--- a/stock_picking_auto_create_lot/README.rst
+++ b/stock_picking_auto_create_lot/README.rst
@@ -85,6 +85,9 @@ Contributors
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 * Denis Roussel <denis.roussel@acsone.eu>
 * Valentin Vinagre <valentin.vinagre@sygel.es>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Aung Ko Ko Lin
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_auto_create_lot/readme/CONTRIBUTORS.rst
+++ b/stock_picking_auto_create_lot/readme/CONTRIBUTORS.rst
@@ -3,3 +3,6 @@
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 * Denis Roussel <denis.roussel@acsone.eu>
 * Valentin Vinagre <valentin.vinagre@sygel.es>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Aung Ko Ko Lin

--- a/stock_picking_auto_create_lot/static/description/index.html
+++ b/stock_picking_auto_create_lot/static/description/index.html
@@ -432,6 +432,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
 <li>Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
 <li>Valentin Vinagre &lt;<a class="reference external" href="mailto:valentin.vinagre&#64;sygel.es">valentin.vinagre&#64;sygel.es</a>&gt;</li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -2,7 +2,7 @@
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.exceptions import UserError
-from odoo.tests import TransactionCase
+from odoo.tests import Form, TransactionCase
 
 from .common import CommonStockPickingAutoCreateLot
 
@@ -34,7 +34,6 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             lambda m: m.product_id == self.product_serial_not_auto
         )
         self.assertTrue(move.display_assign_serial)
-
         # Assign manual serials
         for line in move.move_line_ids:
             line.lot_id = self.lot_obj.create(line._prepare_auto_lot_values())
@@ -144,3 +143,19 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             [("product_id", "=", self.product_serial.id)]
         )
         self.assertEqual(len(lot), 6)
+
+    def test_immediate_validate_tracked_move_with_auto_create_lot(self):
+        # Clear existing moves.
+        self.picking.move_ids = False
+        self._create_move(product=self.product_serial, qty=4.0)
+        self.picking.action_assign()
+        immediate_wizard = self.picking.button_validate()
+        self.assertEqual(immediate_wizard.get("res_model"), "stock.immediate.transfer")
+        immediate_wizard_form = Form(
+            self.env[immediate_wizard["res_model"]].with_context(
+                **immediate_wizard["context"]
+            )
+        ).save()
+        immediate_wizard_form.process()
+        # Confirm that validation is not blocked, for example, by create-backorder wizard.
+        self.assertEqual(self.picking.state, "done")


### PR DESCRIPTION
Related issue: https://github.com/OCA/stock-logistics-workflow/issues/1281
Related odoo commit: https://github.com/odoo/odoo/commit/dd44e1f69dfd217fafa9c2ec5da8b211b2ff3513

@qrtl