### PR TITLE
[IMP] stock_picking_partner_note check note already in use

### DIFF
--- a/stock_picking_partner_note/__manifest__.py
+++ b/stock_picking_partner_note/__manifest__.py
@@ -18,6 +18,7 @@
         "views/stock_picking_type.xml",
         "views/stock_picking_note.xml",
         "views/stock_picking_partner_note_menus.xml",
+        "views/res_config_settings.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/stock_picking_partner_note/i18n/fr.po
+++ b/stock_picking_partner_note/i18n/fr.po
@@ -52,3 +52,26 @@ msgstr "Opération Type de note"
 #: model_terms:ir.ui.view,arch_db:stock_picking_partner_note.view_stock_picking_note_type_tree
 msgid "Picking Note Types"
 msgstr "Opération Types de note"
+
+#. module: stock_picking_partner_note
+#. odoo-python
+#: code:addons/stock_picking_partner_note/models/stock_picking_note.py:0
+#, python-format
+msgid ""
+"You cannot update or delete a note that linked to multiple contacts: "
+"%(partner_ids)s"
+msgstr "Vous ne pouvez pas mettre à jour ou supprimer une note liée à plusieurs contacts."
+
+#. module: stock_picking_partner_note
+#: model_terms:ir.ui.view,arch_db:stock_picking_partner_note.res_config_settings_view_form
+msgid ""
+"Add a constraint to check if the picking note is already in use on multiple "
+"partner"
+msgstr "Ajout d'une contrainte pour vérifier si la note de prélèvement est déjà utilisée par plusieurs "
+"partenaires"
+
+#. module: stock_picking_partner_note
+#: model:ir.model.fields,field_description:stock_picking_partner_note.field_res_company__check_note_already_in_use
+#: model:ir.model.fields,field_description:stock_picking_partner_note.field_res_config_settings__check_note_already_in_use
+msgid "Check picking note already in use"
+msgstr "Vérifier la note de prélèvement déjà utilisée"

--- a/stock_picking_partner_note/i18n/stock_picking_partner_note.pot
+++ b/stock_picking_partner_note/i18n/stock_picking_partner_note.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-03-14 10:52+0000\n"
+"PO-Revision-Date: 2024-03-14 10:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,9 +21,18 @@ msgid "Active"
 msgstr ""
 
 #. module: stock_picking_partner_note
-#: model:ir.model,name:stock_picking_partner_note.model_res_partner
-msgid "Contact"
+#: model_terms:ir.ui.view,arch_db:stock_picking_partner_note.res_config_settings_view_form
+msgid ""
+"Add a constraint to check if the picking note is already in use on multiple "
+"partner"
 msgstr ""
+
+#. module: stock_picking_partner_note
+#: model:ir.model.fields,field_description:stock_picking_partner_note.field_res_company__check_note_already_in_use
+#: model:ir.model.fields,field_description:stock_picking_partner_note.field_res_config_settings__check_note_already_in_use
+msgid "Check picking note already in use"
+msgstr ""
+
 
 #. module: stock_picking_partner_note
 #: model:ir.model.fields,field_description:stock_picking_partner_note.field_stock_picking_note__create_uid
@@ -137,4 +148,13 @@ msgstr ""
 msgid ""
 "Type of note with customer preferences on how his products are prepared for "
 "delivery."
+msgstr ""
+
+#. module: stock_picking_partner_note
+#. odoo-python
+#: code:addons/stock_picking_partner_note/models/stock_picking_note.py:0
+#, python-format
+msgid ""
+"You cannot update or delete a note that linked to multiple contacts: "
+"%(partner_ids)s"
 msgstr ""

--- a/stock_picking_partner_note/models/__init__.py
+++ b/stock_picking_partner_note/models/__init__.py
@@ -3,3 +3,5 @@ from . import stock_picking_note
 from . import stock_picking_type
 from . import stock_picking
 from . import res_partner
+from . import res_company
+from . import res_config_settings

--- a/stock_picking_partner_note/models/res_company.py
+++ b/stock_picking_partner_note/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Camptocamp (<https://www.camptocamp.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    check_note_already_in_use = fields.Boolean(
+        string="Check picking note already in use",
+        default=False,
+    )

--- a/stock_picking_partner_note/models/res_config_settings.py
+++ b/stock_picking_partner_note/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Camptocamp (<https://www.camptocamp.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    check_note_already_in_use = fields.Boolean(
+        related="company_id.check_note_already_in_use",
+        readonly=False,
+        help="That must be activated if you want to prevent the update or deletion "
+        "of a note that is already in use by multiple contacts.",
+    )

--- a/stock_picking_partner_note/models/stock_picking_note.py
+++ b/stock_picking_partner_note/models/stock_picking_note.py
@@ -2,7 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class StockPickingNote(models.Model):
@@ -14,3 +15,25 @@ class StockPickingNote(models.Model):
     active = fields.Boolean(default=True)
     note_type_id = fields.Many2one("stock.picking.note.type", required=True)
     sequence = sequence = fields.Integer(related="note_type_id.sequence", store=True)
+
+    def write(self, vals):
+        self.check_note_already_in_use()
+        return super().write(vals)
+
+    @api.ondelete(at_uninstall=False)
+    def check_note_already_in_use(self):
+        if not self.env.user.company_id.check_note_already_in_use:
+            return True
+        for note in self:
+            partners = self.env["res.partner"].search(
+                [("stock_picking_note_ids", "in", note.ids)]
+            )
+            if len(partners) > 1:
+                raise UserError(
+                    _(
+                        "You cannot update or delete a note that linked to multiple"
+                        " contacts: %(partner_ids)s",
+                        partner_ids=", ".join(partners.mapped("name")),
+                    )
+                )
+        return True

--- a/stock_picking_partner_note/readme/CONFIGURE.rst
+++ b/stock_picking_partner_note/readme/CONFIGURE.rst
@@ -1,3 +1,6 @@
 * Create partner note types in Inventory > Configuration > Note Types.
 * In shipping operation types set field `Partner Note Type`. Only these types will be shown in picking operations notes.
 * On contacts add picking notes. 
+
+
+You can prevent users ot update or delete notes alredy in use by multiple customers by activating setting `Prevent update or delete of notes in use by multiple customers` in Inventory > Configuration > Settings.

--- a/stock_picking_partner_note/views/res_config_settings.xml
+++ b/stock_picking_partner_note/views/res_config_settings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form </field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='operations_setting_container']" position="inside">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="check_pickings_partner_note"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="check_note_already_in_use" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="check_note_already_in_use" />
+                        <div class="text-muted">
+                            Add a constraint to check if the picking note is already in use on multiple partner
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add setting option to validate if picking note is already used in other partners, preventing it to be modified or deleted,