### PR TITLE
[15.0][IMP] product_cost_price_avco_sync: Don't apply qty changes to landed costs

### DIFF
--- a/product_cost_price_avco_sync/models/stock_move_line.py
+++ b/product_cost_price_avco_sync/models/stock_move_line.py
@@ -13,12 +13,12 @@ class StockMoveLine(models.Model):
             "new_stock_move_create", False
         ):
             return super()._create_correction_svl(move, diff)
-        for svl in move.stock_valuation_layer_ids:
-            # TODO: Review if is dropshipping
+        for svl in move.stock_valuation_layer_ids.filtered(
+            lambda x: not x.stock_valuation_layer_id
+        ):
             if move._is_out():
-                svl.quantity -= diff
-            else:
-                svl.quantity += diff
+                diff = -diff
+            svl.quantity += diff
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
When a change is made to the quantities of a stock move that is associated with multiple stock valuation layers, including those related to landed costs, the quantity change is being applied to all the lines instead of only to the one related to the material entry.

With these changes, we restrict the quantity change solely to the stock valuation layer related to the material entry, preventing the change from being applied to the lines associated with landed costs.

cc @Tecnativa TT50028

ping @pedrobaeza @chienandalu 