### PR TITLE
[16.0][IMP] stock_move_line_lock_qty_done: prevent test cases from other modules from failing

### DIFF
--- a/stock_move_line_lock_qty_done/README.rst
+++ b/stock_move_line_lock_qty_done/README.rst
@@ -28,8 +28,8 @@ Lock Done Quantity Changes in Stock Moves
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module limits the capability to modify the done quantity for stock moves
-once they have been validated.
+This module can limit the ability to modify the done quantity of stock moves once they are validated,
+configurable per company through the settings.
 
 **Table of contents**
 
@@ -39,8 +39,10 @@ once they have been validated.
 Configuration
 =============
 
-To configure this module, you need to add the users allowed to edit the done quntity
-for done moves to the group "Can edit done quantity for done stock moves"
+Update the following settings:
+
+* Go to *Inventory > Settings* and select the 'Limit Updates to Done Quantity After Validation' option to enable the restriction. This should be done for each company.
+* Add users who are allowed to edit the done quantity for done moves to the group 'Can edit done quantity for done stock moves'.
 
 Bug Tracker
 ===========
@@ -64,6 +66,9 @@ Contributors
 ~~~~~~~~~~~~
 
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu>
+* `Quartile <https://www.quartile.co>`_:
+
+  * Aung Ko Ko Lin
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_move_line_lock_qty_done/__manifest__.py
+++ b/stock_move_line_lock_qty_done/__manifest__.py
@@ -9,6 +9,8 @@
     "author": "ACSONE SA/NV, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "depends": ["stock"],
-    "data": ["security/res_groups.xml"],
-    "demo": [],
+    "data": [
+        "security/res_groups.xml",
+        "views/res_config_settings_views.xml",
+    ],
 }

--- a/stock_move_line_lock_qty_done/models/__init__.py
+++ b/stock_move_line_lock_qty_done/models/__init__.py
@@ -1,1 +1,3 @@
+from . import res_company
+from . import res_config_settings
 from . import stock_move_line

--- a/stock_move_line_lock_qty_done/models/res_company.py
+++ b/stock_move_line_lock_qty_done/models/res_company.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Quartile
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    lock_qty_done = fields.Boolean(
+        string="Limit Updates to Done Quantity After Validation",
+        help="Only users in the 'Can Edit Done Quantity for Done Stock Moves' group"
+        " are allowed to edit the 'done' quantity for validated transfer.",
+    )

--- a/stock_move_line_lock_qty_done/models/res_config_settings.py
+++ b/stock_move_line_lock_qty_done/models/res_config_settings.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Quartile
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    lock_qty_done = fields.Boolean(
+        related="company_id.lock_qty_done",
+        readonly=False,
+        string="Limit Updates to Done Quantity After Validation",
+        help="Only users in the 'Can Edit Done Quantity for Done Stock Moves' group"
+        " are allowed to edit the 'done' quantity for validated transfer.",
+    )

--- a/stock_move_line_lock_qty_done/models/stock_move_line.py
+++ b/stock_move_line_lock_qty_done/models/stock_move_line.py
@@ -16,7 +16,7 @@ class StockMoveLine(models.Model):
             "stock_move_line_lock_qty_done.group_stock_move_can_edit_done_qty"
         )
         for rec in self:
-            if rec.state != "done":
+            if rec.state != "done" or not rec.company_id.lock_qty_done:
                 continue
             if rec.is_locked:
                 raise UserError(

--- a/stock_move_line_lock_qty_done/readme/CONFIGURE.rst
+++ b/stock_move_line_lock_qty_done/readme/CONFIGURE.rst
@@ -1,2 +1,4 @@
-To configure this module, you need to add the users allowed to edit the done quntity
-for done moves to the group "Can edit done quantity for done stock moves"
+Update the following settings:
+
+* Go to *Inventory > Settings* and select the 'Limit Updates to Done Quantity After Validation' option to enable the restriction. This should be done for each company.
+* Add users who are allowed to edit the done quantity for done moves to the group 'Can edit done quantity for done stock moves'.

--- a/stock_move_line_lock_qty_done/readme/CONTRIBUTORS.rst
+++ b/stock_move_line_lock_qty_done/readme/CONTRIBUTORS.rst
@@ -1,1 +1,4 @@
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu>
+* `Quartile <https://www.quartile.co>`_:
+
+  * Aung Ko Ko Lin

--- a/stock_move_line_lock_qty_done/readme/DESCRIPTION.rst
+++ b/stock_move_line_lock_qty_done/readme/DESCRIPTION.rst
@@ -1,2 +1,2 @@
-This module limits the capability to modify the done quantity for stock moves
-once they have been validated.
+This module can limit the ability to modify the done quantity of stock moves once they are validated,
+configurable per company through the settings.

--- a/stock_move_line_lock_qty_done/static/description/index.html
+++ b/stock_move_line_lock_qty_done/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -370,8 +369,8 @@ ul.auto-toc {
 !! source digest: sha256:ddd0e3ea97313eb20b471c05dc1b1a8d0bf84fcfcf8367f9049daa3cb0ec3fc6
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/stock-logistics-workflow/tree/16.0/stock_move_line_lock_qty_done"><img alt="OCA/stock-logistics-workflow" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/stock-logistics-workflow-16-0/stock-logistics-workflow-16-0-stock_move_line_lock_qty_done"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/stock-logistics-workflow&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module limits the capability to modify the done quantity for stock moves
-once they have been validated.</p>
+<p>This module can limit the ability to modify the done quantity of stock moves once they are validated,
+configurable per company through the settings.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -387,8 +386,11 @@ once they have been validated.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
-<p>To configure this module, you need to add the users allowed to edit the done quntity
-for done moves to the group “Can edit done quantity for done stock moves”</p>
+<p>Update the following settings:</p>
+<ul class="simple">
+<li>Go to <em>Inventory &gt; Settings</em> and select the ‘Limit Updates to Done Quantity After Validation’ option to enable the restriction. This should be done for each company.</li>
+<li>Add users who are allowed to edit the done quantity for done moves to the group ‘Can edit done quantity for done stock moves’.</li>
+</ul>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
@@ -410,6 +412,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
 <li>Souheil Bejaoui &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_move_line_lock_qty_done/tests/test_stock_move_line_lock_qty_done.py
+++ b/stock_move_line_lock_qty_done/tests/test_stock_move_line_lock_qty_done.py
@@ -13,6 +13,7 @@ class TestStockMoveLineLockQtyDone(TransactionCase):
             [("state", "=", "assigned")], limit=1
         )
         cls.move_line = cls.assigned_picking.move_line_ids[0]
+        cls.env.company.sudo().lock_qty_done = True
 
     def test_0(self):
         self.assertEqual(self.assigned_picking.state, "assigned")

--- a/stock_move_line_lock_qty_done/views/res_config_settings_views.xml
+++ b/stock_move_line_lock_qty_done/views/res_config_settings_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_stock_config_settings" model="ir.ui.view">
+        <field name="name">res.config.settings</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='warning_info']" position="after">
+                <div class="col-12 col-lg-6 o_setting_box" id="lock_qty_done">
+                    <div class="o_setting_left_pane">
+                        <field name="lock_qty_done" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="lock_qty_done" />
+                        <div class="text-muted">
+                            Only users in the 'Can Edit Done Quantity for Done Stock Moves' group are allowed to edit the 'done' quantity for validated transfer.
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this PR, if we had other test cases that updated the done quantity after the transfer was done in our module, they would be blocked by `stock_move_line_lock_qty_done`. This PR addresses that issue.

@qrtl QT4650