### PR TITLE
[16.0][IMP] stock_split_picking: assign created moves only if reservation_method is 'at_confirm'

### DIFF
--- a/stock_split_picking/models/stock_picking.py
+++ b/stock_split_picking/models/stock_picking.py
@@ -61,7 +61,6 @@ class StockPicking(models.Model):
                         new_move = self.env["stock.move"].create(new_move_vals)
                     else:
                         new_move = move
-                    new_move._action_confirm(merge=False)
                     new_moves |= new_move
 
             # If we have new moves to move, create the backorder picking
@@ -71,7 +70,7 @@ class StockPicking(models.Model):
                 new_moves.mapped("move_line_ids").write(
                     {"picking_id": backorder_picking.id}
                 )
-                new_moves._action_assign()
+                new_moves._action_confirm(merge=False)
 
     def _create_split_backorder(self, default=None):
         """Copy current picking with defaults passed, post message about


### PR DESCRIPTION
This is a small improvement:

When splitting a picking that have a picking type with a reservation method different than 'at confirm', I except my reservation to not be done.