### PR TITLE
[15.0][FIX] stock_valuation_layer_usage: company security rule

### DIFF
--- a/stock_valuation_layer_usage/__manifest__.py
+++ b/stock_valuation_layer_usage/__manifest__.py
@@ -14,6 +14,7 @@
     "depends": ["sale", "stock_account_product_run_fifo_hook"],
     "data": [
         "security/ir.model.access.csv",
+        "security/ir_rule.xml",
         "views/stock_valuation_layer_usage_views.xml",
         "views/stock_valuation_layer_views.xml",
         "views/stock_move_views.xml",

--- a/stock_valuation_layer_usage/security/ir_rule.xml
+++ b/stock_valuation_layer_usage/security/ir_rule.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record model="ir.rule" id="stock_valuation_layer_usage_company_rule">
+        <field name="name">Company Layer Usages</field>
+        <field name="model_id" ref="model_stock_valuation_layer_usage" />
+        <field name="global" eval="True" />
+        <field name="domain_force">[('company_id','in', company_ids)]</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Without this rule when you open the menu "Stock Valuation Layer Usages" all records are trying to be shown. As a result you get the Access Error if there are records of companies you don't have in your environment.

The error you get:

![image](https://github.com/user-attachments/assets/b8cf0d7b-a047-4daa-b8bf-95a1588cefd0)

