### PR TITLE
[14.0][FIX] stock_picking_partner_note: make note field a text field

### DIFF
--- a/stock_picking_partner_note/models/stock_picking.py
+++ b/stock_picking_partner_note/models/stock_picking.py
@@ -8,7 +8,7 @@ from odoo import api, fields, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    note = fields.Html(compute="_compute_note", store=True)
+    note = fields.Text(compute="_compute_note", store=True)
 
     # TODO: ideally, we should add more detailed dependencies here;
     # however, there's a CacheMiss error that occurs when adding
@@ -27,4 +27,4 @@ class StockPicking(models.Model):
                 for note in picking_notes
                 if note.name and note.name.strip()
             ]
-            picking.note = "<br />".join(picking_notes)
+            picking.note = "\n".join(picking_notes)

--- a/stock_picking_partner_note/models/stock_picking.py
+++ b/stock_picking_partner_note/models/stock_picking.py
@@ -10,11 +10,6 @@ class StockPicking(models.Model):
 
     note = fields.Text(compute="_compute_note", store=True)
 
-    # TODO: ideally, we should add more detailed dependencies here;
-    # however, there's a CacheMiss error that occurs when adding
-    # "picking_type_id.partner_note_type_ids" and "partner_id.stock_picking_note_ids"
-    # so we're leaving it like this for now
-    # (the partner should be enough to trigger the compute).
     @api.depends("partner_id")
     def _compute_note(self):
         for picking in self:

--- a/stock_picking_partner_note/tests/test_stock_picking_partner_note.py
+++ b/stock_picking_partner_note/tests/test_stock_picking_partner_note.py
@@ -41,4 +41,4 @@ class StockPickingPartnerNote(common.SavepointCase):
             (6, 0, (self.note_type1 | self.note_type2).ids)
         ]
         self.order.action_confirm()
-        self.assertIn("<p>Note 1<br>Note 2</p>", self.order.picking_ids[0].note)
+        self.assertIn("Note 1\nNote 2", self.order.picking_ids[0].note)


### PR DESCRIPTION
@santostelmo 

I'm opening this PR after noticing that the `note` field in `stock.picking`, which was created as an HTML, created some conflicts with what shopfloor expects.

Do you think we could make it a Text field (even more considering `note.name` is a Text field too) and then apply styling through CSS if needed?

ref: cos-4507

@simahawk 