### PR TITLE
[IMP] [16.0] stock_customer_deposit: Allow to add more deposits of the same product

### DIFF
--- a/stock_customer_deposit/README.rst
+++ b/stock_customer_deposit/README.rst
@@ -32,6 +32,9 @@ This module extends the functionality of the consignment stock to
 support customer deposits and allows the management of customer deposits
 in warehouses.
 
+Lines that consume customer deposits will have a 100% discount.
+Otherwise, they will use the discount rules provided by Odoo.
+
 It is possible to activate the use of customer deposits per warehouse.
 This will allow the use of an operation type and a route to create
 customer deposits in the warehouse.
@@ -80,15 +83,16 @@ Create Customer deposits:
 3.  Activate **customer deposit** in quotation.
 4.  Add storable product in order lines.
 5.  Add quantity you will keep as a deposit.
-6.  *Confirm* quotation.
-7.  Sale is now ready for invoicing.
-8.  A picking will be created. This picking is an operation Customer
+6.  Discount will be applied following Odoo rules.
+7.  *Confirm* quotation.
+8.  Sale is now ready for invoicing.
+9.  A picking will be created. This picking is an operation Customer
     Deposit and it's **internal** operation.
-9.  Click on smart button with delivery.
-10. Set quantity done in operations or click on **Set Quantities**.
-11. Update location destination if it's necessary in operations
+10. Click on smart button with delivery.
+11. Set quantity done in operations or click on **Set Quantities**.
+12. Update location destination if it's necessary in operations
     detailed.
-12. Click on **Validate**.
+13. Click on **Validate**.
 
 View Customer deposits:
 
@@ -170,10 +174,13 @@ promote its widespread use.
 .. |maintainer-EmilioPascual| image:: https://github.com/EmilioPascual.png?size=40px
     :target: https://github.com/EmilioPascual
     :alt: EmilioPascual
+.. |maintainer-Shide| image:: https://github.com/Shide.png?size=40px
+    :target: https://github.com/Shide
+    :alt: Shide
 
 Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-rafaelbn| |maintainer-EmilioPascual| 
+|maintainer-rafaelbn| |maintainer-EmilioPascual| |maintainer-Shide| 
 
 This module is part of the `OCA/stock-logistics-workflow <https://github.com/OCA/stock-logistics-workflow/tree/16.0/stock_customer_deposit>`_ project on GitHub.
 

--- a/stock_customer_deposit/__manifest__.py
+++ b/stock_customer_deposit/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Inventory/Delivery",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "author": "Moduon, Odoo Community Association (OCA)",
-    "maintainers": ["rafaelbn", "EmilioPascual"],
+    "maintainers": ["rafaelbn", "EmilioPascual", "Shide"],
     "license": "LGPL-3",
     "application": False,
     "installable": True,

--- a/stock_customer_deposit/i18n/es.po
+++ b/stock_customer_deposit/i18n/es.po
@@ -1,21 +1,21 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* stock_customer_deposits
+# 	* stock_customer_deposit
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0+e\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-11 11:27+0000\n"
-"PO-Revision-Date: 2024-03-11 12:28+0100\n"
-"Last-Translator: Emilio Pascual <emilio@moduom.team>\n"
+"POT-Creation-Date: 2024-11-25 09:30+0000\n"
+"PO-Revision-Date: 2024-11-25 10:30+0100\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #. module: stock_customer_deposit
 #. odoo-python
@@ -35,12 +35,8 @@ msgstr "%s Secuencia depósito cliente"
 #. odoo-python
 #: code:addons/stock_customer_deposit/models/sale_order.py:0
 #, python-format
-msgid ""
-"All lines coming from orders marked as 'Customer depot' must have Customer "
-"deposit route."
-msgstr ""
-"Todas las líneas de los pedidos marcados como 'Depósito de cliente' debe "
-"tener la ruta 'Depósito de Cliente\"."
+msgid "All lines coming from orders marked as 'Customer depot' must have Customer deposit route."
+msgstr "Todas las líneas de los pedidos marcados como 'Depósito de cliente' debe tener la ruta 'Depósito de Cliente\"."
 
 #. module: stock_customer_deposit
 #: model:ir.model.fields,field_description:stock_customer_deposit.field_stock_picking_type__assign_owner
@@ -79,8 +75,7 @@ msgstr "Tipo operación Depósito de Cliente"
 
 #. module: stock_customer_deposit
 #. odoo-python
