### PR TITLE
[15.0] Create module stock_move_consu_location_from_putaway

### DIFF
--- a/setup/stock_move_consu_location_from_putaway/odoo/addons/stock_move_consu_location_from_putaway
+++ b/setup/stock_move_consu_location_from_putaway/odoo/addons/stock_move_consu_location_from_putaway
@@ -1,0 +1,1 @@
+../../../../stock_move_consu_location_from_putaway

--- a/setup/stock_move_consu_location_from_putaway/setup.py
+++ b/setup/stock_move_consu_location_from_putaway/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_move_consu_location_from_putaway/README.rst
+++ b/stock_move_consu_location_from_putaway/README.rst
@@ -1,0 +1,1 @@
+To auto generate

--- a/stock_move_consu_location_from_putaway/__init__.py
+++ b/stock_move_consu_location_from_putaway/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_move_consu_location_from_putaway/__manifest__.py
+++ b/stock_move_consu_location_from_putaway/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Move Consumable Location From Putaway",
+    "summary": "Use putaway location as source of move lines for consumables",
+    "version": "15.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Inventory/Inventory",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["grindtildeath"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "stock",
+    ],
+}

--- a/stock_move_consu_location_from_putaway/models/__init__.py
+++ b/stock_move_consu_location_from_putaway/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_move

--- a/stock_move_consu_location_from_putaway/models/stock_move.py
+++ b/stock_move_consu_location_from_putaway/models/stock_move.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
+        res = super()._prepare_move_line_vals(
+            quantity=quantity, reserved_quant=reserved_quant
+        )
+        if (
+            self.product_id.detailed_type == "consu"
+            and self.location_id.usage == "internal"
+        ):
+            putaway_loc = self.location_id._get_putaway_strategy(self.product_id)
+            res["location_id"] = putaway_loc.id
+        return res

--- a/stock_move_consu_location_from_putaway/readme/CONTRIBUTORS.rst
+++ b/stock_move_consu_location_from_putaway/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_move_consu_location_from_putaway/readme/DESCRIPTION.rst
+++ b/stock_move_consu_location_from_putaway/readme/DESCRIPTION.rst
@@ -1,0 +1,15 @@
+This module allows, for consumable products, to use the putaway location
+as a source location of the stock move line, when the stock move
+use a parent location of the putaway location as its source location.
+
+As Odoo allows to define putaway rules for consumable products, incoming moves
+will have the putaway applied to define the destination location of the
+move lines, allowing to display this location in the Picking Operations report.
+
+On outgoing moves though, as the stock levels are obviously not managed for
+consumable products, there is no quantity to reserve in any location and the
+Picking Operations report can only display the source location of the move.
+
+With this module however, as the location of the putaway will be used as
+the source location of the move line, the Picking Operations report will
+display this location where the consumable product is supposed to be stored.

--- a/stock_move_consu_location_from_putaway/tests/test_consumable_move_location.py
+++ b/stock_move_consu_location_from_putaway/tests/test_consumable_move_location.py
@@ -1,0 +1,44 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import Form
+
+from odoo.addons.stock.tests.common import TestStockCommon
+
+
+class TestConsumableMoveLocation(TestStockCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.consu_product = cls.env["product.product"].create(
+            {"name": "Consumable", "type": "consu"}
+        )
+        cls.putaway_location = cls.env["stock.location"].create(
+            {
+                "name": "putaway loc for consumable",
+                "usage": "internal",
+                "location_id": cls.stock_location,
+            }
+        )
+        cls.putaway = cls.env["stock.putaway.rule"].create(
+            {
+                "product_id": cls.consu_product.id,
+                "location_in_id": cls.stock_location,
+                "location_out_id": cls.putaway_location.id,
+            }
+        )
+
+    def test_outgoing_move(self):
+        move_form = Form(self.env["stock.move"])
+        move_form.product_id = self.consu_product
+        move_form.location_id = self.env["stock.location"].browse(self.stock_location)
+        move_form.location_dest_id = self.env["stock.location"].browse(
+            self.pack_location
+        )
+        move = move_form.save()
+        self.assertEqual(move.state, "draft")
+        self.assertEqual(move.location_id.id, self.stock_location)
+        self.assertFalse(move.move_line_ids)
+        move._action_confirm()
+        self.assertEqual(move.state, "assigned")
+        self.assertTrue(move.move_line_ids)
+        self.assertEqual(move.move_line_ids.location_id, self.putaway_location)


### PR DESCRIPTION
This module allows, for consumable products, to use the putaway location
as a source location of the stock move line, when the stock move
use a parent location of the putaway location as its source location.

As Odoo allows to define putaway rules for consumable products, incoming moves
will have the putaway applied to define the destination location of the
move lines, allowing to display this location in the Picking Operations report.

On outgoing moves though, as the stock levels are obviously not managed for
consumable products, there is no quantity to reserve in any location and the
Picking Operations report can only display the source location of the move.

With this module however, as the location of the putaway will be used as
the source location of the move line, the Picking Operations report will
display this location where the consumable product is supposed to be stored.