### PR TITLE
[13.0][ADD]stock_picking_origin_reference*: Base, Purchase and Sales

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.14.2
+_commit: v1.15.0
 _src_path: https://github.com/OCA/oca-addons-repo-template.git
 ci: GitHub
 dependency_installation_mode: PIP
@@ -11,6 +11,7 @@ github_enable_makepot: true
 github_enable_stale_action: true
 github_enforce_dev_status_compatibility: true
 include_wkhtmltopdf: false
+odoo_test_flavor: Both
 odoo_version: 13.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: "3.8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Detect unreleased dependencies
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           for reqfile in requirements.txt test-requirements.txt ; do
               if [ -f ${reqfile} ] ; then
@@ -36,10 +36,10 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
-            makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
             name: test with OCB
+            makepot: "true"
     services:
       postgres:
         image: postgres:9.6
@@ -50,7 +50,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install addons and dependencies

--- a/setup/stock_picking_origin_reference/odoo/addons/stock_picking_origin_reference
+++ b/setup/stock_picking_origin_reference/odoo/addons/stock_picking_origin_reference
@@ -1,0 +1,1 @@
+../../../../stock_picking_origin_reference

--- a/setup/stock_picking_origin_reference/setup.py
+++ b/setup/stock_picking_origin_reference/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/stock_picking_origin_reference_purchase/odoo/addons/stock_picking_origin_reference_purchase
+++ b/setup/stock_picking_origin_reference_purchase/odoo/addons/stock_picking_origin_reference_purchase
@@ -1,0 +1,1 @@
+../../../../stock_picking_origin_reference_purchase

--- a/setup/stock_picking_origin_reference_purchase/setup.py
+++ b/setup/stock_picking_origin_reference_purchase/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/stock_picking_origin_reference_sale/odoo/addons/stock_picking_origin_reference_sale
+++ b/setup/stock_picking_origin_reference_sale/odoo/addons/stock_picking_origin_reference_sale
@@ -1,0 +1,1 @@
+../../../../stock_picking_origin_reference_sale

--- a/setup/stock_picking_origin_reference_sale/setup.py
+++ b/setup/stock_picking_origin_reference_sale/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_picking_origin_reference/__init__.py
+++ b/stock_picking_origin_reference/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_origin_reference/__manifest__.py
+++ b/stock_picking_origin_reference/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Stock Picking Origin Reference",
+    "summary": "Add clickable button to the Transfer Source Document.",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Warehouse Management",
+    "depends": ["stock"],
+    "data": ["views/stock_picking_views.xml"],
+    "installable": True,
+    "application": False,
+}

--- a/stock_picking_origin_reference/models/__init__.py
+++ b/stock_picking_origin_reference/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/stock_picking_origin_reference/models/stock_picking.py
+++ b/stock_picking_origin_reference/models/stock_picking.py
@@ -1,0 +1,29 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    origin_reference = fields.Reference(
+        selection="_selection_origin_reference",
+        compute="_compute_origin_reference",
+        string="Source Document",
+    )
+
+    def _selection_origin_reference(self):
+        return [("stock.picking", "Transfer")]
+
+    @api.model
+    def _get_depends_compute_origin_reference(self):
+        return ["origin"]
+
+    @api.depends(lambda x: x._get_depends_compute_origin_reference())
+    def _compute_origin_reference(self):
+        for picking in self:
+            origin_reference = False
+            rel_picking = self.search([("name", "=", picking.origin)], limit=1)
+            if rel_picking:
+                origin_reference = "%s,%s" % (self._name, rel_picking.id)
+            picking.origin_reference = origin_reference

--- a/stock_picking_origin_reference/readme/CONFIGURE.rst
+++ b/stock_picking_origin_reference/readme/CONFIGURE.rst
@@ -1,0 +1,6 @@
+By just installing this module, the `stock_picking_origin_reference_sale`
+and `stock_picking_origin_reference_purchase` modules are auto-installed, if you have
+corresponding *extension* modules installed, such as sale and purchase respectively.
+
+These two modules together with this one, will enable the navigation to Sales Orders,
+Purchase Orders and Transfers. All possible referenced models used in Odoo by default.

--- a/stock_picking_origin_reference/readme/CONTRIBUTORS.rst
+++ b/stock_picking_origin_reference/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* ForgeFlow S.L.
+  * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/stock_picking_origin_reference/readme/DESCRIPTION.rst
+++ b/stock_picking_origin_reference/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+The Source Document contains a text referencing to the Odoo document from which
+the transfer has been created. This module replaces the Source Document field for a
+field with the same label which is clickable and redirects the user to the document.
+
+If there is an existing Odoo document with the same name as the value in the Source
+Document, the Odoo field is hidden, and the new field is shown by default. Otherwise, it's left as it is.
+
+It also adds the base strucuture in order to reference documents from different Odoo
+models.

--- a/stock_picking_origin_reference/tests/__init__.py
+++ b/stock_picking_origin_reference/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_picking_origin_reference

