### PR TITLE
[FIX] allow_negative_stock field visibility in product form view

### DIFF
--- a/stock_no_negative/README.rst
+++ b/stock_no_negative/README.rst
@@ -89,28 +89,28 @@ Changelog
 16.0.1.0.0 (2022-10-22)
 -----------------------
 
--  [16.0][MIG] stock_no_negative
+- [16.0][MIG] stock_no_negative
 
 15.0.1.0.0 (2021-12-22)
 -----------------------
 
--  [15.0][MIG] stock_no_negative
+- [15.0][MIG] stock_no_negative
 
 14.0.1.0.0 (2020-12-14)
 -----------------------
 
--  [14.0][MIG] stock_no_negative
+- [14.0][MIG] stock_no_negative
 
 13.0.1.0.0 (2020-01-03)
 -----------------------
 
--  [13.0][MIG] stock_no_negative Remove all decorators @api.multi
+- [13.0][MIG] stock_no_negative Remove all decorators @api.multi
 
 11.0.1.1.0 (2018-12-13)
 -----------------------
 
--  Add the ability to allow negative stock for individual stock
-   locations.
+- Add the ability to allow negative stock for individual stock
+  locations.
 
 Bug Tracker
 ===========
@@ -133,34 +133,36 @@ Authors
 Contributors
 ------------
 
--  Alexis de Lattre <alexis.delattre@akretion.com>
+- Alexis de Lattre <alexis.delattre@akretion.com>
 
--  Vishnu Vanneri <vanneri.odoodev@gmail.com>
+- Vishnu Vanneri <vanneri.odoodev@gmail.com>
 
--  Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+- Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 
--  `ForgeFlow S.L. <contact@forgeflow.com>`__:
+- `ForgeFlow S.L. <contact@forgeflow.com>`__:
 
-   -  Jordi Ballester
-   -  Joan Mateu
+  - Jordi Ballester
+  - Joan Mateu
 
--  `Tecnativa <https://www.tecnativa.com>`__:
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-   -  Pedro M. Baeza
+  - Pedro M. Baeza
 
--  `Spacefoot <https://www.spacefoot.com>`__:
+- `Spacefoot <https://www.spacefoot.com>`__:
 
-   -  Quentin Delcourte
+  - Quentin Delcourte
 
--  Vishnu Vanneri <vvanneri@ioppolo.com.au>
+- Vishnu Vanneri <vvanneri@ioppolo.com.au>
 
--  `OERP Canada <https://www.oerp.ca/>`__:
+- `OERP Canada <https://www.oerp.ca/>`__:
 
-   -  Foram Darji <fd@oerp.ca>
+  - Foram Darji <fd@oerp.ca>
 
--  `Dynapps <https://www.dynapps.eu/>`__:
+- `Dynapps <https://www.dynapps.eu/>`__:
 
-   -  Bert Van Groenendael <bert.vangroenendael@dynapps.eu>
+  - Bert Van Groenendael <bert.vangroenendael@dynapps.eu>
+
+- Moaad Bourhim
 
 Maintainers
 -----------

--- a/stock_no_negative/readme/CONTRIBUTORS.md
+++ b/stock_no_negative/readme/CONTRIBUTORS.md
@@ -21,3 +21,5 @@
 
 - [Dynapps](https://www.dynapps.eu/):
   - Bert Van Groenendael \<<bert.vangroenendael@dynapps.eu>\>
+
+- Moaad Bourhim

--- a/stock_no_negative/static/description/index.html
+++ b/stock_no_negative/static/description/index.html
@@ -516,6 +516,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Bert Van Groenendael &lt;<a class="reference external" href="mailto:bert.vangroenendael&#64;dynapps.eu">bert.vangroenendael&#64;dynapps.eu</a>&gt;</li>
 </ul>
 </li>
+<li>Moaad Bourhim</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_no_negative/views/product_product_views.xml
+++ b/stock_no_negative/views/product_product_views.xml
@@ -11,7 +11,10 @@
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">
             <field name="categ_id" position="after">
-                <field name="allow_negative_stock" invisible="type != 'product'" />
+                <field
+                    name="allow_negative_stock"
+                    invisible="type != 'consu' or is_storable == False"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
In Odoo v18, the handling of trackable (storable) products has been updated. This PR modifies the condition for displaying the allow_negative_stock field in the product.template form view.

Before Update:
The form view of product.template before applying the update:
![Screenshot from 2024-11-15 14-56-40](https://github.com/user-attachments/assets/ad927326-bea1-4a2f-87e7-ccaa66c4a69b)

After Update:
The form view of product.template after applying the update:
![Screenshot from 2024-11-15 14-55-27](https://github.com/user-attachments/assets/28657dca-4d5b-49c6-a380-bc6f2ac9b454)