-#: code:addons/stock_customer_deposit/models/res_partner.py:0
-#: code:addons/stock_customer_deposit/models/sale_order.py:0
+#: code:addons/stock_customer_deposit/models/res_partner.py:0 code:addons/stock_customer_deposit/models/sale_order.py:0
 #: code:addons/stock_customer_deposit/models/sale_order_line.py:0
 #: model_terms:ir.ui.view,arch_db:stock_customer_deposit.view_order_form_inherit_customer_deposit
 #: model_terms:ir.ui.view,arch_db:stock_customer_deposit.view_sales_order_filter_inherit_stock_customer_deposit
@@ -108,15 +103,18 @@ msgstr "Depósitos"
 
 #. module: stock_customer_deposit
 #: model:ir.model.fields,help:stock_customer_deposit.field_stock_picking_type__assign_owner
-msgid ""
-"If checked, the owner of the picking will be the partner of the picking."
-msgstr ""
-"Si está marcado, el propietario del albarán será el contacto del albarán."
+msgid "If checked, the owner of the picking will be the partner of the picking."
+msgstr "Si está marcado, el propietario del albarán será el contacto del albarán."
 
 #. module: stock_customer_deposit
 #: model:ir.model,name:stock_customer_deposit.model_stock_picking_type
 msgid "Picking Type"
-msgstr "Tipo de operación"
+msgstr "Tipo de albarán"
+
+#. module: stock_customer_deposit
+#: model:ir.model,name:stock_customer_deposit.model_stock_move_line
+msgid "Product Moves (Stock Move Line)"
+msgstr "Movimientos de Producto (Stock Move Line)"
 
 #. module: stock_customer_deposit
 #: model:ir.model,name:stock_customer_deposit.model_product_product
@@ -136,7 +134,7 @@ msgstr "Cantidad del producto disponible del depósito del cliente."
 #. module: stock_customer_deposit
 #: model:ir.model,name:stock_customer_deposit.model_stock_quant
 msgid "Quants"
-msgstr "Existencia"
+msgstr ""
 
 #. module: stock_customer_deposit
 #: model:ir.model.fields,field_description:stock_customer_deposit.field_sale_order_line__route_id
@@ -151,12 +149,17 @@ msgstr "Pedido de venta"
 #. module: stock_customer_deposit
 #: model:ir.model,name:stock_customer_deposit.model_sale_order_line
 msgid "Sales Order Line"
-msgstr "Línea de pedido de venta"
+msgstr "Línea de Orden de Venta"
 
 #. module: stock_customer_deposit
 #: model:ir.model,name:stock_customer_deposit.model_stock_move
 msgid "Stock Move"
 msgstr "Movimiento de existencias"
+
+#. module: stock_customer_deposit
+#: model:ir.model,name:stock_customer_deposit.model_stock_rule
+msgid "Stock Rule"
+msgstr "Regla de Inventario"
 
 #. module: stock_customer_deposit
 #: model:ir.model,name:stock_customer_deposit.model_stock_picking
@@ -178,36 +181,17 @@ msgstr "Almacén"
 #. odoo-python
 #: code:addons/stock_customer_deposit/models/sale_order.py:0
 #, python-format
-msgid ""
-"You can't add more than the quantity of %(product)s from the customer's "
-"deposit. If the customer wants more, create a new order after confirming "
-"this one."
+msgid "You cannot select Customer Deposit route in an order line if you do not mark the order as a customer depot."
 msgstr ""
-"No puede añadir más cantidad del producto %(product)s del depósito de "
-"cliente. Si el cliente quiere más, cree un nuevo pedido después de confirmar "
-"este."
+"No puede seleccionar la ruta Depósito de cliente en una línea de pedido si no marca el pedido como depósito de cliente."
 
 #. module: stock_customer_deposit
 #. odoo-python
 #: code:addons/stock_customer_deposit/models/sale_order.py:0
 #, python-format
 msgid ""
-"You can't use customer deposit for products with the route 'Customer "
-"Deposit'."
+"You're trying to sell more than what's available in the customer's deposit for '%(product)s'.\n"
+"You can either adjust the quantity to fit what's available or create a new order to increase the deposit before proceeding."
 msgstr ""
