### PR TITLE
[15.0][FIX] stock_picking_auto_create_lot: Lots repeated for different stock move lines with the same product

### DIFF
--- a/stock_picking_auto_create_lot/models/stock_move_line.py
+++ b/stock_picking_auto_create_lot/models/stock_move_line.py
@@ -35,5 +35,8 @@ class StockMoveLine(models.Model):
         for line in self:
             lot = first(lots_by_product[line.product_id.id])
             line.lot_id = lot
-            if lot.product_id.tracking == "serial":
+            # If product has tracking we have to remove the lot to assign the next
+            # lot created. If not do it, different stock move lines will have the same
+            # lot and we will have orphans lots.
+            if lot.product_id.tracking != "none":
                 lots_by_product[line.product_id.id] -= lot

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -167,3 +167,18 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             lambda ln: ln.product_id == self.product
         )
         self.assertEqual(line.qty_done, 2.0)
+
+    def test_multiple_sml_for_one_stock_move(self):
+        """
+        Create a picking and we receive goods from supplier with different features so we
+        want different lots by each stock move line.
+        """
+        self._create_picking()
+        self._create_move(product=self.product, qty=50.0)
+        self.picking.action_assign()
+        self.picking.move_line_ids.qty_done = 25.0
+        # new sml with 25.0 units
+        self.picking.move_line_ids.copy()
+        self.picking.button_validate()
+        lots = self.picking.move_line_ids.lot_id
+        self.assertEqual(len(lots), 2)


### PR DESCRIPTION
For one stock move if I create two sml's and validate the picking two lots are created but the two sml have the same lot (The first lot created)


cc @Tecnativa TT48308

ping @carlosdauden @rousseldenis 

