### PR TITLE
[13.0][FIX] stock_picking_filter_lot: if quantity changes location ids are not computed

### DIFF
--- a/stock_picking_filter_lot/models/stock_production_lot.py
+++ b/stock_picking_filter_lot/models/stock_production_lot.py
@@ -11,7 +11,7 @@ class StockProductionLot(models.Model):
         comodel_name="stock.location", compute="_compute_location_ids", store=True
     )
 
-    @api.depends("quant_ids", "quant_ids.location_id")
+    @api.depends("quant_ids", "quant_ids.location_id", "quant_ids.quantity")
     def _compute_location_ids(self):
         for lot in self:
             lot.location_ids = lot.quant_ids.filtered(lambda l: l.quantity > 0).mapped(

--- a/stock_picking_filter_lot/readme/CONTRIBUTORS.rst
+++ b/stock_picking_filter_lot/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Lois Rilo <lois.rilo@forgeflow.com> (www.forgeflow.com)
 * Alan Ramos <alan.ramos@jarsa.com.mx> (www.jarsa.com.mx)
 * Tharathip Chaweewongphan <tharathipc@ecosoft.co.th> (www.ecosoft.co.th)
+* David Alonso <david.alonso@solvos.es> (www.solvos.es)

--- a/stock_picking_filter_lot/tests/__init__.py
+++ b/stock_picking_filter_lot/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_picking_filter_lot

--- a/stock_picking_filter_lot/tests/test_stock_picking_filter_lot.py
+++ b/stock_picking_filter_lot/tests/test_stock_picking_filter_lot.py
@@ -1,0 +1,44 @@
+# © 2025 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests import SavepointCase
+
+
+class TestStockPickingFilterLot(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test product #1", "type": "product", "tracking": "lot"}
+        )
+        cls.warehouse = cls.env["stock.warehouse"].create(
+            {"name": "Test warehouse #1", "code": "TWH1"}
+        )
+        cls.location = cls.warehouse.lot_stock_id
+        cls.quant_obj = cls.env["stock.quant"]
+
+    def test_stock_picking_filter_lot(self):
+        # When a lot is initially created, no locations are available
+        lot_1 = self.env["stock.production.lot"].create(
+            {
+                "name": "Test lot #1",
+                "product_id": self.product.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        self.assertEqual(len(lot_1.location_ids), 0)
+
+        # Makes a location available
+        quant_1 = self.quant_obj.create(
+            {
+                "product_id": self.product.id,
+                "quantity": 10.0,
+                "location_id": self.location.id,
+                "lot_id": lot_1.id,
+            }
+        )
+        self.assertEqual(len(lot_1.location_ids), 1)
+        self.assertEqual(lot_1.location_ids, self.location)
+
+        # A zero inventory adjustment makes locations unavailable again
+        quant_1.quantity = 0
+        self.assertEqual(len(lot_1.location_ids), 0)


### PR DESCRIPTION
We had quantities in a location and weren't able to select it and we traced the problem to be this missing dependency.

Supersedes #1049 for 13.0 