### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/stock_dangerous_goods/__manifest__.py
+++ b/stock_dangerous_goods/__manifest__.py
@@ -6,7 +6,7 @@
     "version": "14.0.1.0.0",
     "category": "Inventory",
     "website": "https://github.com/OCA/stock-logistics-workflow",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["mmequignon"],
     "license": "AGPL-3",
     "installable": True,

--- a/stock_picking_progress/__manifest__.py
+++ b/stock_picking_progress/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "14.0.1.2.1",
     "category": "Inventory",
     "website": "https://github.com/OCA/stock-logistics-workflow",
-    "author": "mmequignon, Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "mmequignon, Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["mmequignon", "JuMiSanAr"],
     "license": "AGPL-3",
     "installable": True,


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.