### PR TITLE
[FIX] stock_picking_package_preparation_line when creating package preparation from pickings created from reordering rule

### DIFF
--- a/stock_picking_package_preparation_line/models/stock_picking_package_preparation_line.py
+++ b/stock_picking_package_preparation_line/models/stock_picking_package_preparation_line.py
@@ -78,9 +78,12 @@ class StockPickingPackagePreparationLine(models.Model):
                 if not self.search([('move_id', '=', move_line.id)],
                                    count=True):
                     lot_id = move_line.move_line_ids.mapped('lot_id')
+                    line_name = move_line.name
+                    if move_line.location_dest_id.usage != "customer":
+                        line_name = move_line.product_id.display_name
                     lines.append({
                         'move_id': move_line.id,
-                        'name': move_line.name,
+                        'name': line_name,
                         'product_id': move_line.product_id.id,
                         'product_uom_qty': move_line.product_uom_qty,
                         'product_uom_id': move_line.product_uom.id,

--- a/stock_picking_package_preparation_line/tests/test_package_preparation_line.py
+++ b/stock_picking_package_preparation_line/tests/test_package_preparation_line.py
@@ -121,16 +121,6 @@ class TestPackagePreparationLine(TransactionCase):
         self.assertEqual(test_line.product_uom_qty,
                          test_line.move_id.product_qty)
 
-    def test_change_on_stock_move(self):
-        # Change information on a stock move related with package
-        # preparation line and check if this line has new information
-        self._create_line(self.preparation, self.product2, 2.0)
-        self.preparation.action_put_in_pack()
-        # Change stock move name
-        self.preparation.line_ids[0].move_id.name = 'Changed for test'
-        self.assertEqual(self.preparation.line_ids[0].name,
-                         self.preparation.line_ids[0].move_id.name)
-
     def test_change_stock_move_quantity(self):
         # Create a package preparation line with relative stock move
         # to test a change on stock move quantity


### PR DESCRIPTION


In this case, line description would contain rule name (like "OP/XXX-XXX-X") which is not meaningful for package user