### PR TITLE
[FIX] simplify the name of merged procurment groups

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -4,7 +4,7 @@
 
 from itertools import groupby
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.fields import first
 
 
@@ -112,10 +112,14 @@ class StockPicking(models.Model):
         """Build a new procurement group that is the merge of given procurement
         group."""
         sales = move_groups.sale_id
-        return {
-            "sale_ids": [(6, 0, sales.ids)],
-            "name": ", ".join(move_groups.sorted("name").mapped("name")),
-        }
+        partners = move_groups.sale_id.partner_id
+        name = _("Merged procurement")
+        if partners:
+            name = _(
+                "Merged procurement for partners: %(partners_name)s",
+                partners_name=", ".join(partners.mapped("display_name")),
+            )
+        return {"sale_ids": [(6, 0, sales.ids)], "name": name}
 
     def _merge_procurement_groups(self):
         self.ensure_one()

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping.py
@@ -436,7 +436,7 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         group = picking.group_id
         # the group is related to both sales orders
         self.assertEqual(group.sale_ids, so1 | so2)
-        self.assertEqual(group.name, "{}, {}".format(so1.name, so2.name))
+        self.assertEqual(group.name, "Merged procurement for partners: Test Partner")
 
         line = so1.order_line.filtered(lambda line: not line.is_delivery)
 
@@ -465,7 +465,9 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         # so3 moves are merged in the backorder used for so2,
         # a new group is used to hold so2 and so3
         self.assertEqual(backorder.group_id.sale_ids, so2 | so3)
-        self.assertEqual(backorder.group_id.name, "{}, {}".format(so2.name, so3.name))
+        self.assertEqual(
+            backorder.group_id.name, "Merged procurement for partners: Test Partner"
+        )
 
         self.assertEqual(so1.picking_ids, picking)
         self.assertEqual(so2.picking_ids, picking | backorder)


### PR DESCRIPTION
When merging procurement groups for numerous sales orders, we often end up with an excessively long procurement group name that includes all the associated sale orders. 

it's ugly and useless, considering that we can access the linked orders directly from the group. This fix addresses the issue by simply mentioning the related partner name.