--- a/stock_picking_origin_reference/tests/test_stock_picking_origin_reference.py
+++ b/stock_picking_origin_reference/tests/test_stock_picking_origin_reference.py
@@ -1,0 +1,61 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import fields
+from odoo.tests.common import TransactionCase
+
+
+class TestStockPickingOriginReference(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        # Models
+        self.picking_model = self.env["stock.picking"]
+
+        # Existing Instances
+        self.picking_type_in_id = self.env.ref("stock.picking_type_in")
+        self.picking_type_out_id = self.env.ref("stock.picking_type_out")
+        self.location_suppliers = self.env.ref("stock.stock_location_suppliers")
+        self.location_stock = self.env.ref("stock.stock_location_stock")
+        self.location_customers = self.env.ref("stock.stock_location_customers")
+
+        # TO BE USED IN CHILDREN TESTS
+        self.partner_model = self.env["res.partner"]
+
+        self.product = self.env.ref("product.product_product_3")
+
+        self.partner = self.partner_model.create({"name": "Test Partner"})
+
+    def _create_picking(
+        self, picking_type_id, location_id, location_dest_id, origin=False
+    ):
+        picking = self.picking_model.create(
+            {
+                "picking_type_id": picking_type_id.id,
+                "location_id": location_id.id,
+                "location_dest_id": location_dest_id.id,
+                "scheduled_date": fields.Date.today(),
+                "priority": "1",
+                "origin": origin,
+            }
+        )
+        return picking
+
+    def test_01_check_correct_value(self):
+        """
+        Check that the OUT transfer references to the IN transfer with the `origin
+        reference` field.
+        """
+        self.picking_in = self._create_picking(
+            self.picking_type_in_id, self.location_suppliers, self.location_stock
+        )
+        self.picking_out = self._create_picking(
+            self.picking_type_out_id,
+            self.location_stock,
+            self.location_customers,
+            origin=self.picking_in.name,
+        )
+        self.assertEqual(self.picking_out.origin, self.picking_in.name)
+        self.assertEqual(
+            self.picking_out.origin_reference,
+            self.picking_in,
+            "The " "Origin Reference should point to the IN transfer.",
+        )

--- a/stock_picking_origin_reference/views/stock_picking_views.xml
+++ b/stock_picking_origin_reference/views/stock_picking_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form - stock_picking_origin_reference</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <field name="origin" position="after">
+                <field
+                    name="origin_reference"
+                    attrs="{'invisible': [('origin_reference', '=', False)]}"
+                />
+            </field>
+            <field name="origin" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|',('origin', '=', False),('origin_reference', '!=', False)]}</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/stock_picking_origin_reference_purchase/__init__.py
+++ b/stock_picking_origin_reference_purchase/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_origin_reference_purchase/__manifest__.py
+++ b/stock_picking_origin_reference_purchase/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Stock Picking Origin Reference Purchase",
+    "summary": "Transfer to Purchase Order navigation from the Source Document.",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Warehouse Management",
+    "depends": ["stock_picking_origin_reference", "purchase"],
+    "installable": True,
+    "application": False,
+    "auto_install": True,
+}

--- a/stock_picking_origin_reference_purchase/models/__init__.py
+++ b/stock_picking_origin_reference_purchase/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/stock_picking_origin_reference_purchase/models/stock_picking.py
+++ b/stock_picking_origin_reference_purchase/models/stock_picking.py
@@ -1,0 +1,28 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+PO_MODEL_NAME = "purchase.order"
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _selection_origin_reference(self):
+        return super()._selection_origin_reference() + [
+            (PO_MODEL_NAME, "Purchase Order")
+        ]
+
+    @api.depends(lambda x: x._get_depends_compute_origin_reference())
+    def _compute_origin_reference(self):
+        super()._compute_origin_reference()
+        for picking in self:
+            if not picking.origin_reference:
+                rel_purchase = self.env[PO_MODEL_NAME].search(
+                    [("name", "=", picking.origin)], limit=1
+                )
+                if rel_purchase:
+                    picking.origin_reference = "%s,%s" % (
+                        PO_MODEL_NAME,
+                        rel_purchase.id,
+                    )

--- a/stock_picking_origin_reference_purchase/readme/CONTRIBUTORS.rst
+++ b/stock_picking_origin_reference_purchase/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* ForgeFlow S.L.
+  * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/stock_picking_origin_reference_purchase/readme/DESCRIPTION.rst
+++ b/stock_picking_origin_reference_purchase/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module extends the `stock_picking_origin_reference` features by adding Purchase
+Orders as one of the possible referenced documents.

--- a/stock_picking_origin_reference_purchase/tests/__init__.py
+++ b/stock_picking_origin_reference_purchase/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_picking_origin_reference_purchase

