### PR TITLE
[14.0] [IMP] stock_picking_inter_warehouse: sync picking on validate

### DIFF
--- a/stock_picking_inter_warehouse/models/stock_move.py
+++ b/stock_picking_inter_warehouse/models/stock_move.py
@@ -9,6 +9,14 @@ class StockMove(models.Model):
         "Inter-Warehouse Picking",
     )
 
+    def _action_done(self, cancel_backorder=False):
+        res = super()._action_done(cancel_backorder)
+        moves = self.exists().filtered(
+            lambda x: x.state == "done" and x.picking_id.type_inter_warehouse_transfer
+        )
+        moves._push_apply()
+        return res
+
     def _search_picking_for_assignation(self):
         # We do not want to merge pickings made in a transfer
         # between warehouses

--- a/stock_picking_inter_warehouse/models/stock_rule.py
+++ b/stock_picking_inter_warehouse/models/stock_rule.py
@@ -11,6 +11,15 @@ class StockRule(models.Model):
         "stock.warehouse", "Inter Warehouse Source"
     )
 
+    def _run_push(self, move):
+        # Do not execute _run_push if the picking type
+        # is an inter_warehouse_transfer, and it has not been validated
+        if not (
+            move.picking_id.type_inter_warehouse_transfer
+            and move.picking_id.state != "done"
+        ):
+            return super()._run_push(move)
+
     def _push_prepare_move_copy_values(self, move_to_copy, new_date):
         res = super()._push_prepare_move_copy_values(move_to_copy, new_date)
         if move_to_copy.picking_type_id.inter_warehouse_transfer:


### PR DESCRIPTION
Instead of syncing pickings on confirm sync them on validate.

That helps including every changes made to the picking before validating it, which it would not be possible if the user creates a wrong picking as an "Immediate Transfer".