### PR TITLE
[16.0][FIX] stock_picking_return_restricted_qty: remove _onchange_quantity method

### DIFF
--- a/stock_picking_return_restricted_qty/tests/test_stock_picking_return_restricted_qty.py
+++ b/stock_picking_return_restricted_qty/tests/test_stock_picking_return_restricted_qty.py
@@ -102,7 +102,7 @@ class StockPickingReturnRestrictedQtyTest(common.TransactionCase):
 
         wiz.product_return_moves.quantity = 80
         with self.assertRaises(UserError):
-            wiz.product_return_moves._onchange_quantity()
+            wiz._create_returns()
 
     def test_multiple_return_without_restriction(self):
         """On this test we are going to follow a sequence that a client
@@ -122,5 +122,5 @@ class StockPickingReturnRestrictedQtyTest(common.TransactionCase):
         self.assertEqual(wiz.product_return_moves.quantity, 10)
 
         wiz.product_return_moves.quantity = 80
-        wiz.product_return_moves._onchange_quantity()
+        wiz._create_returns()
         self.assertEqual(wiz.product_return_moves.quantity, 80)

--- a/stock_picking_return_restricted_qty/wizard/stock_picking_return.py
+++ b/stock_picking_return_restricted_qty/wizard/stock_picking_return.py
@@ -49,7 +49,11 @@ class ReturnPickingLine(models.TransientModel):
         qty = self.get_returned_restricted_quantity(self.move_id)
 
         if restrict_return_qty and self.quantity > qty:
-            raise UserError(_("Return more quantities than delivered is not allowed."))
+            warning = {
+                "title": ("Warning!"),
+                "message": ("Return more quantities than delivered is not allowed."),
+            }
+            return {"warning": warning}
 
     def get_returned_restricted_quantity(self, stock_move):
         """This function is created to know how many products


### PR DESCRIPTION
This fix replaces the UserError in _onchange_quantity with a warning message. Now, users receive a non-blocking notification when attempting to return more products that delivered, but allows them to modify the quantity before proceeding.

The restriction logic remains unchanged for _create_returns, ensuring hard enforcement at the validation stage.

- Improves UX by preventing unnecessary hard errors on simple mistakes.
- Maintains the business rule enforcement while allowing users to correct their input easily.
