### PR TITLE
[FIX] stock_picking_batch_extended: An user without Administrator group security can not select fields to group picking batch

### DIFF
--- a/stock_picking_batch_extended/security/ir.model.access.csv
+++ b/stock_picking_batch_extended/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 access_stock_picking_batch_creator_group_field_user,access_stock_picking_batch_creator_group_field_user,model_stock_picking_batch_creator_group_field,stock.group_stock_user,1,1,1,1
+base.access_ir_model_fields_user,ir_model_fields all,base.model_ir_model_fields,base.group_user,1,0,0,0


### PR DESCRIPTION
cc @Tecnativa 

ping @carlosdauden @chienandalu 