### PR TITLE
[14.0][FIX] sale_stock_mto_as_mts_orderpoint: fix orderpoint creation

### DIFF
--- a/sale_stock_mto_as_mts_orderpoint/models/sale_order.py
+++ b/sale_stock_mto_as_mts_orderpoint/models/sale_order.py
@@ -73,7 +73,7 @@ class SaleOrderLine(models.Model):
                 .sudo()
                 .create(
                     {
-                        "product_id": self.product_id.id,
+                        "product_id": product_id.id,
                         "warehouse_id": warehouse.id,
                         "location_id": (
                             warehouse._get_locations_for_mto_orderpoints().id


### PR DESCRIPTION
When generation the orderpoint from the sale order line, it might happen that the sale_order_line's product is a BOM, the moves that are generated are based on the components that composes it.

For this reason, when creating the purchase order, we have to get the product from moves, not sale order lines.

ping @sebalix @jbaudoux @TDu 