### PR TITLE
[14.0][IMP] sale_stock_mto_as_mts: add flag on warehouse

### DIFF
--- a/sale_stock_mto_as_mts_orderpoint/__manifest__.py
+++ b/sale_stock_mto_as_mts_orderpoint/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale Stock Mto As Mts Orderpoint",
     "summary": "Materialize need from MTO route through orderpoint",
-    "version": "14.0.1.0.4",
+    "version": "14.0.1.1.0",
     "development_status": "Alpha",
     "category": "Operations/Inventory/Delivery",
     "website": "https://github.com/OCA/stock-logistics-workflow",
@@ -14,5 +14,6 @@
     "depends": ["sale_stock", "stock_orderpoint_manual_procurement"],
     "data": [
         "data/stock_data.xml",
+        "views/stock_warehouse_views.xml",
     ],
 }

--- a/sale_stock_mto_as_mts_orderpoint/migrations/14.0.1.1.0/post-migrate.py
+++ b/sale_stock_mto_as_mts_orderpoint/migrations/14.0.1.1.0/post-migrate.py
@@ -1,0 +1,8 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute("UPDATE stock_warehouse set mto_as_mts = true;")

--- a/sale_stock_mto_as_mts_orderpoint/models/sale_order.py
+++ b/sale_stock_mto_as_mts_orderpoint/models/sale_order.py
@@ -30,6 +30,8 @@ class SaleOrderLine(models.Model):
                     and mto_route not in line.product_id.route_ids
                 ):
                     continue
+                if not delivery_move.warehouse_id.mto_as_mts:
+                    continue
                 orderpoint = line._get_mto_orderpoint(delivery_move.product_id)
                 if orderpoint.procure_recommended_qty:
                     orderpoints_to_procure_ids.append(orderpoint.id)

--- a/sale_stock_mto_as_mts_orderpoint/models/stock_warehouse.py
+++ b/sale_stock_mto_as_mts_orderpoint/models/stock_warehouse.py
@@ -1,11 +1,30 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo import models
+from odoo import fields, models
 
 
 class StockWarehouse(models.Model):
 
     _inherit = "stock.warehouse"
 
+    mto_as_mts = fields.Boolean(inverse="_inverse_mto_as_mts")
+
     def _get_locations_for_mto_orderpoints(self):
         return self.mapped("lot_stock_id")
+
+    def _inverse_mto_as_mts(self):
+        mto_route = self.env.ref("stock.route_warehouse0_mto", raise_if_not_found=False)
+        if not mto_route:
+            return
+        for warehouse in self:
+            if warehouse.mto_as_mts:
+                wh_mto_rules = self.env["stock.rule"].search(
+                    [
+                        ("route_id", "=", mto_route.id),
+                        "|",
+                        ("warehouse_id", "=", warehouse.id),
+                        ("picking_type_id.warehouse_id", "=", warehouse.id),
+                    ]
+                )
+                if wh_mto_rules:
+                    wh_mto_rules.active = False

--- a/sale_stock_mto_as_mts_orderpoint/readme/CONFIGURATION.rst
+++ b/sale_stock_mto_as_mts_orderpoint/readme/CONFIGURATION.rst
@@ -10,3 +10,6 @@ from Stock:
   the need is materialized by the procure_recommended_qty on the orderpoint,
   if the ensuing procurement (purchase order/manufacturing order) having the
   orderpoint as origin is canceled.
+
+To activate the functionality you need to activate the field `MTO as MTS` on
+the warehouse.

--- a/sale_stock_mto_as_mts_orderpoint/tests/test_sale_stock_mto_as_mts_orderpoint.py
+++ b/sale_stock_mto_as_mts_orderpoint/tests/test_sale_stock_mto_as_mts_orderpoint.py
@@ -24,7 +24,7 @@ class TestSaleStockMtoAsMtsOrderpoint(SavepointCase):
         )
 
         cls.warehouse = ref("stock.warehouse0")
-
+        cls.warehouse.mto_as_mts = True
         cls.mto_route = ref("stock.route_warehouse0_mto")
         cls.buy_route = ref("purchase_stock.route_warehouse0_buy")
         cls.product.write({"route_ids": [(6, 0, [cls.mto_route.id, cls.buy_route.id])]})

--- a/sale_stock_mto_as_mts_orderpoint/views/stock_warehouse_views.xml
+++ b/sale_stock_mto_as_mts_orderpoint/views/stock_warehouse_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="stock_warehouse_form_view_inherit" model='ir.ui.view'>
+        <field name="name">stock.warehouse.form.view.inherit</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="mto_as_mts" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add a flag `mto_as_mts`on the warehouse to activate the functionality of the module.

It will fix the interferences with other modules in the repository. And allows for better customization

This a backport from v16 improvements.