-"No puede usar Depósito de cliente para productos con la ruta 'Depósito de "
-"cliente'."
-
-#. module: stock_customer_deposit
-#. odoo-python
-#: code:addons/stock_customer_deposit/models/sale_order.py:0
-#, python-format
-msgid ""
-"You cannot select Customer Deposit route in an order line if you do not mark "
-"the order as a customer depot."
-msgstr ""
-"No puede seleccionar la ruta Depósito de cliente en una línea de pedido si "
-"no marca el pedido como depósito de cliente."
-
-#~ msgid "Deposit Availiable Qty"
-#~ msgstr "Cantidad de depósito disponible"
+"Estás intentando vender más de lo que hay disponible en el depósito del cliente para '%(product)s'.\n"
+"Puedes ajustar la cantidad a lo disponible o crear un nuevo pedido para aumentar el depósito antes de continuar."

--- a/stock_customer_deposit/i18n/stock_customer_deposit.pot
+++ b/stock_customer_deposit/i18n/stock_customer_deposit.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-25 09:29+0000\n"
+"PO-Revision-Date: 2024-11-25 09:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -183,25 +185,15 @@ msgstr ""
 #: code:addons/stock_customer_deposit/models/sale_order.py:0
 #, python-format
 msgid ""
-"You can't add more than the quantity of %(product)s from the customer's "
-"deposit. If the customer wants more, create a new order after confirming "
-"this one."
-msgstr ""
-
-#. module: stock_customer_deposit
-#. odoo-python
-#: code:addons/stock_customer_deposit/models/sale_order.py:0
-#, python-format
-msgid ""
-"You can't use customer deposit for products with the route 'Customer "
-"Deposit'."
-msgstr ""
-
-#. module: stock_customer_deposit
-#. odoo-python
-#: code:addons/stock_customer_deposit/models/sale_order.py:0
-#, python-format
-msgid ""
 "You cannot select Customer Deposit route in an order line if you do not mark"
 " the order as a customer depot."
+msgstr ""
+
+#. module: stock_customer_deposit
+#. odoo-python
+#: code:addons/stock_customer_deposit/models/sale_order.py:0
+#, python-format
+msgid ""
+"You're trying to sell more than what's available in the customer's deposit for '%(product)s'.\n"
+"You can either adjust the quantity to fit what's available or create a new order to increase the deposit before proceeding."
 msgstr ""

--- a/stock_customer_deposit/models/sale_order.py
+++ b/stock_customer_deposit/models/sale_order.py
@@ -71,9 +71,11 @@ class SaleOrder(models.Model):
                 ):
                     raise ValidationError(
                         _(
-                            "You can't add more than the quantity of %(product)s"
-                            " from the customer's deposit. If the customer wants"
-                            " more, create a new order after confirming this one.",
+                            "You're trying to sell more than what's available "
+                            "in the customer's deposit for '%(product)s'.\n"
+                            "You can either adjust the quantity to fit what's "
+                            "available or create a new order to increase the "
+                            "deposit before proceeding.",
                             product=product.name,
                         )
                     )

--- a/stock_customer_deposit/models/sale_order_line.py
+++ b/stock_customer_deposit/models/sale_order_line.py
@@ -3,6 +3,7 @@
 
 
 from odoo import _, api, fields, models
+from odoo.tools import float_compare
 
 
 class SaleOrderLine(models.Model):
@@ -67,15 +68,42 @@ class SaleOrderLine(models.Model):
             line.deposit_allowed_qty = line.deposit_available_qty - line.product_uom_qty
 
     @api.depends(
-        "product_id", "product_uom", "product_uom_qty", "deposit_available_qty"
+        "product_id",
+        "product_uom",
+        "product_uom_qty",
+        "deposit_available_qty",
+        "warehouse_id.use_customer_deposits",
+        "order_id.customer_deposit",
+        "pricelist_item_id",
+        "order_id.pricelist_id",
     )
     def _compute_discount(self):
-        """Set discount to 100% if use_customer_deposit is True
-        because customer paid before for them."""
+        """Apply 100% discount when customer is taking from customer deposit"""
         res = super()._compute_discount()
         for line in self:
