### PR TITLE
[14.0][FIX] stock_picking_invoice_link: inv duplication: copy false

### DIFF
--- a/stock_picking_invoice_link/models/account_move.py
+++ b/stock_picking_invoice_link/models/account_move.py
@@ -56,6 +56,7 @@ class AccountMoveLine(models.Model):
         column2="move_id",
         string="Related Stock Moves",
         readonly=True,
+        copy=False,
         help="Related stock moves "
         "(only when the invoice has been generated from a sale order).",
     )


### PR DESCRIPTION
When copying an invoice, the related stock move relations are currently being kept. I believe this is not the intended behavior