--- a/stock_picking_origin_reference_purchase/tests/test_stock_picking_origin_reference_purchase.py
+++ b/stock_picking_origin_reference_purchase/tests/test_stock_picking_origin_reference_purchase.py
@@ -1,0 +1,52 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import fields
+
+from odoo.addons.stock_picking_origin_reference.tests import (
+    test_stock_picking_origin_reference,
+)
+
+
+class TestStockPickingOriginReferencePurchase(
+    test_stock_picking_origin_reference.TestStockPickingOriginReference
+):
+    def setUp(self):
+        super().setUp()
+        self.purchase_model = self.env["purchase.order"]
+
+    def _create_purchase(self, partner, product):
+        purchase = self.purchase_model.create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.name,
+                            "product_id": product.id,
+                            "product_qty": 5,
+                            "product_uom": product.uom_id.id,
+                            "price_unit": 500,
+                            "date_planned": fields.datetime.now(),
+                        },
+                    )
+                ],
+            }
+        )
+        return purchase
+
+    def test_01_check_correct_value(self):
+        """
+        Check that the Transfer created from the purchase is referencing it.
+        """
+        purchase = self._create_purchase(self.partner, self.product)
+        purchase.button_confirm()
+        self.assertTrue(purchase.picking_ids)
+        self.assertEqual(
+            len(purchase.picking_ids), 1, "Only one Transfer should be created."
+        )
+        picking = purchase.picking_ids
+        self.assertEqual(
+            picking.origin_reference, purchase, "The Transfer should reference the PO."
+        )

--- a/stock_picking_origin_reference_sale/__init__.py
+++ b/stock_picking_origin_reference_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_origin_reference_sale/__manifest__.py
+++ b/stock_picking_origin_reference_sale/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Stock Picking Origin Reference Sale",
+    "summary": "Transfer to Sales Order navigation from the Source Document.",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Warehouse Management",
+    "depends": ["stock_picking_origin_reference", "sale"],
+    "installable": True,
+    "application": False,
+    "auto_install": True,
+}

--- a/stock_picking_origin_reference_sale/models/__init__.py
+++ b/stock_picking_origin_reference_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/stock_picking_origin_reference_sale/models/stock_picking.py
+++ b/stock_picking_origin_reference_sale/models/stock_picking.py
@@ -1,0 +1,23 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+SO_MODEL_NAME = "sale.order"
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _selection_origin_reference(self):
+        return super()._selection_origin_reference() + [(SO_MODEL_NAME, "Sales Order")]
+
+    @api.depends(lambda x: x._get_depends_compute_origin_reference())
+    def _compute_origin_reference(self):
+        super()._compute_origin_reference()
+        for picking in self:
+            if not picking.origin_reference:
+                rel_sale = self.env[SO_MODEL_NAME].search(
+                    [("name", "=", picking.origin)], limit=1
+                )
+                if rel_sale:
+                    picking.origin_reference = "%s,%s" % (SO_MODEL_NAME, rel_sale.id)

--- a/stock_picking_origin_reference_sale/readme/CONTRIBUTORS.rst
+++ b/stock_picking_origin_reference_sale/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* ForgeFlow S.L.
+  * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/stock_picking_origin_reference_sale/readme/DESCRIPTION.rst
+++ b/stock_picking_origin_reference_sale/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module extends the `stock_picking_origin_reference` features by adding Sales
+Orders as one of the possible referenced documents.

--- a/stock_picking_origin_reference_sale/tests/__init__.py
+++ b/stock_picking_origin_reference_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_picking_origin_reference_sale

--- a/stock_picking_origin_reference_sale/tests/test_stock_picking_origin_reference_sale.py
+++ b/stock_picking_origin_reference_sale/tests/test_stock_picking_origin_reference_sale.py
@@ -1,0 +1,48 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.addons.stock_picking_origin_reference.tests import (
+    test_stock_picking_origin_reference,
+)
+
+
+class TestStockPickingOriginReferenceSale(
+    test_stock_picking_origin_reference.TestStockPickingOriginReference
+):
+    def setUp(self):
+        super().setUp()
+        self.sale_model = self.env["sale.order"]
+
+    def _create_sale(self, partner, product):
+        sale = self.sale_model.create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.name,
+                            "product_id": product.id,
+                            "product_uom_qty": 5,
+                            "price_unit": 500,
+                        },
+                    )
+                ],
+            }
+        )
+        return sale
+
+    def test_01_check_correct_value(self):
+        """
+        Check that the Transfer created from the SO is referencing it.
+        """
+        sale = self._create_sale(self.partner, self.product)
+        sale.action_confirm()
+        self.assertTrue(sale.picking_ids)
+        self.assertEqual(
+            len(sale.picking_ids), 1, "Only one Transfer should be created."
+        )
+        picking = sale.picking_ids
+        self.assertEqual(
+            picking.origin_reference, sale, "The Transfer should reference the SO."
+        )


### PR DESCRIPTION
This PR adds three modules, the base module which allows to extend it in order to add more models to be searched for the Source Document in Transfers. And also the modules for the Sales and Purchase sections, which are the two values set in the Source Document in Odoo standard.

cc @ForgeFlow