### PR TITLE
[16.0][FIX] stock_picking_auto_create_lot: use standard method for lot val prep

### DIFF
--- a/stock_picking_auto_create_lot/models/stock_move_line.py
+++ b/stock_picking_auto_create_lot/models/stock_move_line.py
@@ -8,12 +8,11 @@ class StockMoveLine(models.Model):
 
     _inherit = "stock.move.line"
 
-    def _prepare_auto_lot_values(self):
-        """
-        Prepare multi valued lots per line to use multi creation.
-        """
-        self.ensure_one()
-        return {"product_id": self.product_id.id, "company_id": self.company_id.id}
+    def _get_value_production_lot(self):
+        res = super()._get_value_production_lot()
+        if "name" in res and not res["name"]:
+            del res["name"]
+        return res
 
     def set_lot_auto(self):
         """
@@ -25,7 +24,8 @@ class StockMoveLine(models.Model):
         stock_lot_obj = self.env["stock.lot"]
         lots_by_product = dict()
         for line in self:
-            values.append(line._prepare_auto_lot_values())
+            # Prepare multi valued lots per line to use multi creation.
+            values.append(line._get_value_production_lot())
         lots = stock_lot_obj.create(values)
         for lot in lots:
             if lot.product_id.id not in lots_by_product:

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -36,7 +36,7 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
         self.assertTrue(move.display_assign_serial)
         # Assign manual serials
         for line in move.move_line_ids:
-            line.lot_id = self.lot_obj.create(line._prepare_auto_lot_values())
+            line.lot_id = self.lot_obj.create(line._get_value_production_lot())
 
         self.picking.button_validate()
         lot = self.env["stock.lot"].search([("product_id", "=", self.product.id)])
@@ -88,7 +88,7 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
 
         # Assign manual serials
         for line in moves.mapped("move_line_ids"):
-            line.lot_id = self.lot_obj.create(line._prepare_auto_lot_values())
+            line.lot_id = self.lot_obj.create(line._get_value_production_lot())
 
         self.picking.button_validate()
         for line in moves.mapped("move_line_ids"):


### PR DESCRIPTION
This PR supersedes https://github.com/OCA/stock-logistics-workflow/pull/1297.

@qrtl