### PR TITLE
[FIX] stock_picking_group_by_partner_by_carrier: Don't get the assigned picking group

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -20,6 +20,21 @@ class StockMove(models.Model):
         string="Original Procurement Group",
     )
 
+    def write(self, vals):
+        """
+        During picking assignation, Odoo is overwriting the group on stock
+        moves from found picking. Here, get the original group on stock moves.
+        """
+        if (
+            self.env.context.get("picking_no_overwrite_partner_origin")
+            and "picking_id" in vals
+            and "group_id" not in vals
+            and len(self.group_id) == 1
+        ):
+            vals["group_id"] = self.group_id.id
+        res = super().write(vals)
+        return res
+
     @api.model
     def _prepare_merge_moves_distinct_fields(self):
         # Prevent merging pulled moves. This allows to cancel a SO without

--- a/stock_picking_group_by_partner_by_carrier/tests/__init__.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/__init__.py
@@ -1,3 +1,6 @@
-from . import test_grouping_disable_on_partner
-from . import test_grouping
-from . import test_report
+from . import (
+    test_grouping,
+    test_grouping_disable_on_partner,
+    test_merge_wizard,
+    test_report,
+)

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping.py
@@ -125,6 +125,7 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         move = first(pick.move_ids)
         move.quantity_done = 5
         pick.with_context(cancel_backorder=False)._action_done()
+        so2.invalidate_recordset()
         self.assertTrue(so2.picking_ids & so1.picking_ids)
         self.assertEqual(so2.picking_ids.sale_ids, so1 + so2)
 

--- a/stock_picking_group_by_partner_by_carrier/tests/test_merge_wizard.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_merge_wizard.py
@@ -4,11 +4,11 @@
 
 
 from odoo import exceptions
-from odoo.tests.common import SavepointCase, tagged
+from odoo.tests.common import TransactionCase, tagged
 
 
 @tagged("post_install", "-at_install")
-class TestMergeWizard(SavepointCase):
+class TestMergeWizard(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
As Odoo changed its behavior to auto assign picking group to moves when picking_id field is filled in (backorder creation, assignation), we let the original group on move level.

Changed here:

https://github.com/odoo/odoo/commit/ca9aab977d6aa7d3565c2b69f1cddd3edcb7fc9f

Restored also inactive test.