### PR TITLE
[14.0][FIX] stock_picking_auto_create_package: Zero check on selecting product packaging

### DIFF
--- a/stock_picking_auto_create_package/models/stock_picking.py
+++ b/stock_picking_auto_create_package/models/stock_picking.py
@@ -38,11 +38,11 @@ class StockPicking(models.Model):
                     continue
                 qty_to_pack = move_line.qty_done
                 max_pack_qty = 1
-                packagings = move_line.product_id.packaging_ids
+                packagings = move_line.product_id.packaging_ids.filtered(
+                    lambda pack: pack.qty > 0
+                )
                 if packagings:
-                    smallest_packaging = packagings.filtered(
-                        lambda pack: pack.qty > 0
-                    ).sorted("qty")[0]
+                    smallest_packaging = packagings.sorted("qty")[0]
                     max_pack_qty = smallest_packaging.qty
                 while qty_to_pack:
                     pack_qty = min(qty_to_pack, max_pack_qty)

--- a/stock_picking_auto_create_package/tests/test_automatic_package.py
+++ b/stock_picking_auto_create_package/tests/test_automatic_package.py
@@ -100,3 +100,10 @@ class TestAutomaticPackage(SavepointCase):
         self.picking._action_done()
         self.assertTrue(self.picking.move_line_ids.result_package_id)
         self.assertTrue(len(self.picking.move_line_ids.result_package_id), 5)
+
+    def test_automatic_packaging_with_qty_zero_on_packaging(self):
+        self.picking.picking_type_id.automatic_package_creation_mode = "packaging"
+        self.product_packaging.qty = 0
+        self.picking._action_done()
+        self.assertTrue(self.picking.move_line_ids.result_package_id)
+        self.assertTrue(len(self.picking.move_line_ids.result_package_id), 5)


### PR DESCRIPTION
There was a obvious bug implemented with the last PR.
https://github.com/OCA/stock-logistics-workflow/pull/1702

With the additional check for 0. 

cc @jbaudoux @TDu 