### PR TITLE
[15.0][FIX] stock_picking_invoice_link: Wrong link when several lines have same product

### DIFF
--- a/stock_picking_invoice_link/models/sale_order.py
+++ b/stock_picking_invoice_link/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrderLine(models.Model):
     def get_stock_moves_link_invoice(self):
         moves_linked = self.env["stock.move"]
         to_invoice = self.qty_to_invoice
-        for stock_move in self.move_ids.sorted(
+        for stock_move in self.move_ids.filtered(lambda sm: sm.state == "done").sorted(
             lambda m: (m.write_date, m.id), reverse=True
         ):
             if (


### PR DESCRIPTION
When credit note has several lines with the same product, all lines are linked with all related stock moves

@Tecnativa TT43399

Ping @antonyht27 @CarlosRoca13 @chienandalu 