### PR TITLE
[16.0] [FIX] stock_picking_batch_extended_account: Remove `stock_picking_batch_extended` dependency

### DIFF
--- a/stock_picking_batch_extended_account/__manifest__.py
+++ b/stock_picking_batch_extended_account/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
+# Copyright 2023 Moduon Team - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
@@ -9,7 +10,7 @@
     "maintainers": ["ernestotejeda"],
     "development_status": "Beta",
     "category": "Warehouse Management",
-    "depends": ["stock_picking_batch_extended"],
+    "depends": ["stock_picking_batch", "sale"],
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "data": ["views/stock_batch_picking.xml", "views/res_partner_views.xml"],
     "installable": True,

--- a/stock_picking_batch_extended_account/readme/CONTRIBUTORS.rst
+++ b/stock_picking_batch_extended_account/readme/CONTRIBUTORS.rst
@@ -4,3 +4,8 @@
   * Pedro M. Baeza
   * Carlos Dauden
   * Sergio Teruel
+
+
+* `Moduon Team <https://www.moduon.team>`_:
+
+  * Eduardo de Miguel

--- a/stock_picking_batch_extended_account/views/stock_batch_picking.xml
+++ b/stock_picking_batch_extended_account/views/stock_batch_picking.xml
@@ -2,15 +2,9 @@
 <odoo>
     <record id="stock_picking_batch_form" model="ir.ui.view">
         <field name="model">stock.picking.batch</field>
-        <field
-            name="inherit_id"
-            ref="stock_picking_batch_extended.stock_picking_batch_form"
-        />
+        <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//form/header/button[@name='action_print_picking']"
-                position="before"
-            >
+            <xpath expr="//form/header/field[@name='state']" position="before">
                 <button
                     name="action_print_invoices"
                     string="Print Invoices"

--- a/stock_picking_batch_extended_account_sale_type/tests/test_stock_picking_batch_extended_account_sale_type.py
+++ b/stock_picking_batch_extended_account_sale_type/tests/test_stock_picking_batch_extended_account_sale_type.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Sergio Teruel - Tecnativa <sergio.teruel@tecnativa.com>
+# Copyright 2023 Moduon Team - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo.addons.stock_picking_batch_extended_account.tests import (
     test_stock_picking_batch_extended_account as test_bp_account,
@@ -31,6 +32,8 @@ class TestStockPickingBatchExtendedAccountSaleType(
         move_lines.qty_done = 1.0
         bp = self._create_batch_picking(pickings)
         bp.action_assign()
-        bp.action_done()
+        action_done_res = bp.action_done()
+        if action_done_res is not True:
+            self._process_immediate_transfer(action_done_res)
         self.assertFalse(self.order1.invoice_ids)
         self.assertTrue(self.order2.invoice_ids)


### PR DESCRIPTION
Removed unnecessary dependency: `stock_picking_batch_extended`.

Nothing of these modules is used on `stock_picking_batch_extended_account` nor `stock_picking_batch_extended_account_sale_type`, so we can remove dependency and work in the same way.

Button has moved before `state` field, like `stock_picking_batch_extended` does.

Tests has been modified to not use `stock_picking_batch_extended` methods and use the standard ones.

Separated in 2 commits to improve migrations.

MT-3611 @moduon @rafaelbn @fcvalgar @gelojr @ernestotejeda please review if you want 😸 