### PR TITLE
[14.0] [FIX] stock_picking_inter_warehouse: picking type permission error

### DIFF
--- a/stock_picking_inter_warehouse/models/stock_picking.py
+++ b/stock_picking_inter_warehouse/models/stock_picking.py
@@ -38,10 +38,13 @@ class StockPicking(models.Model):
     def _onchange_partner_id(self):
         if hasattr(super(), "_onchange_partner_id"):
             super()._onchange_partner_id()
+
+        location_dest_id = self.partner_id.default_stock_location_src_id
         if (
             self.type_inter_warehouse_transfer
             and self.partner_id.default_stock_location_src_id
+            and self.picking_type_id.default_location_dest_id != location_dest_id
         ):
-            self.picking_type_id.default_location_dest_id = (
-                self.partner_id.default_stock_location_src_id
+            self.picking_type_id.sudo().write(
+                {"default_location_dest_id": location_dest_id.id}
             )


### PR DESCRIPTION
Trying to create a picking will write the picking type `default_location_dest_id` and would raise an error if the user creating the picking has user access to the inventory.

With this fix it will write on the picking type only when it's strictly necessary with sudo access to avoid the error.