### PR TITLE
[15.0][IMP] stock_reception_discrepancy_distribution: Update initial demandto avoid an extra picking when use multi steps reception and MTO

### DIFF
--- a/stock_reception_discrepancy_distribution/wizards/stock_reception_discrepancy_distribution_wiz.py
+++ b/stock_reception_discrepancy_distribution/wizards/stock_reception_discrepancy_distribution_wiz.py
@@ -41,4 +41,7 @@ class StockReceptionDiscrepancyDistributionWiz(models.TransientModel):
         self.move_id.move_dest_ids = self.move_dest_ids
 
     def action_confirm(self):
-        """Dummy button"""
+        # Update initial demand to avoid an extra picking when use multi steps reception
+        # and MTO
+        if self.move_id.quantity_done > self.move_id.product_uom_qty:
+            self.move_id.product_uom_qty = self.move_id.quantity_done


### PR DESCRIPTION
cc @Tecnativa 

ping @carlosdauden @CarlosRoca13 