### PR TITLE
[FIX] stock_picking_start: Don't evaluate void browse records to boolean value

### DIFF
--- a/stock_picking_start/models/stock_picking.py
+++ b/stock_picking_start/models/stock_picking.py
@@ -1,9 +1,9 @@
 # Copyright 2022 ACSONE SA/NV
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.models import BaseModel
 
 
 class StockPicking(models.Model):
@@ -66,7 +66,13 @@ class StockPicking(models.Model):
 
     def _is_inverse_started_modify_origin(self, vals):
         for k, v in vals.items():
-            if self._origin[k] != v:
+            if isinstance(self._origin[k], BaseModel) and not self._origin[k]:
+                # We evaluate fields that are browse records as
+                # void browse record != False
+                value = False
+            else:
+                value = self._origin[k]
+            if value != v:
                 return True
         return False
 

--- a/stock_picking_start/tests/test_stock_picking_start.py
+++ b/stock_picking_start/tests/test_stock_picking_start.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo.exceptions import UserError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 
 
 class TestStockPickinStart(TransactionCase):
@@ -196,3 +196,14 @@ class TestStockPickinStart(TransactionCase):
         self.assigned_picking.action_start()
         new_picking = self.assigned_picking.copy()
         self.assertFalse(new_picking.started)
+
+    def test_picking_creation(self):
+        # Activate the user change at start
+        # Check the picking can be created
+        self.env.company.stock_picking_assign_operator_at_start = True
+        picking_form = Form(
+            self.env["stock.picking"].with_context(
+                default_picking_type_id=self.env.ref("stock.picking_type_in").id
+            )
+        )
+        picking_form.save()


### PR DESCRIPTION


e.g.: If user_id is set to False and was not set before, the condition to check if record is modified would return True as res.users() != False