### PR TITLE
[16.0][FIX] stock_picking_invoice_link: Avoid doble compute picking_count

### DIFF
--- a/stock_picking_invoice_link/models/account_move.py
+++ b/stock_picking_invoice_link/models/account_move.py
@@ -29,7 +29,6 @@ class AccountMove(models.Model):
             invoice.picking_ids = invoice.mapped(
                 "invoice_line_ids.move_line_ids.picking_id"
             )
-            invoice.picking_count = len(invoice.picking_ids)
 
     @api.depends("picking_ids")
     def _compute_picking_count(self):


### PR DESCRIPTION
After the change added in the commit [[FIX] stock_picking_invoice_link: Avoid inconsistent computes](https://github.com/OCA/stock-logistics-workflow/commit/38b1742d33eaa04318a0e8c28d93c7bcd9fd4def) the picking_count field is being calculated twice.
This generates a strange interaction with the "payment.return" when confirming in which it checks if the generated account.move is balanced ahead of time and prevents it from being created.