### PR TITLE
[14.0][FIX] stock_picking_putinpack_restriction: Restriction check after action_done

### DIFF
--- a/stock_picking_putinpack_restriction/models/stock_move_line.py
+++ b/stock_picking_putinpack_restriction/models/stock_move_line.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Camptocamp (https://www.camptocamp.com)
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, models
@@ -9,7 +10,8 @@ class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
     def _action_done(self):
-        for line in self:
+        res = super()._action_done()
+        for line in self.exists():
             picking_type = line.move_id.picking_type_id
             restriction = picking_type.put_in_pack_restriction
             if not restriction:
@@ -24,4 +26,4 @@ class StockMoveLine(models.Model):
                 raise ValidationError(
                     _("A package is required for transfer type %s.") % picking_type.name
                 )
-        return super()._action_done()
+        return res

--- a/stock_picking_putinpack_restriction/readme/CONTRIBUTORS.rst
+++ b/stock_picking_putinpack_restriction/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>


### PR DESCRIPTION
If there is a move_line with a qty_done = 0
it will be removed by _action_done
therefor check the restriction after _action_done
otherwise lines will be checked which will be deleted

cc @jbaudoux @TDu 