### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/stock_picking_propagate_scheduled_date/__manifest__.py
+++ b/stock_picking_propagate_scheduled_date/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": "Propagate Stock Picking Scheduled Date",
     "version": "15.0.1.0.1",
     "license": "AGPL-3",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "depends": ["stock"],
 }


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 15.0.