### PR TITLE
[16.0][IMP][stock_restrict_lot] propagation of restrict_lot changes

### DIFF
--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -1,5 +1,6 @@
 from odoo import _, api, exceptions, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.misc import OrderedSet
 
 
 class StockMove(models.Model):
@@ -140,10 +141,12 @@ class StockMove(models.Model):
         else:
             restrict_lot_id = vals.pop("restrict_lot_id")
             restrict_lot = self.env["stock.lot"].browse(restrict_lot_id)
-            chained_moves = self | self.get_all_dest_moves() | self.get_all_orig_moves()
+            chained_moves = OrderedSet()
+            self._rollup_move_dests(chained_moves)
+            self._rollup_move_origs(chained_moves)
             if any(
                 [
-                    sm.state == "done" and sm.lot_ids != restrict_lot
+                    sm.state == "done" and sm.lot_ids and sm.lot_ids != restrict_lot
                     for sm in chained_moves
                 ]
             ):
@@ -156,15 +159,3 @@ class StockMove(models.Model):
                 )
             super(StockMove, chained_moves).write({"restrict_lot_id": restrict_lot_id})
         return super().write(vals)
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        res = super().create(vals_list)
-        for move in res:
-            if not move.restrict_lot_id:
-                chained_moves = (
-                    move | move.get_all_dest_moves() | move.get_all_orig_moves()
-                )
-                if chained_moves.restrict_lot_id:
-                    move.restrict_lot_id = chained_moves.restrict_lot_id[0]
-        return res

--- a/stock_restrict_lot/models/stock_rule.py
+++ b/stock_restrict_lot/models/stock_rule.py
@@ -8,3 +8,10 @@ class StockRule(models.Model):
         fields = super()._get_custom_move_fields()
         fields += ["restrict_lot_id"]
         return fields
+
+    def _push_prepare_move_copy_values(self, move_to_copy, new_date):
+        values = super()._push_prepare_move_copy_values(move_to_copy, new_date)
+        values["restrict_lot_id"] = (
+            move_to_copy.restrict_lot_id.id if move_to_copy.restrict_lot_id else False
+        )
+        return values

--- a/stock_restrict_lot/tests/test_restrict_lot.py
+++ b/stock_restrict_lot/tests/test_restrict_lot.py
@@ -373,7 +373,9 @@ class TestRestrictLot(TransactionCase):
     def test_restrict_lot_no_propagation_error(self):
         move, new_lot = self._create_move_with_lot()
         orig_move = move.move_orig_ids
-        orig_move.state = "done"
+        orig_move._action_assign()
+        orig_move.quantity_done = orig_move.product_uom_qty
+        orig_move._action_done()
         self.assertEqual(orig_move.state, "done")
         with self.assertRaises(ValidationError) as m:
             move.restrict_lot_id = new_lot.id

--- a/stock_restrict_lot/tests/test_restrict_lot.py
+++ b/stock_restrict_lot/tests/test_restrict_lot.py
@@ -1,4 +1,4 @@
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -17,6 +17,50 @@ class TestRestrictLot(TransactionCase):
                 "name": "lot1",
                 "product_id": cls.product.id,
                 "company_id": cls.warehouse.company_id.id,
+            }
+        )
+
+    def _create_move_with_lot(self):
+        move = self.env["stock.move"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.output_loc.id,
+                "location_dest_id": self.customer_loc.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "name": "test",
+                "procure_method": "make_to_order",
+                "warehouse_id": self.warehouse.id,
+                "route_ids": [(6, 0, self.warehouse.delivery_route_id.ids)],
+                "restrict_lot_id": self.lot.id,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        new_lot = self.env["stock.lot"].create(
+            {
+                "name": "lot2",
+                "product_id": self.product.id,
+                "company_id": self.warehouse.company_id.id,
+            }
+        )
+        return move, new_lot
+
+    def _create_move_dest(self):
+        return self.env["stock.move"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.customer_loc.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "picking_type_id": self.warehouse.out_type_id.id,
+                "location_dest_id": self.output_loc.id,
+                "name": "test",
+                "procure_method": "make_to_order",
+                "warehouse_id": self.warehouse.id,
+                "route_ids": [(6, 0, self.warehouse.delivery_route_id.ids)],
+                "state": "waiting",
+                "restrict_lot_id": self.lot.id,
             }
         )
 
@@ -299,3 +343,38 @@ class TestRestrictLot(TransactionCase):
         self.assertRaises(UserError, move._action_done)
         move_line.lot_id = self.lot
         move._action_done()
+        
+    def test_restrict_lot_propagation_dest_moves(self):
+        move, new_lot = self._create_move_with_lot()
+        move_dest = self._create_move_dest()
+        move.move_dest_ids = [(4, move_dest.id)]
+        self.assertEqual(move_dest.restrict_lot_id, self.lot)
+        move.restrict_lot_id = new_lot.id
+        self.assertEqual(move_dest.restrict_lot_id, new_lot)
+
+    def test_restrict_lot_propagation_origin_moves(self):
+        move, new_lot = self._create_move_with_lot()
+        orig_move = move.move_orig_ids
+        self.assertEqual(orig_move.restrict_lot_id, self.lot)
+        move.restrict_lot_id = new_lot.id
+        self.assertEqual(orig_move.restrict_lot_id, new_lot)
+
+    def test_restrict_lot_propagation_origin_and_dest_moves(self):
+        move, new_lot = self._create_move_with_lot()
+        move_dest = self._create_move_dest()
+        move.move_dest_ids = [(4, move_dest.id)]
+        orig_move = move.move_orig_ids
+        self.assertEqual(move_dest.restrict_lot_id, self.lot)
+        self.assertEqual(orig_move.restrict_lot_id, self.lot)
+        move.restrict_lot_id = new_lot.id
+        self.assertEqual(orig_move.restrict_lot_id, new_lot)
+        self.assertEqual(move_dest.restrict_lot_id, new_lot)
+
+    def test_restrict_lot_no_propagation_error(self):
+        move, new_lot = self._create_move_with_lot()
+        orig_move = move.move_orig_ids
+        orig_move.state = "done"
+        self.assertEqual(orig_move.state, "done")
+        with self.assertRaises(ValidationError) as m:
+            move.restrict_lot_id = new_lot.id
+        self.assertIn("You can't modify the Lot/Serial number", m.exception.args[0])

--- a/stock_restrict_lot/tests/test_restrict_lot.py
+++ b/stock_restrict_lot/tests/test_restrict_lot.py
@@ -343,7 +343,7 @@ class TestRestrictLot(TransactionCase):
         self.assertRaises(UserError, move._action_done)
         move_line.lot_id = self.lot
         move._action_done()
-        
+
     def test_restrict_lot_propagation_dest_moves(self):
         move, new_lot = self._create_move_with_lot()
         move_dest = self._create_move_dest()


### PR DESCRIPTION
The restrict_lot_id is "shared" in the stock moves chain through stock rules when procurements are run.

But changing a lot / serial in one of the stock move is breaking the chain.

We think we need to grant consistency in the whole chain by allowing to change restrict_lot_id on every stock move of the chain at the same time and only if no move is already done.

Both @metaminux and me worked on this PR.