### PR TITLE
[16.0][FIX] stock_move_line_auto_fill: to fix installation error when mrp & stock_barcode apps exist on the db

### DIFF
--- a/stock_move_line_auto_fill/views/stock_picking_type_views.xml
+++ b/stock_move_line_auto_fill/views/stock_picking_type_views.xml
@@ -5,7 +5,7 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
-            <xpath expr="//sheet/group[2]" position="inside">
+            <xpath expr="//group[@name='second']" position="inside">
                 <group name="automation" string="Automation">
                     <field name="auto_fill_operation" />
                     <field


### PR DESCRIPTION
This commit is to ensure that this module can be installed when the database already has the 'mrp' and 'stock_barcode' modules installed. both of the modules are inheriting the stock_picking_type_views.xml.

@qrtl 