### PR TITLE
[16.0][FIX] sale_order_global_stock_route

### DIFF
--- a/sale_order_global_stock_route/models/sale_order.py
+++ b/sale_order_global_stock_route/models/sale_order.py
@@ -28,7 +28,8 @@ class SaleOrder(models.Model):
             lines = self.mapped("order_line").filtered(
                 lambda l: l.route_id.id != vals["route_id"]
             )
-            lines.write({"route_id": vals["route_id"]})
+            for line in lines:
+                line.write({"route_id": vals["route_id"]})
         return res
 
     class SaleOrderLine(models.Model):


### PR DESCRIPTION
Fixed write method to update all sale order line records, addressing the first-record-only issue in the absence of for loop.