### PR TITLE
[16.0][FIX] stock_procurement_customer: stock picking view

### DIFF
--- a/stock_procurement_customer/views/stock_picking.xml
+++ b/stock_procurement_customer/views/stock_picking.xml
@@ -10,12 +10,14 @@
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="customer_id_visible" invisible="1" />
-                <div class="o_td_label">
+                <div
+                    class="o_td_label"
+                    attrs="{'invisible': [('customer_id_visible', '=', False)]}"
+                >
                     <label
                         for="customer_id"
                         string="Customer Address"
                         style="font-weight:bold;"
-                        attrs="{'invisible': [('customer_id_visible', '=', False)]}"
                     />
                 </div>
                 <field


### PR DESCRIPTION
Move the atribute invisible from label customer_id to the containing div to avoid an empty div in the flow even when the field is not displayed.