### PR TITLE
[16.0][FIX] stock_picking_restrict_cancel_printed: move cancellation

### DIFF
--- a/stock_picking_restrict_cancel_printed/__manifest__.py
+++ b/stock_picking_restrict_cancel_printed/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Camptocamp (<https://www.camptocamp.com>).
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -8,6 +9,7 @@
     "category": "Inventory",
     "summary": "Prevent canceling a stock transfer if printed.",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
+    "maintainers": ["jbaudoux"],
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "license": "AGPL-3",
     "depends": ["stock"],

--- a/stock_picking_restrict_cancel_printed/models/__init__.py
+++ b/stock_picking_restrict_cancel_printed/models/__init__.py
@@ -1,2 +1,3 @@
+from . import stock_move
 from . import stock_picking
 from . import stock_picking_type

--- a/stock_picking_restrict_cancel_printed/models/stock_move.py
+++ b/stock_picking_restrict_cancel_printed/models/stock_move.py
@@ -1,0 +1,20 @@
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _action_cancel(self):
+        for move in self:
+            if (
+                move.picking_id.printed
+                and move.picking_type_id.restrict_cancel_if_printed
+            ):
+                raise UserError(
+                    _("You cannot cancel a transfer that is already printed.")
+                )
+        return super()._action_cancel()

--- a/stock_picking_restrict_cancel_printed/tests/test_stock_picking_restrict_cancel_printed.py
+++ b/stock_picking_restrict_cancel_printed/tests/test_stock_picking_restrict_cancel_printed.py
@@ -1,25 +1,41 @@
 # Copyright 2024 Camptocamp (<https://www.camptocamp.com>).
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo import Command
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
-class TestResPartnerGetAddress(TransactionCase):
+class TestPickingRestrictCancel(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env["base"].with_context(**DISABLED_MAIL_CONTEXT).env
         cls.partner_1 = cls.env.ref("base.res_partner_1")
         cls.picking_type = cls.env.ref("stock.picking_type_out")
+        cls.product = cls.env.ref("product.product_product_5")
         cls.picking = cls.env["stock.picking"].create(
             {
                 "partner_id": cls.partner_1.id,
                 "picking_type_id": cls.picking_type.id,
                 "location_id": cls.env.ref("stock.stock_location_stock").id,
                 "location_dest_id": cls.env.ref("stock.stock_location_customers").id,
+                "move_ids": [
+                    Command.create(
+                        {
+                            "name": "Test move",
+                            "product_id": cls.product.id,
+                            "product_uom_qty": 1,
+                            "location_id": cls.env.ref("stock.stock_location_stock").id,
+                            "location_dest_id": cls.env.ref(
+                                "stock.stock_location_customers"
+                            ).id,
+                        }
+                    )
+                ],
             }
         )
 
@@ -32,3 +48,13 @@ class TestResPartnerGetAddress(TransactionCase):
         self.picking_type.restrict_cancel_if_printed = False
         self.picking.printed = True
         self.picking.action_cancel()
+
+    def test_stock_move_restrict_cancel_printed_enabled(self):
+        self.picking.printed = True
+        with self.assertRaises(UserError):
+            self.picking.move_ids._action_cancel()
+
+    def test_stock_move_restrict_cancel_printed_disabled(self):
+        self.picking_type.restrict_cancel_if_printed = False
+        self.picking.printed = True
+        self.picking.move_ids._action_cancel()


### PR DESCRIPTION
Prevent cancellation of stock move if picking is printed

cc @santostelmo @rousseldenis 