### PR TITLE
[15.0][IMP] stock_owner_restriction: Partner or unassigned stock option

### DIFF
--- a/stock_owner_restriction/README.rst
+++ b/stock_owner_restriction/README.rst
@@ -23,7 +23,7 @@ Stock Owner Restriction
     :target: https://runbot.odoo-community.org/runbot/154/15.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module extends the functionality of stock module to allow restriction
 of product quantities (quants) for stock operations such as reserve quantities
@@ -113,6 +113,10 @@ Contributors
     * Sergio Teruel
     * César A. Sánchez
     * Luis D. Lafaurie
+
+* `Studio73 <https://www.studio73.es>`_:
+
+    * Ferran Mora
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_owner_restriction/models/stock_move.py
+++ b/stock_owner_restriction/models/stock_move.py
@@ -27,6 +27,20 @@ class StockMove(models.Model):
                 StockMove,
                 moves_to_assign.with_context(force_restricted_owner_id=owner_id),
             )._action_assign()
+            if (
+                owner_id
+                and moves_to_assign.picking_type_id.owner_restriction
+                == "partner_or_unassigned"
+                and sum(
+                    move.reserved_availability - move.product_uom_qty
+                    for move in moves_to_assign
+                )
+                < 0
+            ):
+                super(
+                    StockMove,
+                    moves_to_assign.with_context(force_restricted_owner_id=False),
+                )._action_assign()
         return res
 
     def _update_reserved_quantity(

--- a/stock_owner_restriction/models/stock_picking_type.py
+++ b/stock_owner_restriction/models/stock_picking_type.py
@@ -12,6 +12,7 @@ class StockPickingType(models.Model):
             ("standard_behavior", "Standard behavior"),
             ("unassigned_owner", "Unassigned owner"),
             ("picking_partner", "Picking partner"),
+            ("partner_or_unassigned", "Picking partner or unassigned owner"),
         ],
         default="standard_behavior",
     )

--- a/stock_owner_restriction/tests/test_stock_owner_restriction.py
+++ b/stock_owner_restriction/tests/test_stock_owner_restriction.py
@@ -123,6 +123,27 @@ class TestStockOwnerRestriction(TransactionCase):
         self.assertTrue(self.picking_out.move_line_ids.mapped("owner_id"))
         self.assertEqual(self.picking_out.state, "assigned")
 
+        # Set restriction options on picking type to get only quants with an
+        # owner assigned.
+        # The picking partner has quants assigned and there ara unassigned quants
+        # so the picking is in assigned state and with 1000 reserved units
+        self.picking_type_out.owner_restriction = "partner_or_unassigned"
+        self.picking_out.do_unreserve()
+        self.picking_out.action_assign()
+        self.assertEqual(self.picking_out.move_lines.reserved_availability, 1000.00)
+        self.assertEqual(len(self.picking_out.move_line_ids), 2)
+        self.assertEqual(self.picking_out.move_line_ids.mapped("owner_id"), self.owner)
+
+        # Set restriction options on picking type to get only quants with an
+        # owner assigned.
+        # The picking partner has not quants assigned but there are unassigned quants
+        # so the picking is in assigned state with 500 reserved units
+        self.picking_out.partner_id = False
+        self.picking_out.do_unreserve()
+        self.picking_out.action_assign()
+        self.assertEqual(self.picking_out.move_lines.reserved_availability, 500.00)
+        self.assertEqual(len(self.picking_out.move_line_ids), 1)
+
     def test_search_qty(self):
         products = self.env["product.product"].search(
             [("id", "=", self.product.id), ("qty_available", ">", 500.00)]


### PR DESCRIPTION
Forward port from 14.0
- https://github.com/OCA/stock-logistics-workflow/pull/1132