### PR TITLE
[15.0][IMP] stock_owner_restriction: Prevent a negative quant from being created with owner

### DIFF
--- a/stock_owner_restriction/models/stock_quant.py
+++ b/stock_owner_restriction/models/stock_quant.py
@@ -22,7 +22,9 @@ class StockQuant(models.Model):
             location_id,
             lot_id=lot_id,
             package_id=package_id,
-            owner_id=owner_id,
+            # Prevent a negative quant from being created with owner instead of reducing
+            # the original quant when a return is made by assigning owner
+            owner_id=owner_id if location_id.usage != "customer" else None,
             strict=strict,
         )
         restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)


### PR DESCRIPTION
… instead of reducing the original quant when a return is made by assigning owner.

Needed to avoid this restriction when packages are used: https://github.com/odoo/odoo/blob/11d81b2145e95c50481101a63d3ad1d244279af4/addons/stock/models/stock_move.py#L1739 

@Tecnativa TT46054
ping @sergio-teruel @chienandalu 