### PR TITLE
[17.0][FIX] stock_restrict_lot: fix outgoing quantity in test

### DIFF
--- a/stock_restrict_lot/tests/test_restrict_lot.py
+++ b/stock_restrict_lot/tests/test_restrict_lot.py
@@ -8,7 +8,7 @@ class TestRestrictLot(TransactionCase):
         super().setUpClass()
         cls.customer_loc = cls.env.ref("stock.stock_location_customers")
         cls.output_loc = cls.env.ref("stock.stock_location_output")
-        cls.product = cls.env.ref("product.product_product_16")
+        cls.product = cls.env.ref("product.product_product_16").copy()
         cls.product.write({"tracking": "lot"})
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.warehouse.write({"delivery_steps": "pick_ship"})


### PR DESCRIPTION
The outgoing quantity is different depending on whether mrp is loaded, as the demo data of that module adds an outgoing quantity of 3. In the test, use a copy of the demo product to ensure there are no preexisting stock operations.

Fixes
```
odoo.addons.stock_restrict_lot.tests.test_restrict_lot: FAIL: TestRestrictLot.test_compute_quantites
Traceback (most recent call last):
  File "/__w/stock-logistics-workflow/stock-logistics-workflow/stock_restrict_lot/tests/test_restrict_lot.py", line 254, in test_compute_quantites
    self.assertEqual(product.outgoing_qty, 2)
AssertionError: 5.0 != 2
```
as can be seen in https://github.com/OCA/stock-logistics-workflow/pull/1654