### PR TITLE
[FIX]_batch_extended:delete lot_id attributes

### DIFF
--- a/stock_picking_batch_extended/views/stock_move_views.xml
+++ b/stock_picking_batch_extended/views/stock_move_views.xml
@@ -24,12 +24,6 @@
                 >{'readonly': [('state', 'in', ('done', 'cancel')), ('is_locked', '=', True)], 'invisible': [('lots_visible', '=', False)]}</attribute>
                 <attribute name="optional">show</attribute>
             </field>
-            <field name="lot_name" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'readonly': [('state', 'in', ('done', 'cancel')), ('is_locked', '=', True)], 'invisible': [('lots_visible', '=', False)]}</attribute>
-                <attribute name="optional">hide</attribute>
-            </field>
             <field name="location_id" position="attributes">
                 <attribute
                     name="attrs"


### PR DESCRIPTION
In inherited view before we had lot_name and now it does't exist anymore, so i delete the reference to that field.