### PR TITLE
[16.0][FIX] stock_picking_batch_print_invoices: Print all invoices from pickings

### DIFF
--- a/stock_picking_batch_print_invoices/views/report_picking_batch_print_invoices.xml
+++ b/stock_picking_batch_print_invoices/views/report_picking_batch_print_invoices.xml
@@ -9,7 +9,7 @@
         <xpath expr="//t[@name='print_pickings']" position="after">
             <t
                 name="print_invoices"
-                t-foreach="set(picking.sale_id.invoice_ids.filtered(lambda p: p.partner_id == partner))"
+                t-foreach="set(doc.picking_ids.filtered(lambda p: p.partner_id == partner).sale_id.invoice_ids)"
                 t-as="invoice"
             >
                 <t


### PR DESCRIPTION
Before patch:

- Don't print invoices if invoice address isn't shipping address.
- Only print the last invoice for pickings with the same shipping address.

Now print all invoices together (regardless of invoice partner) for pickings with the same shipping address.

MT-4407 @moduon