### PR TITLE
[ADD][12.0] product_weighable_default_weight : new module to guess weight field from products UoM, for weighable products

### DIFF
--- a/product_weighable_default_weight/__init__.py
+++ b/product_weighable_default_weight/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from .hooks import post_init_hook

--- a/product_weighable_default_weight/__manifest__.py
+++ b/product_weighable_default_weight/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2023 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Weighable Product - Default Weight",
+    "version": "12.0.1.0.0",
+    "category": "Point Of Sale",
+    "summary": "Set default weight on weighable product,"
+    " the weight is guessed from the ratio of the unit of mesure",
+    "author": "GRAP, Odoo Community Association (OCA)",
+    "maintainers": ["legalsylvain"],
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "license": "AGPL-3",
+    "depends": ["product"],
+    "demo": ["demo/res_groups.xml"],
+    "post_init_hook": "post_init_hook",
+    "installable": True,
+}

--- a/product_weighable_default_weight/demo/res_groups.xml
+++ b/product_weighable_default_weight/demo/res_groups.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2023 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="uom.group_uom" model="res.groups">
+        <field name="users" eval="[(4, ref('base.user_admin'))]"/>
+    </record>
+
+</odoo>

--- a/product_weighable_default_weight/hooks.py
+++ b/product_weighable_default_weight/hooks.py
@@ -1,0 +1,61 @@
+import logging
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr, registry):
+
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        _logger.info(
+            "[default UoM] Fast initializing weight fields for products"
+            ", if not set"
+        )
+        env.cr.execute("""
+            SELECT value
+            FROM ir_config_parameter
+            WHERE key='product.weight_in_lbs';""")
+        res = env.cr.fetchone()
+        if res and res[0] == 1:
+            # LBs is the global default UoM
+            default_uom = env.ref("uom.product_uom_lb")
+        else:
+            # Kg is the global default UoM
+            default_uom = env.ref("uom.product_uom_kgm")
+        if default_uom:
+            env.cr.execute("""
+                UPDATE product_template
+                SET weight = 1.0
+                WHERE uom_id = %s
+                AND (weight = 0.0 or weight is null);""", (default_uom.id,))
+            env.cr.execute("""
+                UPDATE product_product pp
+                SET weight = 1.0
+                FROM product_template pt
+                WHERE pt.id = pp.product_tmpl_id
+                AND pt.uom_id = %s
+                AND (
+                    pp.weight = 0.0 or pp.weight is null);""", (default_uom.id,))
+
+        _logger.info(
+            "[Other UoM] Initializing weight fields for weighable products,"
+            " if not set, via ORM"
+        )
+        groups = env["product.product"].read_group(
+            [
+                ("uom_id.measure_type", "=", "weight"),
+                '|', ("weight", "=", 0.0), ('weight', '=', False)
+            ],
+            fields=["weight", "uom_id"],
+            groupby="uom_id")
+
+        for group in groups:
+            products = env["product.product"].search(group["__domain"])
+            new_weight = env["product.template"]._get_weight_from_uom_id(
+                group["uom_id"][0]
+            )
+            _logger.info(
+                f"Writing new weight {new_weight} for {len(products)} products."
+            )
+            products.write({"weight": new_weight})

--- a/product_weighable_default_weight/i18n/fr.po
+++ b/product_weighable_default_weight/i18n/fr.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * product_weighable_default_weight
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-12 15:39+0000\n"
+"PO-Revision-Date: 2024-02-12 15:39+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_weighable_default_weight
+#: model:ir.model,name:product_weighable_default_weight.model_product_product
+msgid "Product"
+msgstr "Article"
+
+#. module: product_weighable_default_weight
+#: model:ir.model,name:product_weighable_default_weight.model_product_template
+msgid "Product Template"
+msgstr "Modèle d'article"
+

--- a/product_weighable_default_weight/models/__init__.py
+++ b/product_weighable_default_weight/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_product
+from . import product_template

--- a/product_weighable_default_weight/models/product_product.py
+++ b/product_weighable_default_weight/models/product_product.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2023 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, api
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.onchange("uom_id", "uom_po_id")
+    def _onchange_uom(self):
+        res = super()._onchange_uom()
+        new_weight = self.product_tmpl_id._get_weight_from_uom(self.uom_id)
+        if new_weight:
+            self.weight = new_weight
+        return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            new_weight = self.env["product.template"]._get_weight_from_uom_id(
+                vals.get("uom_id", False)
+            )
+            if new_weight:
+                vals["weight"] = new_weight
+        return super().create(vals_list)
+
+    def write(self, vals):
+        new_weight = self.env["product.template"]._get_weight_from_uom_id(
+            vals.get("uom_id", False)
+        )
+        if new_weight:
+            vals["weight"] = new_weight
+        return super().write(vals)

