### PR TITLE
[15.0] [FIX] stock_picking_propagate_scheduled_date: recursion error

### DIFF
--- a/stock_picking_propagate_scheduled_date/models/__init__.py
+++ b/stock_picking_propagate_scheduled_date/models/__init__.py
@@ -1,1 +1,2 @@
 from . import stock_move
+from . import stock_picking

--- a/stock_picking_propagate_scheduled_date/models/stock_move.py
+++ b/stock_picking_propagate_scheduled_date/models/stock_move.py
@@ -31,7 +31,7 @@ class StockMove(models.Model):
 
     def write(self, vals):
         # propagate date changes in the stock move chain
-        if "date" in vals:
+        if self and "date" in vals:
             self._propagate_date(vals.get("date"))
         return super(StockMove, self).write(vals)
 

--- a/stock_picking_propagate_scheduled_date/models/stock_move.py
+++ b/stock_picking_propagate_scheduled_date/models/stock_move.py
@@ -10,10 +10,13 @@ class StockMove(models.Model):
 
     def _propagate_date(self, new_date):
         """Propagate the date of a move to its destination."""
-        already_propagated_ids = self.env.context.get(
-            "date_propagation_ids", set()
-        ) | set(self.ids)
-        self = self.with_context(date_propagation_ids=already_propagated_ids)
+        # This should never happen (see :meth:`_register_hook`), but still..
+        if "date_propagation_ids" not in self.env.context:
+            self = self.with_context(date_propagation_ids=set())
+        # Update the already propagated ids, to avoid impacting the same move twice
+        already_propagated_ids = self.env.context.get("date_propagation_ids")
+        already_propagated_ids.update(self.ids)  # keep the same variable reference
+        # Propagate the date delta to destination moves
         for move in self:
             if move.date:
                 delta = move.date - fields.Datetime.to_datetime(new_date)
@@ -30,4 +33,20 @@ class StockMove(models.Model):
         # propagate date changes in the stock move chain
         if "date" in vals:
             self._propagate_date(vals.get("date"))
-        return super().write(vals)
+        return super(StockMove, self).write(vals)
+
+    def _register_hook(self):
+        # Patch `write` to initialize `date_propagated_ids` in the context, so that
+        # it's available on the whole stack chain, independent of the MRO.
+        res = super()._register_hook()
+
+        def make_write():
+            def write(self, vals, **kw):
+                if "date_propagation_ids" not in self.env.context:
+                    self = self.with_context(date_propagation_ids=set())
+                return write.origin(self, vals, **kw)
+
+            return write
+
+        self._patch_method("write", make_write())
+        return res

--- a/stock_picking_propagate_scheduled_date/models/stock_picking.py
+++ b/stock_picking_propagate_scheduled_date/models/stock_picking.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _register_hook(self):
+        # Patch `_action_don` to initialize `date_propagated_ids` in the context, so that
+        # it's available on the whole stack chain, independent of the MRO.
+        #
+        # This is required because some addons such as mrp_subcontracting will act on that
+        # method with a different context and we end up propagating the date changes more
+        # than once.
+        res = super()._register_hook()
+
+        def make_action_done():
+            def _action_done(self, **kw):
+                if "date_propagation_ids" not in self.env.context:
+                    self = self.with_context(date_propagation_ids=set())
+                return _action_done.origin(self, **kw)
+
+            return _action_done
+
+        self._patch_method("_action_done", make_action_done())
+        return res


### PR DESCRIPTION
Depending on the installed modules, their resolution order (MRO), and the moves relationships through their `move_dest_ids` and `move_orig_ids` fields, we could get into a situation where the very same move that triggered the propagation gets propagated twice (or more) in the same transaction.

This happens because the modified context, which we use to keep track of the already propagated moves, is only available down the stack, and it's lost once we exit the method. However, other modules might also react to the changes and trigger other kinds of propagations, which might lead to our original record being propagated again.

This is the case with the core `mrp_subcontracting` module, which propagates the move's `date` to the related manufacturing order's `date_planned_start` and `date_planned_finished` fields. Which, in turn, triggers the propagation of these two fields to their related `move_raw_ids` and `move_finished_ids`.

It can just so happen that one of these related moves also points to our original move in their `move_dest_ids` or `move_orig_ids` fields chain.

The solution relies on the `_register_hook` method, which gets executed after the model has been initialized, and so it's able to patch the `write` method getting a top position in the stack, and inject the context key there.

---

Superseeds https://github.com/OCA/stock-logistics-workflow/pull/1644

@gurneyalex @SilvioC2C @vvrossem @yankinmax 