### PR TITLE
[16.0][FIX] stock_split_picking: pass backorder context when splitting

### DIFF
--- a/stock_split_picking/models/stock_picking.py
+++ b/stock_split_picking/models/stock_picking.py
@@ -44,7 +44,9 @@ class StockPicking(models.Model):
                         qty_split, move.product_id.uom_id, rounding_method="HALF-UP"
                     )
                     # Empty list is returned for moves with zero qty_done.
-                    new_move_vals = move._split(qty_uom_split)
+                    new_move_vals = move.with_context(cancel_backorder=False)._split(
+                        qty_uom_split
+                    )
                     if new_move_vals:
                         for move_line in move.move_line_ids:
                             if move_line.reserved_qty and move_line.qty_done:


### PR DESCRIPTION
If we do not pass the context, when splitting a picking for a subcontracted product Odoo will consider that we are cancelling the quantities that we split. Consequently, it will cancel the subcontracting MO with the split quantity.

Right now when doing the split the quantity of the original stock move is updated and this logic is run: https://github.com/odoo/odoo/blob/7ecd94133d029195e6a0ebbd35f86d1f8063efe9/addons/mrp_subcontracting/models/stock_move.py#L136. This ends up cancelling the new MO for the split quantities.

With the change the new MO with the split quantities is kept correctly open, which is in fact the same result you get when you do a backorder.