--- a/product_weighable_default_weight/models/product_template.py
+++ b/product_weighable_default_weight/models/product_template.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2023 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    @api.onchange('uom_id')
+    def _onchange_uom_id(self):
+        res = super()._onchange_uom_id()
+        new_weight = self._get_weight_from_uom(self.uom_id)
+        if new_weight:
+            self.weight = new_weight
+        return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            new_weight = self._get_weight_from_uom_id(vals.get("uom_id", False))
+            if new_weight:
+                vals["weight"] = new_weight
+        return super().create(vals_list)
+
+    def write(self, vals):
+        new_weight = self._get_weight_from_uom_id(vals.get("uom_id", False))
+        if new_weight:
+            vals["weight"] = new_weight
+        return super().write(vals)
+
+    @api.model
+    def _get_weight_from_uom_id(self, uom_id):
+        if not uom_id:
+            return
+        return self._get_weight_from_uom(self.env["uom.uom"].browse(uom_id))
+
+    @api.model
+    def _get_weight_from_uom(self, uom):
+        if not uom.measure_type == "weight":
+            return
+        return uom._compute_quantity(
+            1,
+            self._get_weight_uom_id_from_ir_config_parameter()
+        )

--- a/product_weighable_default_weight/readme/CONTRIBUTORS.rst
+++ b/product_weighable_default_weight/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Sylvain LE GAL <https://twitter.com/legalsylvain>

--- a/product_weighable_default_weight/readme/DESCRIPTION.rst
+++ b/product_weighable_default_weight/readme/DESCRIPTION.rst
@@ -1,0 +1,12 @@
+This module extends the functionality of product module to set
+default value on weight field for weighable products.
+
+Once installed, when a user create a new weighable product
+(``uom_id.measure_type == "weight"``), the ``weight`` field
+will be computed, depending on the UoM.
+
+- if UoM is "kg", weight will be 1.0
+- if UoM is "ton", weight will be 1000.0
+
+This module is interesting if you use other modules based on the
+``weight`` field. (Ex: ``sale_order_weight`` in OCA/sale-workflow repo)

--- a/product_weighable_default_weight/tests/__init__.py
+++ b/product_weighable_default_weight/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_module

--- a/product_weighable_default_weight/tests/test_module.py
+++ b/product_weighable_default_weight/tests/test_module.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2023 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form
+
+
+class TestModule(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.ProductProduct = self.env["product.product"]
+        self.ProductTemplate = self.env["product.template"]
+        self.uom_kg = self.browse_ref("uom.product_uom_kgm")
+        self.uom_ton = self.browse_ref("uom.product_uom_ton")
+
+    def _test_create_write(self, model):
+        item = model.create({
+            "name": "Demo Product",
+            "uom_id": self.uom_kg.id,
+            "uom_po_id": self.uom_kg.id,
+        })
+        self.assertEqual(item.weight, 1.0)
+        item.uom_id = self.uom_ton
+        self.assertEqual(item.weight, 1000.0)
+
+    def test_create_product_product(self):
+        self._test_create_write(self.ProductProduct)
+
+    def test_create_product_template(self):
+        self._test_create_write(self.ProductTemplate)
+
+    def _test_onchange(self, model):
+        f = Form(model)
+        self.assertEqual(f.weight, 0.0)
+        f.uom_id = self.uom_kg
+        self.assertEqual(f.weight, 1.0)
+        f.uom_id = self.uom_ton
+        self.assertEqual(f.weight, 1000.0)
+
+    def test_onchange_product_product(self):
+        self._test_onchange(self.ProductProduct)
+
+    def test_onchange_product_template(self):
+        self._test_onchange(self.ProductTemplate)

--- a/setup/product_weighable_default_weight/odoo/addons/product_weighable_default_weight
+++ b/setup/product_weighable_default_weight/odoo/addons/product_weighable_default_weight
@@ -1,0 +1,1 @@
+../../../../product_weighable_default_weight

--- a/setup/product_weighable_default_weight/setup.py
+++ b/setup/product_weighable_default_weight/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module extends the functionality of product module to set default value on weight field for weighable products.

Once installed, when a user create a new weighable product (``uom_id.measure_type == "weight"``), the ``weight`` field will be computed, depending on the UoM.

- if UoM is "kg", weight will be 1.0
- if UoM is "ton", weight will be 1000.0

This module is interesting if you use other modules based on the ``weight`` field. (Ex: ``sale_order_weight`` in OCA/sale-workflow repo).
