### PR TITLE
[16.0][FIX] stock_picking_restrict_cancel_printed: allow moves merge

### DIFF
--- a/stock_picking_restrict_cancel_printed/models/stock_move.py
+++ b/stock_picking_restrict_cancel_printed/models/stock_move.py
@@ -8,7 +8,15 @@ from odoo.exceptions import UserError
 class StockMove(models.Model):
     _inherit = "stock.move"
 
+    def _merge_moves(self, merge_into=False):
+        # Merging moves will cancel the merged move. We need to allow this.
+        return super(
+            StockMove, self.with_context(disable_printed_check=True)
+        )._merge_moves(merge_into=merge_into)
+
     def _action_cancel(self):
+        if self.env.context.get("disable_printed_check"):
+            return super()._action_cancel()
         # if picking_type create_backorder is never, then move is canceled on action_done
         if self.env.context.get("cancel_backorder"):
             return super()._action_cancel()

--- a/stock_picking_restrict_cancel_printed/tests/test_stock_picking_restrict_cancel_printed.py
+++ b/stock_picking_restrict_cancel_printed/tests/test_stock_picking_restrict_cancel_printed.py
@@ -65,3 +65,13 @@ class TestPickingRestrictCancel(TransactionCase):
         self.picking.move_ids.quantity_done = 1
         self.picking_type.create_backorder = "never"
         self.picking.button_validate()
+
+    def test_stock_move_restrict_cancel_printed_enabled_move_merge(self):
+        """Check a picking processed in excess can be validated
+
+        This will trigger the creation of an extra move.
+        That extra gets merged and then canceled.
+        """
+        self.picking.printed = True
+        self.picking.move_ids.quantity_done = 10
+        self.picking.button_validate()


### PR DESCRIPTION
Support validation of picking with quantity in excess. Odoo creates an extra move that gets merged and then canceled. No need to allow this cancellation.

@santostelmo @rousseldenis @mt-software-de  