### PR TITLE
[FIX] [16.0] stock_customer_deposit_sale_margin: Fix case when deposit is equal to product_uom_qty

### DIFF
--- a/stock_customer_deposit_sale_margin/README.rst
+++ b/stock_customer_deposit_sale_margin/README.rst
@@ -116,6 +116,7 @@ Contributors
 ------------
 
 -  Emilio Pascual (`Moduon <https://www.moduon.team/>`__)
+-  Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 -----------

--- a/stock_customer_deposit_sale_margin/readme/CONTRIBUTORS.md
+++ b/stock_customer_deposit_sale_margin/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 -   Emilio Pascual ([Moduon](https://www.moduon.team/))
+-   Eduardo de Miguel ([Moduon](https://www.moduon.team/))

--- a/stock_customer_deposit_sale_margin/static/description/index.html
+++ b/stock_customer_deposit_sale_margin/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -462,12 +463,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Emilio Pascual (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
+<li>Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/stock_customer_deposit_sale_margin/tests/test_stock_customer_deposit_sale_margin.py
+++ b/stock_customer_deposit_sale_margin/tests/test_stock_customer_deposit_sale_margin.py
@@ -28,7 +28,7 @@ class TestCustomeDepostiSaleMargin(TestStockCustomerDepositCommon):
         so_form.partner_id = self.partner1
         so_form.warehouse_id = self.warehouse
         product_qty_dict = {
-            self.productA: 50.0,
+            self.productA: 100.0,
             self.productB: 130.0,
             self.productC: 90.0,
         }


### PR DESCRIPTION
When quantities on deposit are equal to the product_uom_qty, doesn't set purchase_price to 0.0.

Fixed + refactor to view clearly all the cases

MT-6706 @moduon @Gelojr @fcvalgar @yajo @rafaelbn please review if you want.