-            if line.deposit_available_qty:
-                line.discount = 100.0
+            if (
+                line.warehouse_id.use_customer_deposits
+                and line.product_id.type == "product"
+            ):
+                if line.order_id.customer_deposit:
+                    # Customer deposit: Pricelist choose the price and discount
+                    pricelist = (
+                        line.pricelist_item_id.pricelist_id
+                        or line.order_id.pricelist_id
+                    )
+                    if pricelist.discount_policy == "with_discount":
+                        line.discount = 0.0
+                    continue
+
+                if (
+                    float_compare(
+                        line.deposit_available_qty,
+                        0.0,
+                        precision_rounding=line.product_id.uom_id.rounding,
+                    )
+                    > 0
+                ):
+                    line.discount = 100.0
         return res
 
     @api.depends("qty_invoiced", "qty_delivered", "product_uom_qty", "state")

--- a/stock_customer_deposit/models/sale_order_line.py
+++ b/stock_customer_deposit/models/sale_order_line.py
@@ -28,6 +28,7 @@ class SaleOrderLine(models.Model):
         "product_id", "warehouse_id.use_customer_deposits", "order_id.customer_deposit"
     )
     def _compute_route_id(self):
+        """Set route_id to customer deposit route if use_customer_deposits is True"""
         for line in self:
             line.route_id = (
                 line.warehouse_id.customer_deposit_route_id

--- a/stock_customer_deposit/models/stock_quant.py
+++ b/stock_customer_deposit/models/stock_quant.py
@@ -4,6 +4,7 @@
 
 from odoo import api, models
 from odoo.osv import expression
+from odoo.tools import float_compare
 
 
 class StockQuant(models.Model):
@@ -47,7 +48,9 @@ class StockQuant(models.Model):
         owner_id=None,
         in_date=None,
     ):
-        if quantity > 0 and self.env.context.get("owner", False):
+        if float_compare(
+            quantity, 0.0, precision_rounding=product_id.uom_id.rounding
+        ) > 0 and self.env.context.get("owner", False):
             owner_id = (
                 owner_id
                 or self.env["res.partner"].browse(self.env.context.get("owner"))

--- a/stock_customer_deposit/readme/DESCRIPTION.md
+++ b/stock_customer_deposit/readme/DESCRIPTION.md
@@ -1,3 +1,5 @@
 This module extends the functionality of the consignment stock to support customer deposits and allows the management of customer deposits in warehouses.
 
+Lines that consume customer deposits will have a 100% discount. Otherwise, they will use the discount rules provided by Odoo.
+
 It is possible to activate the use of customer deposits per warehouse. This will allow the use of an operation type and a route to create customer deposits in the warehouse.

--- a/stock_customer_deposit/readme/USAGE.md
+++ b/stock_customer_deposit/readme/USAGE.md
@@ -7,13 +7,14 @@ Create Customer deposits:
 3. Activate **customer deposit** in quotation.
 4. Add storable product in order lines.
 5. Add quantity you will keep as a deposit.
-6. *Confirm* quotation.
-7. Sale is now ready for invoicing.
-8. A picking will be created. This picking is an operation Customer Deposit and it's **internal** operation.
-9. Click on smart button with delivery.
-10. Set quantity done in operations or click on **Set Quantities**.
-11. Update location destination if it's necessary in operations detailed.
-12. Click on **Validate**.
+6. Discount will be applied following Odoo rules.
+7. *Confirm* quotation.
+8. Sale is now ready for invoicing.
+9. A picking will be created. This picking is an operation Customer Deposit and it's **internal** operation.
+10. Click on smart button with delivery.
+11. Set quantity done in operations or click on **Set Quantities**.
+12. Update location destination if it's necessary in operations detailed.
+13. Click on **Validate**.
 
 View Customer deposits:
 

--- a/stock_customer_deposit/static/description/index.html
+++ b/stock_customer_deposit/static/description/index.html
@@ -373,6 +373,8 @@ ul.auto-toc {
 <p>This module extends the functionality of the consignment stock to
 support customer deposits and allows the management of customer deposits
 in warehouses.</p>
+<p>Lines that consume customer deposits will have a 100% discount.
+Otherwise, they will use the discount rules provided by Odoo.</p>
 <p>It is possible to activate the use of customer deposits per warehouse.
 This will allow the use of an operation type and a route to create
 customer deposits in the warehouse.</p>
@@ -428,6 +430,7 @@ to the customer at a later date.</p>
 <li>Activate <strong>customer deposit</strong> in quotation.</li>
 <li>Add storable product in order lines.</li>
 <li>Add quantity you will keep as a deposit.</li>
+<li>Discount will be applied following Odoo rules.</li>
 <li><em>Confirm</em> quotation.</li>
 <li>Sale is now ready for invoicing.</li>
 <li>A picking will be created. This picking is an operation Customer
@@ -510,7 +513,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/rafaelbn"><img alt="rafaelbn" src="https://github.com/rafaelbn.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/EmilioPascual"><img alt="EmilioPascual" src="https://github.com/EmilioPascual.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/rafaelbn"><img alt="rafaelbn" src="https://github.com/rafaelbn.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/EmilioPascual"><img alt="EmilioPascual" src="https://github.com/EmilioPascual.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/Shide"><img alt="Shide" src="https://github.com/Shide.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/stock-logistics-workflow/tree/16.0/stock_customer_deposit">OCA/stock-logistics-workflow</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/stock_customer_deposit/tests/test_sale_customer_deposit.py
+++ b/stock_customer_deposit/tests/test_sale_customer_deposit.py
@@ -28,6 +28,16 @@ class TestSaleCustomerDeposits(TestStockCustomerDepositCommon):
                 cls.productB: 110,
             },
         }
