### PR TITLE
[15.0][IMP] stock_picking_mass_action: allow to configure `check_assign_all` domain

### DIFF
--- a/stock_picking_mass_action/models/stock_picking.py
+++ b/stock_picking_mass_action/models/stock_picking.py
@@ -10,9 +10,13 @@ class StockPicking(Model):
     _inherit = "stock.picking"
 
     @api.model
-    def check_assign_all(self):
+    def check_assign_all(self, domain=None):
         """Try to assign confirmed pickings"""
-        domain = [("picking_type_code", "=", "outgoing"), ("state", "=", "confirmed")]
+        if not domain:
+            domain = [
+                ("picking_type_code", "=", "outgoing"),
+                ("state", "=", "confirmed"),
+            ]
         records = self.search(domain, order="scheduled_date")
         records.action_assign()
 


### PR DESCRIPTION
It is useful for a easy tweaking of the configuration.