### PR TITLE
[FIX] stock_no_negative: use display_name instead of name_get because it is deprecated

### DIFF
--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -39,7 +39,7 @@ class StockQuant(models.Model):
             ):
                 msg_add = ""
                 if quant.lot_id:
-                    msg_add = _(" lot {}").format(quant.lot_id.name_get()[0][1])
+                    msg_add = _(" lot %(name)s", name=quant.lot_id.display_name)
                 raise ValidationError(
                     _(
                         "You cannot validate this stock operation because the "

--- a/stock_no_negative/tests/test_stock_no_negative.py
+++ b/stock_no_negative/tests/test_stock_no_negative.py
@@ -134,6 +134,26 @@ class TestStockNoNegative(TransactionCase):
         with self.assertRaises(ValidationError):
             self.stock_picking.button_validate()
 
+    def test_check_constrains_with_lot(self):
+        """Assert that constraint is raised when user
+        tries to validate the stock operation which would
+        make the stock level of the product negative with
+        a product with lot"""
+        self.stock_picking_with_lot.action_confirm()
+        self.stock_move_line_with_lot = self.env["stock.move.line"].create(
+            {
+                "product_id": self.product_with_lot.id,
+                "quantity": 100.0,
+                "picking_id": self.stock_picking_with_lot.id,
+                "move_id": self.stock_move_with_lot.id,
+                "location_id": self.location_id.id,
+                "location_dest_id": self.location_dest_id.id,
+                "lot_id": self.lot1.id,
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.stock_picking_with_lot.button_validate()
+
     def test_true_allow_negative_stock_product(self):
         """Assert that negative stock levels are allowed when
         the allow_negative_stock is set active in the product"""


### PR DESCRIPTION
name_get is deprecated the error 
`AttributeError: 'stock.lot' object has no attribute 'name_get' `
appear