### PR TITLE
[16.0][FIX] stock_grn: bad widget for grn_id

### DIFF
--- a/stock_grn/views/stock_move_views.xml
+++ b/stock_grn/views/stock_move_views.xml
@@ -8,7 +8,7 @@
     <field name="inherit_id" ref="stock.view_move_tree" />
     <field name="arch" type="xml">
       <field name="state" position="after">
-        <field name="grn_id" widget="boolean" string="GRN" />
+        <field name="grn_id" string="GRN" />
       </field>
     </field>
   </record>


### PR DESCRIPTION
There was a boolean widget for a many2one field so the stock moves tree crashed on opening.