### PR TITLE
[16.0][FIX] purchase_stock_picking_invoice_link: Fallback to load CoA

### DIFF
--- a/purchase_stock_picking_invoice_link/tests/test_purchase_stock_picking_invoice_link.py
+++ b/purchase_stock_picking_invoice_link/tests/test_purchase_stock_picking_invoice_link.py
@@ -9,6 +9,15 @@ class TestPurchaseSTockPickingInvoiceLink(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.supplier = cls.env["res.partner"].create({"name": "Supplier for Test"})
         cls.product = cls.env["product.product"].create({"name": "Product for Test"})
         po_form = Form(cls.env["purchase.order"])


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa