### PR TITLE
[16.0][FIX] stock_lock_lot fix: fixed permissions issue when creating product categories

### DIFF
--- a/stock_lock_lot/models/product_category.py
+++ b/stock_lock_lot/models/product_category.py
@@ -2,7 +2,7 @@
 # Copyright 2015 AvanzOsc (http://www.avanzosc.es)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, exceptions, fields, models
+from odoo import _, exceptions, fields, models
 
 
 class ProductCategory(models.Model):
@@ -14,9 +14,16 @@ class ProductCategory(models.Model):
         "by default",
     )
 
-    @api.constrains("lot_default_locked")
     def _check_category_lock_unlock(self):
         if not self.user_has_groups("stock_lock_lot.group_lock_lot"):
             raise exceptions.AccessError(
                 _("You are not allowed to block/unblock Serial Numbers/Lots")
             )
+
+    def write(self, vals):
+        if (
+            "lot_default_locked" in vals
+            and vals["lot_default_locked"] != self.lot_default_locked
+        ):
+            self._check_category_lock_unlock()
+        return super().write(vals)

--- a/stock_lock_lot/tests/test_stock_lock_lot.py
+++ b/stock_lock_lot/tests/test_stock_lock_lot.py
@@ -72,3 +72,14 @@ class TestStockLockLot(common.TransactionCase):
         self.assertEqual(
             subtype, expected_subtype, "Incorrect subtype for unlocked state"
         )
+
+    def test_category_lock_permissions(self):
+        # Remove lock permission
+        self.env.user.groups_id -= self.env.ref("stock_lock_lot.group_lock_lot")
+        # Change lot_default_locked should fail
+        with self.assertRaises(exceptions.AccessError):
+            self.category.write({"lot_default_locked": False})
+        self.env.user.groups_id += self.env.ref("stock_lock_lot.group_lock_lot")
+        # Now the change should work
+        self.category.write({"lot_default_locked": False})
+        self.assertFalse(self.category.lot_default_locked)


### PR DESCRIPTION
**Fix permissions validation when changing 'lot_default_locked' field**

The permission checks for modifying the lot_default_locked field has been improved. Now, the system compares the current value of lot_default_locked with the new value being set and ensures the user has the necessary permissions (stock_lock_lot.group_lock_lot) before allowing the change. This prevents unauthorized users from blocking or unblocking serial numbers/lots. 