### PR TITLE
[16.0][IMP] stock_picking_mass_action: imp reservation logic from odoo base

### DIFF
--- a/stock_picking_mass_action/models/stock_picking.py
+++ b/stock_picking_mass_action/models/stock_picking.py
@@ -2,23 +2,35 @@
 # Copyright 2018 Tecnativa - Vicent Cubells
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+
 from odoo import _, api
 from odoo.models import Model
+from odoo.osv import expression
 
 
 class StockPicking(Model):
     _inherit = "stock.picking"
 
     @api.model
-    def check_assign_all(self, domain=None):
+    def check_assign_all(self, domain=None, batch_size=False, company=None):
         """Try to assign confirmed pickings"""
-        search_domain = [("state", "=", "confirmed")]
+        if not batch_size:
+            batch_size = 1000
+        move_assign_domain = self.env["procurement.group"]._get_moves_to_assign_domain(
+            company
+        )
         if domain:
-            search_domain += domain
-        else:
-            search_domain += [("picking_type_code", "=", "outgoing")]
-        records = self.search(search_domain, order="scheduled_date")
-        records.action_assign()
+            move_assign_domain = expression.AND([domain, move_assign_domain])
+
+        moves_to_assign = self.env["stock.move"].search(
+            move_assign_domain,
+            limit=None,
+            order="reservation_date, priority desc, date asc, id asc",
+        )
+        total_items = len(moves_to_assign)
+        for i in range(0, total_items, batch_size):
+            batch = moves_to_assign[i : i + batch_size]
+            self.env["stock.move"].browse(batch.ids).sudo()._action_assign()
 
     def action_immediate_transfer_wizard(self):
         view = self.env.ref("stock.view_immediate_transfer")

--- a/stock_picking_mass_action/tests/test_mass_action.py
+++ b/stock_picking_mass_action/tests/test_mass_action.py
@@ -1,6 +1,9 @@
 # Copyright 2018 Tecnativa - Vicent Cubells
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from datetime import timedelta
+
+from odoo import fields
 from odoo.tests import common
 
 
@@ -20,7 +23,7 @@ class TestMassAction(common.TransactionCase):
             {
                 "product_id": product.id,
                 "location_id": stock_location.id,
-                "quantity": 600.0,
+                "quantity": 900,
             }
         )
         # Force Odoo not to automatically reserve the products on the pickings
@@ -51,6 +54,9 @@ class TestMassAction(common.TransactionCase):
         )
 
     def test_mass_action(self):
+        """
+        Test manual assignment of pickings
+        """
         self.assertEqual(self.picking.state, "draft")
         wiz = self.env["stock.picking.mass.action"]
         # We test confirming a picking
@@ -80,10 +86,10 @@ class TestMassAction(common.TransactionCase):
         wiz_confirm.mass_action()
         self.assertEqual(pick1.state, "confirmed")
         self.assertEqual(pick2.state, "confirmed")
+        # Confirm pickings are not assigned automatically
         pickings.check_assign_all()
-        self.assertEqual(pick1.state, "assigned")
-        self.assertEqual(pick2.state, "assigned")
-
+        self.assertEqual(pick1.state, "confirmed")
+        self.assertEqual(pick2.state, "confirmed")
         pick3 = self.picking.copy()
         pickings |= pick3
         pick4 = self.picking.copy()
@@ -95,9 +101,69 @@ class TestMassAction(common.TransactionCase):
         wiz_confirm.mass_action()
         self.assertEqual(pick3.state, "confirmed")
         self.assertEqual(pick4.state, "confirmed")
-        pickings.check_assign_all(domain=[("picking_type_code", "=", "outgoing")])
+        pickings.check_assign_all(domain=[("picking_code", "=", "outgoing")])
+        self.assertEqual(pick3.state, "confirmed")
+        self.assertEqual(pick4.state, "confirmed")
+        # Confirm pickings are assigned manually
+        pick1.action_assign()
+        pick2.action_assign()
         self.assertEqual(pick1.state, "assigned")
         self.assertEqual(pick2.state, "assigned")
+        pick3.action_assign()
+        pick4.action_assign()
+        self.assertEqual(pick3.state, "assigned")
+        self.assertEqual(pick4.state, "assigned")
+
+    def test_at_confirm_reservation(self):
+        """
+        Test automatically reservation at picking confirmation
+        """
+        # Set at_confirm method
+        self.env.ref("stock.picking_type_out").write(
+            {"reservation_method": "at_confirm"}
+        )
+        self.assertEqual(self.picking.state, "draft")
+        for line in self.picking.move_ids:
+            self.assertEqual(line.state, "draft")
+        self.picking.action_confirm()
+        self.assertEqual(self.picking.state, "assigned")
+        for line in self.picking.move_ids:
+            self.assertEqual(line.state, "assigned")
+            self.assertEqual(line.reserved_availability, 200.0)
+
+    def test_mass_action_by_date(self):
+        """
+        Test automatically reservation by date
+        """
+        # Set by date method
+        self.env.ref("stock.picking_type_out").write(
+            {"reservation_method": "by_date", "reservation_days_before": 4}
+        )
+        self.assertEqual(self.picking.state, "draft")
+        wiz = self.env["stock.picking.mass.action"]
+        # We test checking assign all with "by date" method
+        pickings = self.env["stock.picking"]
+        pickOutDate = self.picking.copy()
+        # Set scheduled date out of the range of 4 days
+        pickOutDate.scheduled_date = fields.Date.today() + timedelta(days=15)
+        pickings |= pickOutDate
+        pickInDate = self.picking.copy()
+        pickings |= pickInDate
+        self.assertEqual(pickOutDate.state, "draft")
+        self.assertEqual(pickInDate.state, "draft")
+        wiz_confirm = wiz.create(
+            {"picking_ids": [(6, 0, [pickOutDate.id, pickInDate.id])]}
+        )
+        wiz_confirm.confirm = True
+        wiz_confirm.mass_action()
+        self.assertEqual(pickOutDate.state, "confirmed")
+        self.assertEqual(pickInDate.state, "assigned")
+        pickings.check_assign_all()
+        self.assertEqual(pickOutDate.state, "confirmed")
+        # Change scheduled date in the range of 4 days
+        pickOutDate.scheduled_date = fields.Date.today() + timedelta(days=1)
+        pickings.check_assign_all()
+        self.assertEqual(pickOutDate.state, "assigned")
 
     def test_mass_action_inmediate_transfer(self):
         wiz_tranfer = self.env["stock.picking.mass.action"].create(


### PR DESCRIPTION
The check_assign_all() method in the stock.picking model of the stock_picking_mass_action module has been enhanced to align with Odoo's stock reservation logic.

Changes implemented:
- Assignement at stock.move level:
    - Availability checks now respect the domain defined by Odoo's scheduler logic.
- Custom domain
    - The planned action accepts a configurable domain(at stock.move level)t o adapt the movements to be processed
- Batch processing
    - Added support for processing moves in configurable batches, with a default size of 1000