### PR TITLE
[14.0] stock_picking_group_by_partner_by_carrier: Bump dev status

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/__manifest__.py
+++ b/stock_picking_group_by_partner_by_carrier/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Stock Picking: group by partner and carrier",
     "Summary": "Group sales deliveries moves in 1 picking per partner and carrier",
     "version": "14.0.1.4.3",
-    "development_status": "Alpha",
+    "development_status": "Production/Stable",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "category": "Warehouse Management",


### PR DESCRIPTION
Required for CI after a bunch of modules depending on this one either had their dev status bumped as well or don't have any dev status. Cf:

- https://github.com/OCA/wms/actions/runs/6628639166/job/18006169885?pr=566#step:6:5
- https://github.com/OCA/wms/blob/14.0/stock_picking_type_shipping_policy/__manifest__.py#L7
