### PR TITLE
[14.0][FIX] sale_stock_mto_as_mts_orderpoint: fix orderpoint activation condition

### DIFF
--- a/sale_stock_mto_as_mts_orderpoint/models/sale_order.py
+++ b/sale_stock_mto_as_mts_orderpoint/models/sale_order.py
@@ -27,7 +27,7 @@ class SaleOrderLine(models.Model):
             for delivery_move in delivery_moves:
                 if (
                     not delivery_move.is_from_mto_route
-                    and mto_route not in line.product_id.route_ids
+                    and mto_route not in delivery_move.product_id.route_ids
                 ):
                     continue
                 orderpoint = line._get_mto_orderpoint(delivery_move.product_id)


### PR DESCRIPTION
When running orderpoints for mto products, we should ensure that move has been issued by an MTO product and that move's product is MTO.