### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/stock_picking_progress/__manifest__.py
+++ b/stock_picking_progress/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "16.0.1.0.0",
     "category": "Inventory",
     "website": "https://github.com/OCA/stock-logistics-workflow",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["mmequignon", "JuMiSanAr"],
     "license": "AGPL-3",
     "installable": True,


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 16.0.