### PR TITLE
[16.0][FIX] stock_picking_auto_create_lot: immediate transfer with auto_create_lot option

### DIFF
--- a/stock_picking_auto_create_lot/README.rst
+++ b/stock_picking_auto_create_lot/README.rst
@@ -85,6 +85,9 @@ Contributors
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 * Denis Roussel <denis.roussel@acsone.eu>
 * Valentin Vinagre <valentin.vinagre@sygel.es>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Aung Ko Ko Lin
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_auto_create_lot/readme/CONTRIBUTORS.rst
+++ b/stock_picking_auto_create_lot/readme/CONTRIBUTORS.rst
@@ -3,3 +3,6 @@
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 * Denis Roussel <denis.roussel@acsone.eu>
 * Valentin Vinagre <valentin.vinagre@sygel.es>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Aung Ko Ko Lin

--- a/stock_picking_auto_create_lot/static/description/index.html
+++ b/stock_picking_auto_create_lot/static/description/index.html
@@ -432,6 +432,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
 <li>Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
 <li>Valentin Vinagre &lt;<a class="reference external" href="mailto:valentin.vinagre&#64;sygel.es">valentin.vinagre&#64;sygel.es</a>&gt;</li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
I accidentally closed the brach of this PR https://github.com/OCA/stock-logistics-workflow/pull/1283
Superseded by current PR.

@qrtl