### PR TITLE
[16.0][FIX] stock_picking_group_by_partner_by_carrier: add the same class style as in the base report

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -177,7 +177,7 @@
             expr='//p[@t-field="o.sudo().sale_id.client_order_ref"]'
             position="after"
         >
-            <p>
+            <p class="m-0">
                 <t t-esc="o.get_customer_refs().pop()" />
             </p>
         </xpath>


### PR DESCRIPTION
This [PR](https://github.com/odoo/odoo/pull/172366) accepts a change that fixes how the information section looks like.

It is necessary to change the views that add changes in this section.