### PR TITLE
[14.0][IMP] product_supplierinfo_for_customer_picking: no compute old pickings

### DIFF
--- a/product_supplierinfo_for_customer_picking/models/stock_move.py
+++ b/product_supplierinfo_for_customer_picking/models/stock_move.py
@@ -6,9 +6,7 @@ from odoo import api, fields, models
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    @api.depends(
-        "picking_id.partner_id", "product_id", "product_id.customer_ids.product_code"
-    )
+    @api.depends("picking_id.partner_id", "product_id")
     def _compute_product_customer_code(self):
         for move in self:
             product_customer_name = ""

--- a/product_supplierinfo_for_customer_picking/tests/test_product_supplierinfo_for_customer_picking.py
+++ b/product_supplierinfo_for_customer_picking/tests/test_product_supplierinfo_for_customer_picking.py
@@ -64,7 +64,16 @@ class TestProductSupplierinfoForCustomerPicking(TransactionCase):
             }
         )
         move = delivery_picking.move_lines[0]
-        move._compute_product_customer_code()
+        self.assertEqual(move.product_customer_code, "test_agrolait")
+        self.assertEqual(move.product_customer_name, "test prod name 1")
+
+        # Test that name stays the same on picking
+        # even after a change
+        customerinfo = self.computer_SC234.customer_ids.filtered(
+            lambda x: x.name == self.agrolait
+        )
+        customerinfo.product_code = "different_code"
+        customerinfo.product_name = "different name"
         self.assertEqual(move.product_customer_code, "test_agrolait")
         self.assertEqual(move.product_customer_name, "test prod name 1")
 
@@ -97,6 +106,12 @@ class TestProductSupplierinfoForCustomerPicking(TransactionCase):
             }
         )
         move = delivery_picking.move_lines[0]
-        move._compute_product_customer_code()
         self.assertEqual(move.product_customer_code, "test_gemini")
         self.assertEqual(move.product_customer_name, "test prod name 2")
+
+    def test_picking_customer_code_persists(self):
+        """
+        Checks that the customer code on the picking doesn't change
+        even if the customer code changes
+        """
+        self.assertTrue(1)


### PR DESCRIPTION
Do not recompute the customer code and name on pickings if they change, keep the ones valid at the time of the picking.