### PR TITLE
[14.0] [FIX] stock_picking_inter_warehouse: fix destination location

### DIFF
--- a/stock_picking_inter_warehouse/models/stock_picking.py
+++ b/stock_picking_inter_warehouse/models/stock_picking.py
@@ -34,10 +34,10 @@ class StockPicking(models.Model):
             else:
                 picking.inter_warehouse_contact_domain_ids = all_partner_ids
 
-    @api.onchange("partner_id")
-    def _onchange_partner_id(self):
-        if hasattr(super(), "_onchange_partner_id"):
-            super()._onchange_partner_id()
+    @api.onchange("picking_type_id", "partner_id")
+    def onchange_picking_type(self):
+        if hasattr(super(), "onchange_picking_type"):
+            super().onchange_picking_type()
 
         location_dest_id = self.partner_id.default_stock_location_src_id
         if (
@@ -45,6 +45,4 @@ class StockPicking(models.Model):
             and self.partner_id.default_stock_location_src_id
             and self.picking_type_id.default_location_dest_id != location_dest_id
         ):
-            self.picking_type_id.sudo().write(
-                {"default_location_dest_id": location_dest_id.id}
-            )
+            self.location_dest_id = location_dest_id

--- a/stock_picking_inter_warehouse/tests/test_stock_picking_inter_warehouse.py
+++ b/stock_picking_inter_warehouse/tests/test_stock_picking_inter_warehouse.py
@@ -171,10 +171,9 @@ class TestStockPickingInterWarehouse(SavepointCase):
 
         picking_out = self.StockPicking.create(
             {
-                "partner_id": self.test_partner_2.id,
                 "picking_type_id": self.stock_wh1.int_type_id.id,
                 "location_id": self.stock_wh1.int_type_id.default_location_src_id.id,
-                "location_dest_id": self.test_partner_2.default_stock_location_src_id.id,
+                "location_dest_id": self.stock_wh1.int_type_id.default_location_dest_id.id,
                 "move_lines": [
                     (
                         0,
@@ -198,6 +197,14 @@ class TestStockPickingInterWarehouse(SavepointCase):
                     ),
                 ],
             }
+        )
+        # test that onchange_picking_type() uses the right
+        # destination location instead of the picking type's default destination location
+        picking_out.write({"partner_id": self.test_partner_2.id})
+        picking_out.onchange_picking_type()
+        self.assertEqual(
+            self.test_partner_2.default_stock_location_src_id,
+            picking_out.location_dest_id,
         )
 
         for ml in picking_out.move_lines:


### PR DESCRIPTION
Fix and improve the code managing the destination location of the picking, ignoring the default destination location of the picking type under certain circumstances..