### PR TITLE
[FIX] stock_owner_restriction : apply standard behaviour if picking_t…

### DIFF
--- a/stock_owner_restriction/models/stock_move.py
+++ b/stock_owner_restriction/models/stock_move.py
@@ -16,7 +16,8 @@ class StockMove(models.Model):
         those moves.
         """
         return self.filtered(
-            lambda m: m.picking_type_id.owner_restriction == "standard_behavior"
+            lambda m: not m.picking_type_id
+            or m.picking_type_id.owner_restriction == "standard_behavior"
         )
 
     def _get_owner_for_assign(self):


### PR DESCRIPTION
…ype_id is not set on stock move

This is making tests fail in PR #1560 : see https://github.com/OCA/stock-logistics-workflow/actions/runs/10963208625/job/30444169592?pr=1560#step:8:677

