### PR TITLE
[16.0][FIX] cannot re-assign move after applying inventory

### DIFF
--- a/stock_move_free_reservation_reassign/models/stock_quant.py
+++ b/stock_move_free_reservation_reassign/models/stock_quant.py
@@ -25,5 +25,7 @@ class StockQuant(models.Model):
         ]._get_move_free_reservation_ids() as move_to_reassign_ids:
             res = super()._apply_inventory()
         if move_to_reassign_ids:
-            self.env["stock.move"].browse(move_to_reassign_ids)._action_assign()
+            self.env["stock.move"].browse(move_to_reassign_ids).with_context(
+                inventory_mode=False
+            )._action_assign()
         return res


### PR DESCRIPTION
Related issue: https://github.com/OCA/stock-logistics-workflow/issues/1380