### PR TITLE
[FIX] sale_global_stock_route: typo

### DIFF
--- a/sale_order_global_stock_route/views/sale_order_views.xml
+++ b/sale_order_global_stock_route/views/sale_order_views.xml
@@ -10,7 +10,6 @@
                      disappear  in v13. So we use the same group that route_id
                      field in sale order lines.
                  -->
-                <field name="route_id" groups="stock.group_adv_location" />
                 <field
                     name="route_id"
                     attrs="{'readonly': [('state', 'in', ('sale', 'done', 'cancel'))]}"


### PR DESCRIPTION
cc @rousseldenis 