### PR TITLE
[16.0] stock_picking_partner_note: only use active notes

### DIFF
--- a/stock_picking_partner_note/models/stock_picking.py
+++ b/stock_picking_partner_note/models/stock_picking.py
@@ -15,7 +15,7 @@ class StockPicking(models.Model):
         for picking in self:
             picking_type_note_type_ids = picking.picking_type_id.partner_note_type_ids
             picking_notes = picking.partner_id.stock_picking_note_ids.filtered(
-                lambda n: n.note_type_id in picking_type_note_type_ids
+                lambda n: n.active and n.note_type_id in picking_type_note_type_ids
             )
             picking_notes = [
                 note.name.strip()


### PR DESCRIPTION
Taken from version 14.0:

https://github.com/OCA/stock-logistics-workflow/pull/1504/commits/1014270142a932eaf51123e567246123f2338615