### PR TITLE
[14.0] [FIX] stock_picking_inter_warehouse: proper merge picking managing

### DIFF
--- a/stock_picking_inter_warehouse/models/stock_move.py
+++ b/stock_picking_inter_warehouse/models/stock_move.py
@@ -1,8 +1,13 @@
-from odoo import models
+from odoo import fields, models
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
+
+    inter_warehouse_picking_id = fields.Many2one(
+        "stock.picking",
+        "Inter-Warehouse Picking",
+    )
 
     def _search_picking_for_assignation(self):
         # We do not want to merge pickings made in a transfer
@@ -13,5 +18,14 @@ class StockMove(models.Model):
                 "disable_merge_picking_moves"
             )
         ):
-            return False
+            domain = self._search_picking_for_assignation_domain()
+            picking = (
+                self.env["stock.picking"]
+                .search(domain)
+                .filtered(
+                    lambda x: x.move_lines.inter_warehouse_picking_id
+                    == self.inter_warehouse_picking_id
+                )
+            )
+            return picking or False
         return res

--- a/stock_picking_inter_warehouse/models/stock_rule.py
+++ b/stock_picking_inter_warehouse/models/stock_rule.py
@@ -17,5 +17,10 @@ class StockRule(models.Model):
             partner_id = (
                 move_to_copy.picking_type_id.warehouse_id.receipt_picking_partner_id
             )
-            res.update({"partner_id": partner_id.id})
+            res.update(
+                {
+                    "partner_id": partner_id.id,
+                    "inter_warehouse_picking_id": move_to_copy.picking_id.id,
+                }
+            )
         return res


### PR DESCRIPTION
Before this PR the "Disable Merge Picking Moves" option on the picking type would have split the picking lines into multiple pickings.

The correct behavior is that the picking lines from the same picking should be aggregated, while the picking lines from different pickings should not be aggregated between them.  