### PR TITLE
[15.0][FIX] stock_picking_invoice_link: Users without stock group can not view pickings. So hide button picking in invoice view

### DIFF
--- a/stock_picking_invoice_link/views/account_invoice_view.xml
+++ b/stock_picking_invoice_link/views/account_invoice_view.xml
@@ -15,6 +15,7 @@
                     class="oe_stat_button"
                     icon="fa-truck"
                     attrs="{'invisible': [('delivery_count', '=', 0)]}"
+                    groups="stock.group_stock_user"
                 >
                     <field name="delivery_count" widget="statinfo" string="Delivery" />
                 </button>


### PR DESCRIPTION
cc @Tecnativa TT44565

ping @chienandalu @CarlosRoca13 