### PR TITLE
[15.0][FIX] stock_landed_costs_delivery: Filtering the correct Landed Cost

### DIFF
--- a/stock_landed_costs_delivery/models/purchase_order.py
+++ b/stock_landed_costs_delivery/models/purchase_order.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 Tecnativa - Víctor Martínez
+# Copyright 2021-2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import models
 
@@ -23,6 +23,11 @@ class PurchaseOrder(models.Model):
         if carrier.create_landed_cost_line:
             vals = self._prepare_landed_cost_line_delivery_values(carrier, price_unit)
             lc = self.sudo().landed_cost_ids.filtered(lambda x: x.state == "draft")
+            # Use the context to identify which picking is being generated from and
+            # set cost lines in the correct Landed cost.
+            if self.env.context.get("from_picking"):
+                picking = self.env.context.get("from_picking")
+                lc = lc.filtered(lambda x: picking in x.picking_ids)
             if lc:
                 lc[0].cost_lines = [(0, 0, vals)]
         return res

--- a/stock_landed_costs_delivery/models/stock_picking.py
+++ b/stock_landed_costs_delivery/models/stock_picking.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Tecnativa - Víctor Martínez
+# Copyright 2023-2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import models
 from odoo.tools import config
@@ -6,6 +6,12 @@ from odoo.tools import config
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
+
+    def _add_delivery_cost_to_po(self):
+        """We add the context to identify in _create_delivery_line() method the picking."""
+        self.ensure_one()
+        self = self.with_context(from_picking=self)
+        return super()._add_delivery_cost_to_po()
 
     def _action_done(self):
         """Validate Landed costs linked to the purchase and picking."""


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/stock-logistics-workflow/pull/1480

It is necessary to filter the correct Landed Cost (from the correct picking) to set the cost lines.

Example use case:
- PO without carrier.
- Picking A without carrier done > LC A (draft) without cost lines.
- Picking B with carrier done > LC B (done) with cost lines.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45656