### PR TITLE
[16.0][IMP] stock_picking_auto_create_lot

### DIFF
--- a/stock_picking_auto_create_lot/models/__init__.py
+++ b/stock_picking_auto_create_lot/models/__init__.py
@@ -3,3 +3,4 @@ from . import product
 from . import stock_picking
 from . import stock_picking_type
 from . import stock_move
+from . import stock_move_line

--- a/stock_picking_auto_create_lot/models/stock_move_line.py
+++ b/stock_picking_auto_create_lot/models/stock_move_line.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Quartile Limited
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def _get_lot_sequence(self):
+        self.ensure_one()
+        return self.env["ir.sequence"].next_by_code("stock.lot.serial")

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, models
+from odoo import models
 
 
 class StockPicking(models.Model):
@@ -21,7 +21,7 @@ class StockPicking(models.Model):
             )
         )
         for line in lines:
-            line.lot_name = self._get_lot_sequence()
+            line.lot_name = line._get_lot_sequence()
 
     def _action_done(self):
         self._set_auto_lot()
@@ -30,7 +30,3 @@ class StockPicking(models.Model):
     def button_validate(self):
         self._set_auto_lot()
         return super().button_validate()
-
-    @api.model
-    def _get_lot_sequence(self):
-        return self.env["ir.sequence"].next_by_code("stock.lot.serial")


### PR DESCRIPTION
This PR moves `_get_lot_sequence` method from `stock.picking` to` stock.move.line`. This change allows us to extend the method to retrieve the specific sequence based on the product of each move line.
Related: https://github.com/OCA/stock-logistics-workflow/pull/1619

@qrtl QT4624