### PR TITLE
[14.0][FIX]stock_picking_return_lot: handle list ValueError

### DIFF
--- a/stock_picking_return_lot/wizard/stock_picking_return.py
+++ b/stock_picking_return_lot/wizard/stock_picking_return.py
@@ -27,5 +27,6 @@ class ReturnPicking(models.TransientModel):
             )
             if ml and not ml.lot_id and (ml.product_uom_qty == line.qty_done):
                 ml.lot_id = line.lot_id
-            ml_ids_to_update.remove(ml.id)
+            if ml.id in ml_ids_to_update:
+                ml_ids_to_update.remove(ml.id)
         return res


### PR DESCRIPTION
`ml_ids_to_update` might be empty, trying to remove a non-existent element will raise a ValueError