### PR TITLE
[FIX] stock_restrict_lot : _rollup_not_cancelled_move_origs call itself

### DIFF
--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -125,7 +125,7 @@ class StockMove(models.Model):
         for dst in self.move_orig_ids:
             if dst.id not in seen and dst.state != "cancel":
                 seen.add(dst.id)
-                dst._rollup_move_origs(seen)
+                dst._rollup_not_cancelled_move_origs(seen)
         return seen
 
     def write(self, vals):


### PR DESCRIPTION
fix recursive call to search all uncancelled origin moves, including done moves