### PR TITLE
[16.0][FIX] stock_picking_auto_create_lot: fix creating lot for 0 qty move lines for serial product

### DIFF
--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -2,25 +2,50 @@
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
+from odoo.osv import expression
 
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
+    def _prepare_auto_lot_domain(self, immediate=False):
+        """Prepare the domain to search for stock.move.line records that require
+        automatic lot assignment.
+        The 'immediate' parameter influences the inclusion of 'qty_done' in the search criteria,
+        depending on whether the transfer is immediate or planned.
+        """
+        domain = [
+            ("picking_id", "in", self.ids),
+            ("lot_id", "=", False),
+            ("lot_name", "=", False),
+            ("product_id.tracking", "!=", "none"),
+            ("product_id.auto_create_lot", "=", True),
+        ]
+        if not immediate:
+            domain = expression.AND([domain, [("qty_done", ">", 0)]])
+        return domain
+
     def _set_auto_lot(self):
         """
-        Allows to be called either by button or through code
+        Allows to be called either by button or through code.
         """
+        lines_to_set = self.env["stock.move.line"]
         pickings = self.filtered(lambda p: p.picking_type_id.auto_create_lot)
-        lines = pickings.mapped("move_line_ids").filtered(
-            lambda x: (
-                not x.lot_id
-                and not x.lot_name
-                and x.product_id.tracking != "none"
-                and x.product_id.auto_create_lot
+        if not pickings:
+            return
+        immediate_domain = []
+        planned_domain = []
+        immediate_pickings = pickings._check_immediate()
+        if immediate_pickings:
+            immediate_domain = immediate_pickings._prepare_auto_lot_domain(
+                immediate=True
             )
-        )
-        for line in lines:
+        planned_pickings = pickings - immediate_pickings
+        if planned_pickings:
+            planned_domain = planned_pickings._prepare_auto_lot_domain()
+        domain = expression.OR([immediate_domain, planned_domain])
+        lines_to_set = lines_to_set.search(domain)
+        for line in lines_to_set:
             line.lot_name = line._get_lot_sequence()
 
     def _action_done(self):

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -178,3 +178,18 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
         moves.move_line_ids.qty_done = 1.0
         for line in moves.move_line_ids:
             line.lot_name = self.env["ir.sequence"].next_by_code("stock.lot.serial")
+
+    def test_auto_create_lot_with_quantity_done(self):
+        self.picking.action_assign()
+        move = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_serial
+        )
+        self.assertEqual(move.product_uom_qty, 3.0)
+        self.assertFalse(move.display_assign_serial)
+        move.write({"quantity_done": 1.00})
+        self.picking._action_done()
+        # Search for serials
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product_serial.id)]
+        )
+        self.assertEqual(len(lot), 1)


### PR DESCRIPTION
Before this commit, when we use `stock_picking_auto_create_lot` for serial product with planned tansfer and set `quantity_done` that is less than demand, it will create lots record for all demand quantity and some records are quantity `0.00`.
Eg, our demand is `5` and `quantity_done` is `3`. It will create `5` stock lot records and `2` records are quantity `0.00`.
This commit is to address this issue.

@qrtl