### PR TITLE
[MIG] stock_no_negative: Migration to 18.0

### DIFF
--- a/stock_no_negative/views/product_product_views.xml
+++ b/stock_no_negative/views/product_product_views.xml
@@ -11,7 +11,10 @@
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">
             <field name="categ_id" position="after">
-                <field name="allow_negative_stock" invisible="type != 'product'" />
+                <field
+                    name="allow_negative_stock"
+                    invisible="type != 'consu' or is_storable == False"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
In Odoo v18, the handling of trackable (storable) products has been updated. This PR modifies the condition for displaying the allow_negative_stock field in the product.template form view.

Before Update:
The form view of product.template before applying the update:
![Screenshot from 2024-11-15 14-56-40](https://github.com/user-attachments/assets/569a73f6-12fc-4d56-a5d9-44d2ac72ecdc)

After Update:
The form view of product.template after applying the update:
![Screenshot from 2024-11-15 14-55-27](https://github.com/user-attachments/assets/0e0166b7-824c-45fc-adda-ec4fd1738b33)


