### PR TITLE
[16.0][IMP] stock_restrict_lot: Consistent field label

### DIFF
--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -7,7 +7,9 @@ class StockMove(models.Model):
     # seems better to not copy this field except when a move is splitted, because a move
     # can be copied in multiple different occasions and could even be copied with a
     # different product...
-    restrict_lot_id = fields.Many2one("stock.lot", string="Restrict Lot", copy=False)
+    restrict_lot_id = fields.Many2one(
+        "stock.lot", string="Restrict Lot/Serial Number", copy=False
+    )
 
     def _prepare_procurement_values(self):
         vals = super()._prepare_procurement_values()

--- a/stock_restrict_lot/models/stock_picking.py
+++ b/stock_restrict_lot/models/stock_picking.py
@@ -8,5 +8,5 @@ class StockPicking(models.Model):
     # this is a technical field, making possible to search a picking by any restrict lot
     # defined on its line, from the web search bar.
     restrict_lot_id = fields.Many2one(
-        related="move_ids.restrict_lot_id", string="Restrict Lot"
+        related="move_ids.restrict_lot_id", string="Restrict Lot/Serial Number"
     )


### PR DESCRIPTION
Make the field labels for lot_id more consistent with the core stock module, which has the field label "Lot/Serial Number"