### PR TITLE
[FIX] stock_owner_restriction: incompatibility with stock_barcode

### DIFF
--- a/stock_owner_restriction/views/stock_picking_type_views.xml
+++ b/stock_owner_restriction/views/stock_picking_type_views.xml
@@ -4,7 +4,7 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
-            <xpath expr="//sheet/group[2]" position="inside">
+            <xpath expr="//sheet//group[@name='second']" position="inside">
                 <group name="owner_restriction" string="Owner settings">
                     <field name="owner_restriction" />
                 </group>


### PR DESCRIPTION
When installing `stock_barcode` before installing this module, this one cannot be installed later.

@moduon MT-3005