### PR TITLE
[16.0][FIX] stock_picking_restrict_cancel_printed: fix no backorder

### DIFF
--- a/stock_picking_restrict_cancel_printed/models/stock_move.py
+++ b/stock_picking_restrict_cancel_printed/models/stock_move.py
@@ -9,6 +9,9 @@ class StockMove(models.Model):
     _inherit = "stock.move"
 
     def _action_cancel(self):
+        # if picking_type create_backorder is never, then move is canceled on action_done
+        if self.env.context.get("cancel_backorder"):
+            return super()._action_cancel()
         for move in self:
             if (
                 move.picking_id.printed

--- a/stock_picking_restrict_cancel_printed/tests/test_stock_picking_restrict_cancel_printed.py
+++ b/stock_picking_restrict_cancel_printed/tests/test_stock_picking_restrict_cancel_printed.py
@@ -28,7 +28,7 @@ class TestPickingRestrictCancel(TransactionCase):
                         {
                             "name": "Test move",
                             "product_id": cls.product.id,
-                            "product_uom_qty": 1,
+                            "product_uom_qty": 3,
                             "location_id": cls.env.ref("stock.stock_location_stock").id,
                             "location_dest_id": cls.env.ref(
                                 "stock.stock_location_customers"
@@ -58,3 +58,10 @@ class TestPickingRestrictCancel(TransactionCase):
         self.picking_type.restrict_cancel_if_printed = False
         self.picking.printed = True
         self.picking.move_ids._action_cancel()
+
+    def test_stock_move_restrict_cancel_printed_enabled_nobackorder(self):
+        """Check a picking partially processed can be validated when no backorder are created"""
+        self.picking.printed = True
+        self.picking.move_ids.quantity_done = 1
+        self.picking_type.create_backorder = "never"
+        self.picking.button_validate()


### PR DESCRIPTION
Allow to validate a partial picking when the backorder policy is set to never