### PR TITLE
[16.0][FIX] stock_picking_invoice_link: don't store auxiliar fields

### DIFF
--- a/stock_picking_invoice_link/models/account_move.py
+++ b/stock_picking_invoice_link/models/account_move.py
@@ -19,8 +19,8 @@ class AccountMove(models.Model):
         help="Related pickings (only when the invoice has been generated from a sale order).",
     )
 
-    delivery_count = fields.Integer(
-        string="Delivery Orders", compute="_compute_picking_ids", store=True
+    picking_count = fields.Integer(
+        string="Pickings count", compute="_compute_picking_ids"
     )
 
     @api.depends("invoice_line_ids", "invoice_line_ids.move_line_ids")
@@ -29,7 +29,7 @@ class AccountMove(models.Model):
             invoice.picking_ids = invoice.mapped(
                 "invoice_line_ids.move_line_ids.picking_id"
             )
-            invoice.delivery_count = len(invoice.picking_ids)
+            invoice.picking_count = len(invoice.picking_ids)
 
     def action_show_picking(self):
         """This function returns an action that display existing pickings

--- a/stock_picking_invoice_link/views/account_invoice_view.xml
+++ b/stock_picking_invoice_link/views/account_invoice_view.xml
@@ -14,9 +14,9 @@
                     name="action_show_picking"
                     class="oe_stat_button"
                     icon="fa-truck"
-                    attrs="{'invisible': [('delivery_count', '=', 0)]}"
+                    attrs="{'invisible': [('picking_count', '=', 0)]}"
                 >
-                    <field name="delivery_count" widget="statinfo" string="Delivery" />
+                    <field name="picking_count" widget="statinfo" string="Delivery" />
                 </button>
             </div>
             <xpath expr="//field[@name='invoice_line_ids']//tree" position="inside">


### PR DESCRIPTION
fw of https://github.com/OCA/stock-logistics-workflow/pull/1617

In c332869b09d99231f3c5f957089fddd257ee23ba a new computed field was introduced to show the count of a move's related pickings. But it was made stored, which is needless for this kind of field and adds a huge overhead when migrating from big DBs from previous versions.

With this commit:

- We drop the storing of this field which is meant to play a UI role.
- We rename the field to picking count, as a more precise nomenclature.

cc @Tecnativa TT46020

please review @pedrobaeza @sergio-teruel 