### PR TITLE
[14.0] Create module sale_purchase_stock_line_note

### DIFF
--- a/sale_purchase_stock_line_note/README.rst
+++ b/sale_purchase_stock_line_note/README.rst
@@ -1,0 +1,1 @@
+auto generate

--- a/sale_purchase_stock_line_note/__init__.py
+++ b/sale_purchase_stock_line_note/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_purchase_stock_line_note/__manifest__.py
+++ b/sale_purchase_stock_line_note/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Sale Purchase Stock Line Note",
+    "summary": "Propagate sale line note to stock move and purchase",
+    "version": "14.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Hidden",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["grindtildeath"],
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "sale_order_line_note",
+        "sale_purchase_stock",
+    ],
+    "data": [
+        "views/purchase_order.xml",
+        "views/stock_picking.xml",
+    ],
+}

--- a/sale_purchase_stock_line_note/models/__init__.py
+++ b/sale_purchase_stock_line_note/models/__init__.py
@@ -1,0 +1,4 @@
+from . import purchase_order_line
+from . import sale_order_line
+from . import stock_move
+from . import stock_rule

--- a/sale_purchase_stock_line_note/models/purchase_order_line.py
+++ b/sale_purchase_stock_line_note/models/purchase_order_line.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    sale_note = fields.Text()
+
+    @api.model
+    def _prepare_purchase_order_line_from_procurement(
+        self, product_id, product_qty, product_uom, company_id, values, po
+    ):
+        res = super()._prepare_purchase_order_line_from_procurement(
+            product_id, product_qty, product_uom, company_id, values, po
+        )
+        res["sale_note"] = values.get("sale_note", False)
+        return res

--- a/sale_purchase_stock_line_note/models/sale_order_line.py
+++ b/sale_purchase_stock_line_note/models/sale_order_line.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _prepare_procurement_values(self, group_id=False):
+        res = super()._prepare_procurement_values(group_id=group_id)
+        if self.note:
+            res["sale_note"] = self.note
+        return res

--- a/sale_purchase_stock_line_note/models/stock_move.py
+++ b/sale_purchase_stock_line_note/models/stock_move.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    sale_note = fields.Text()
+
+    def _prepare_procurement_values(self):
+        res = super()._prepare_procurement_values()
+        if self.sale_note:
+            res["sale_note"] = self.sale_note
+        return res

--- a/sale_purchase_stock_line_note/models/stock_rule.py
+++ b/sale_purchase_stock_line_note/models/stock_rule.py
@@ -1,0 +1,34 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _get_stock_move_values(
+        self,
+        product_id,
+        product_qty,
+        product_uom,
+        location_id,
+        name,
+        origin,
+        company_id,
+        values,
+    ):
+        res = super()._get_stock_move_values(
+            product_id,
+            product_qty,
+            product_uom,
+            location_id,
+            name,
+            origin,
+            company_id,
+            values,
+        )
+        sale_note = values.get("sale_note")
+        if sale_note:
+            res["sale_note"] = sale_note
+        return res

--- a/sale_purchase_stock_line_note/readme/CONTRIBUTORS.md
+++ b/sale_purchase_stock_line_note/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/sale_purchase_stock_line_note/readme/DESCRIPTION.md
+++ b/sale_purchase_stock_line_note/readme/DESCRIPTION.md
@@ -1,0 +1,3 @@
+This module allows to propagate the value of note field from the sale
+order lines to the stock moves and from the stock moves to the purchase
+order lines in case of MTO.

--- a/sale_purchase_stock_line_note/tests/__init__.py
+++ b/sale_purchase_stock_line_note/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_stock_purchase_line_note

--- a/sale_purchase_stock_line_note/tests/test_sale_stock_purchase_line_note.py
+++ b/sale_purchase_stock_line_note/tests/test_sale_stock_purchase_line_note.py
@@ -1,0 +1,37 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests.common import Form, SavepointCase
+
+
+class TestSalePurchaseStockLineNote(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env.ref("base.res_partner_12")
+        cls.product = cls.env.ref("product.product_product_9")
+        cls.mto_route = cls.env.ref("stock.route_warehouse0_mto")
+        cls.mto_route.active = True
+        cls.sale_note = "Custom sale note"
+
+    @classmethod
+    def _create_sale_order(cls):
+        sale_form = Form(cls.env["sale.order"])
+        sale_form.partner_id = cls.partner
+        with sale_form.order_line.new() as line_form:
+            line_form.product_id = cls.product
+            line_form.product_uom_qty = 100
+            line_form.route_id = cls.mto_route
+            line_form.note = cls.sale_note
+        return sale_form.save()
+
+    def test_create_move(self):
+        sale = self._create_sale_order()
+        sale.action_confirm()
+        delivery_move = sale.order_line.move_ids
+        self.assertEqual(delivery_move.sale_note, self.sale_note)
+
+    def test_purchase_line(self):
+        sale = self._create_sale_order()
+        sale.action_confirm()
+        purchase_order = sale._get_purchase_orders()
+        self.assertEqual(purchase_order.order_line.sale_note, self.sale_note)

--- a/sale_purchase_stock_line_note/views/purchase_order.xml
+++ b/sale_purchase_stock_line_note/views/purchase_order.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="purchase_order_view_form_inherit" model="ir.ui.view">
+        <field name="name">purchase.order.form.inherit</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']/tree//field[@name='name']"
+                position="after"
+            >
+                <field name="sale_note" optional="hide" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='analytic_tag_ids']"
+                position="after"
+            >
+                <field name="sale_note" optional="hide" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_purchase_stock_line_note/views/stock_picking.xml
+++ b/sale_purchase_stock_line_note/views/stock_picking.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='move_ids_without_package']//tree//field[@name='description_picking']"
+                position="after"
+            >
+                <field name="sale_note" optional="hide" />
+            </xpath>
+            <xpath
+                expr="//field[@name='move_ids_without_package']//form//field[@name='description_picking']"
+                position="after"
+            >
+                <field name="sale_note" optional="hide" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/sale_purchase_stock_line_note/odoo/addons/sale_purchase_stock_line_note
+++ b/setup/sale_purchase_stock_line_note/odoo/addons/sale_purchase_stock_line_note
@@ -1,0 +1,1 @@
+../../../../sale_purchase_stock_line_note

--- a/setup/sale_purchase_stock_line_note/setup.py
+++ b/setup/sale_purchase_stock_line_note/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to propagate the value of note field from the sale
order lines to the stock moves and from the stock moves to the purchase
order lines in case of MTO.