+        cls.result_test_second_deposit = {
+            False: {
+                cls.productA: 100,
+                cls.productB: 80,
+            },
+            cls.partner1: {
+                cls.productA: 200,
+                cls.productB: 220,
+            },
+        }
 
     @users("user_customer_deposit")
     def test_sale_customer_deposit(self):
@@ -107,6 +117,23 @@ class TestSaleCustomerDeposits(TestStockCustomerDepositCommon):
                         product, self.warehouse.lot_stock_id, owner_id=partner
                     ),
                     quantity,
+                    "First deposit not added correctly",
+                )
+        # Add another order to deposit
+        so_2 = so.copy()
+        so_2.action_confirm()
+        so_2.picking_ids.action_confirm()
+        so_2.picking_ids.action_assign()
+        so_2.picking_ids.action_set_quantities_to_reservation()
+        so_2.picking_ids.button_validate()
+        for partner, products in self.result_test_second_deposit.items():
+            for product, quantity in products.items():
+                self.assertEqual(
+                    self.env["stock.quant"]._get_available_quantity(
+                        product, self.warehouse.lot_stock_id, owner_id=partner
+                    ),
+                    quantity,
+                    "Second deposit not added correctly",
                 )
 
     @users("user_customer_deposit")

--- a/stock_customer_deposit/views/sale_order_views.xml
+++ b/stock_customer_deposit/views/sale_order_views.xml
@@ -34,7 +34,7 @@
                 />
             </xpath>
             <xpath
-                expr="//field[@name='order_line']/tree//field[@name='price_unit']"
+                expr="//field[@name='order_line']/tree//field[@name='product_uom']"
                 position="before"
             >
                 <field name="deposit_available_qty" invisible="1" />
@@ -42,7 +42,7 @@
                 <button
                     name="action_view_customer_deposits"
                     type="object"
-                    icon="fa-cubes"
+                    icon="fa-cubes text-primary"
                     title="Customer Deposits"
                     width="20px"
                     aria-label="Customer Deposits"
@@ -51,13 +51,12 @@
                 <button
                     name="action_view_customer_deposits"
                     type="object"
-                    icon="fa-cubes"
-                    class="text-danger"
+                    icon="fa-cubes text-danger"
                     title="Customer Deposits"
                     width="20px"
                     aria-label="Customer Deposits"
                     attrs="{'invisible': ['|', ('deposit_available_qty', '&lt;=', 0),('deposit_allowed_qty', '&gt;=', 0)], 'column_invisible': ['|', ('parent.state', 'not in', ('draft', 'sent')), ('parent.customer_deposit_count', '=', 0)]}"
-                    groups="sales_team.group_sale_manager,stock.group_stock_user"
+                    groups="stock.group_tracking_owner,stock.group_stock_user"
                 />
             </xpath>
             <xpath


### PR DESCRIPTION
Allows to add more deposits of the same product even if the customer already have a deposit.

Major refactoring in:
- `sale_order._check_can_customer_deposit` to perform the check all at once + simplified `sale_order._action_confirm`
- `stock_move._action_assign` to split casuistic and have a better control over the moves.
- `float_compare` when it's necessary

MT-7979 @moduon @EmilioPascual @rafaelbn @yajo @Gelojr @fcvalgar please review if you want :)