### PR TITLE
[15.0][FIX] stock_scrap_tier_validation: notification subtypes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements

--- a/stock_return_request/i18n/gl.po
+++ b/stock_return_request/i18n/gl.po
@@ -308,7 +308,7 @@ msgid ""
 msgstr ""
 "Non hai suficientes movementos para devolver este produto.\n"
 "Non foi posible atopar suficientes movementos para devolver {line_quantity} "
-"{line_product_uom_ide_name}de {line_product_ide_displayname}. Pódese "
+"{line_product_uom_id_name} de {line_product_id_displayname}. Pódese "
 "devolver un máximo de {qty_found}."
 
 #. module: stock_return_request

--- a/stock_scrap_tier_validation/models/stock_scrap.py
+++ b/stock_scrap_tier_validation/models/stock_scrap.py
@@ -13,13 +13,13 @@ class StockScrap(models.Model):
     _tier_validation_manual_config = False
 
     def _get_requested_notification_subtype(self):
-        return "stock_scrap_tier_validation.sale_order_tier_validation_requested"
+        return "stock_scrap_tier_validation.stock_scrap_tier_validation_requested"
 
     def _get_accepted_notification_subtype(self):
-        return "stock_scrap_tier_validation.sale_order_tier_validation_accepted"
+        return "stock_scrap_tier_validation.stock_scrap_tier_validation_accepted"
 
     def _get_rejected_notification_subtype(self):
-        return "stock_scrap_tier_validation.sale_order_tier_validation_rejected"
+        return "stock_scrap_tier_validation.stock_scrap_tier_validation_rejected"
 
     @api.model
     def _get_under_validation_exceptions(self):

--- a/stock_scrap_tier_validation/tests/test_tier_validation.py
+++ b/stock_scrap_tier_validation/tests/test_tier_validation.py
@@ -41,6 +41,15 @@ class TestSaleTierValidation(common.TransactionCase):
         cls.scrap_location = cls.env["stock.location"].search(
             [("scrap_location", "=", True)], limit=1
         )
+        cls.scrap = cls.env["stock.scrap"].create(
+            {
+                "product_id": cls.product.id,
+                "product_uom_id": cls.product.uom_id.id,
+                "scrap_qty": 1.0,
+                "location_id": cls.location.id,
+                "scrap_location_id": cls.scrap_location.id,
+            }
+        )
 
     def test_tier_validation_model_name(self):
         self.assertIn(
@@ -48,19 +57,25 @@ class TestSaleTierValidation(common.TransactionCase):
         )
 
     def test_validation_stock_scrap(self):
-        scrap = self.env["stock.scrap"].create(
-            {
-                "product_id": self.product.id,
-                "product_uom_id": self.product.uom_id.id,
-                "scrap_qty": 1.0,
-                "location_id": self.location.id,
-                "scrap_location_id": self.scrap_location.id,
-            }
-        )
         with self.assertRaises(ValidationError):
-            scrap.action_validate()
-        scrap.request_validation()
-        scrap.invalidate_cache()
-        scrap.with_user(self.test_user_1).validate_tier()
-        scrap.action_validate()
-        self.assertEqual(scrap.state, "done")
+            self.scrap.action_validate()
+        self.scrap.request_validation()
+        self.scrap.invalidate_cache()
+        self.scrap.with_user(self.test_user_1).validate_tier()
+        self.scrap.action_validate()
+        self.assertEqual(self.scrap.state, "done")
+
+    def test_notification_subtypes(self):
+        """Check that the notification subtypes are correctly returned."""
+        self.assertEqual(
+            self.scrap._get_requested_notification_subtype(),
+            "stock_scrap_tier_validation.stock_scrap_tier_validation_requested",
+        )
+        self.assertEqual(
+            self.scrap._get_accepted_notification_subtype(),
+            "stock_scrap_tier_validation.stock_scrap_tier_validation_accepted",
+        )
+        self.assertEqual(
+            self.scrap._get_rejected_notification_subtype(),
+            "stock_scrap_tier_validation.stock_scrap_tier_validation_rejected",
+        )


### PR DESCRIPTION
Backport from https://github.com/OCA/stock-logistics-workflow/pull/1894