### PR TITLE
[15.0][FIX] stock_force_assign_by_type: Hide forced reservation check box on the stock picking

### DIFF
--- a/stock_force_assign_by_type/views/stock_picking_views.xml
+++ b/stock_force_assign_by_type/views/stock_picking_views.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <field name="use_create_lots" position="after">
-                <field name="picking_type_force_reservation" />
+                <field name="picking_type_force_reservation" invisible="1" />
             </field>
             <!-- WARNING: The 'attrs' attributes of the 'do_unreserve' button and the
                 'forecast_availability' field are overridden in this view. This change


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/00286120-1f4f-4302-96cd-eb8d34f375ab)

cc @Tecnativa

@victoralmau @carlos-lopez-tecnativa please review