### PR TITLE
[14.0][FIX] stock_picking_invoice_link: BackPort reverse_moves on refunds

### DIFF
--- a/stock_picking_invoice_link/models/stock_picking.py
+++ b/stock_picking_invoice_link/models/stock_picking.py
@@ -4,7 +4,7 @@
 # Copyright 2017 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockPicking(models.Model):
@@ -12,6 +12,9 @@ class StockPicking(models.Model):
 
     invoice_ids = fields.Many2many(
         comodel_name="account.move", copy=False, string="Invoices", readonly=True
+    )
+    invoice_count = fields.Integer(
+        string="Number of Invoices", compute="_compute_invoice_count"
     )
 
     def action_view_invoice(self):
@@ -22,12 +25,18 @@ class StockPicking(models.Model):
         """
         self.ensure_one()
         form_view_name = "account.view_move_form"
-        xmlid = "account.action_move_out_invoice_type"
-        action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
+        result = self.env["ir.actions.act_window"]._for_xml_id(
+            "account.action_move_out_invoice_type"
+        )
         if len(self.invoice_ids) > 1:
-            action["domain"] = "[('id', 'in', %s)]" % self.invoice_ids.ids
+            result["domain"] = f"[('id', 'in', {self.invoice_ids.ids})]"
         else:
             form_view = self.env.ref(form_view_name)
-            action["views"] = [(form_view.id, "form")]
-            action["res_id"] = self.invoice_ids.id
-        return action
+            result["views"] = [(form_view.id, "form")]
+            result["res_id"] = self.invoice_ids.id
+        return result
+
+    @api.depends("invoice_ids")
+    def _compute_invoice_count(self):
+        for order in self:
+            order.invoice_count = len(order.invoice_ids)

--- a/stock_picking_invoice_link/views/account_invoice_view.xml
+++ b/stock_picking_invoice_link/views/account_invoice_view.xml
@@ -10,20 +10,21 @@
             <div name="button_box" position="inside">
                 <field name="picking_ids" invisible="1" />
                 <button
+                    type="object"
                     name="action_show_picking"
                     class="oe_stat_button"
                     icon="fa-truck"
-                    type="object"
                     attrs="{'invisible': [('picking_ids', '=', [])]}"
                     string="Pickings"
                 >
+                    <field name="picking_count" widget="statinfo" string="Delivery" />
                 </button>
             </div>
             <xpath expr="//field[@name='invoice_line_ids']//tree" position="inside">
-                <field name="move_line_ids" force_save="1" invisible="1" />
+                <field name="move_line_ids" force_save="1" column_invisible="1" />
             </xpath>
             <xpath expr="//field[@name='line_ids']//tree" position="inside">
-                <field name="move_line_ids" force_save="1" invisible="1" />
+                <field name="move_line_ids" force_save="1" column_invisible="1" />
             </xpath>
         </field>
     </record>

--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -9,13 +9,14 @@
             <div name="button_box" position="inside">
                 <field name="invoice_ids" invisible="1" />
                 <button
+                    type="object"
                     name="action_view_invoice"
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
-                    type="object"
                     attrs="{'invisible': [('invoice_ids', '=', [])]}"
                     string="Invoices"
                 >
+                    <field name="invoice_count" widget="statinfo" string="Invoice" />
                 </button>
             </div>
         </field>
@@ -27,6 +28,7 @@
         <field name="inherit_id" ref="stock.view_move_form" />
         <field name="arch" type="xml">
             <group name="linked_group" position="after">
+                <field name="invoice_line_ids" inivisible="1" />
                 <group
                     name="invoice_line"
                     string="Invoice Lines"
@@ -49,6 +51,7 @@
         <field name="inherit_id" ref="stock.view_move_form" />
         <field name="arch" type="xml">
             <group position="after">
+                <field name="invoice_line_ids" inivisible="1" />
                 <group
                     name="invoice_line"
                     string="Invoice Lines"

--- a/stock_picking_invoice_link/wizards/account_move_reversal.py
+++ b/stock_picking_invoice_link/wizards/account_move_reversal.py
@@ -8,13 +8,24 @@ class AccountMoveReversal(models.TransientModel):
 
     def reverse_moves(self):
         """Link return moves to the lines of refund invoice"""
-        action = super().reverse_moves()
+        action = super(
+            AccountMoveReversal, self.with_context(force_copy_stock_moves=True)
+        ).reverse_moves()
         if "res_id" in action:
             moves = self.env["account.move"].browse(action["res_id"])
         else:
             moves = self.env["account.move"].search(action["domain"])
-        for line in moves.mapped("invoice_line_ids"):
-            reverse_moves = line.move_line_ids.mapped("returned_move_ids")
-            if reverse_moves:
-                line.move_line_ids = reverse_moves
+        if self.refund_method == "modify":
+            origin_moves = self.move_ids
+            for line in origin_moves.mapped("invoice_line_ids"):
+                reverse_moves = line.move_line_ids.mapped("returned_move_ids")
+                if reverse_moves:
+                    moves.mapped("invoice_line_ids").filtered(
+                        lambda m, line=line: m.product_id == line.product_id
+                    ).move_line_ids = reverse_moves
+        else:
+            for line in moves.mapped("invoice_line_ids"):
+                reverse_moves = line.move_line_ids.mapped("returned_move_ids")
+                if reverse_moves:
+                    line.move_line_ids = reverse_moves
         return action


### PR DESCRIPTION
Backported the fix done in [ffa0e97](https://github.com/OCA/stock-logistics-workflow/pull/1006/commits/ffa0e9722a034b4a5070e5d3085219cc55cbbbb9#diff-dfac55439119a501e356975046033089d43cb7ffb6b439078961abdfe107f0ff)