### PR TITLE
[IMP] [16.0] stock_picking_auto_create_lot: Make it compatible with Stock Picking Batches

### DIFF
--- a/stock_picking_auto_create_lot/README.rst
+++ b/stock_picking_auto_create_lot/README.rst
@@ -47,6 +47,9 @@ To configure this module, you need to:
 #. Go to a *Inventory > Master Data > Products*.
 #. Set 'auto create lot' option for the products you need.
 
+#. Go to a *Inventory > Configuration > Products > Product Categories*.
+#. Set 'auto create lot' option for the categories you need.
+
 Usage
 =====
 
@@ -54,7 +57,7 @@ To use this module you need to:
 
 #. Go to a *Product > Inventory tab*.
 #. Set a tracking option for this product.
-#. Set auto create lot.
+#. Set auto create lot on the product or in the category.
 #. Go to *Inventory > Incoming* and create one.
 #. Validate picking without lot.
 

--- a/stock_picking_auto_create_lot/README.rst
+++ b/stock_picking_auto_create_lot/README.rst
@@ -29,7 +29,7 @@ Stock Picking Auto Create Lot
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module extends the functionality of stock module to allow auto create
-lots for incoming pickings.
+lots for selected picking types.
 
 **Table of contents**
 
@@ -88,6 +88,8 @@ Contributors
 * `Quartile <https://www.quartile.co>`__:
 
   * Aung Ko Ko Lin
+
+* Eduardo de Miguel <info@moduon.team>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_auto_create_lot/__manifest__.py
+++ b/stock_picking_auto_create_lot/__manifest__.py
@@ -12,6 +12,10 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["stock"],
-    "data": ["views/product_views.xml", "views/stock_picking_type_views.xml"],
+    "data": [
+        "views/product_views.xml",
+        "views/product_category_views.xml",
+        "views/stock_picking_type_views.xml",
+    ],
     "maintainers": ["sergio-teruel"],
 }

--- a/stock_picking_auto_create_lot/models/__init__.py
+++ b/stock_picking_auto_create_lot/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import product
+from . import product_category
 from . import stock_picking
 from . import stock_picking_type
 from . import stock_move

--- a/stock_picking_auto_create_lot/models/product_category.py
+++ b/stock_picking_auto_create_lot/models/product_category.py
@@ -1,0 +1,9 @@
+# Copyright 2025 Moduon Team
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ProductCategory(models.Model):
+    _inherit = "product.category"
+
+    auto_create_lot = fields.Boolean()

--- a/stock_picking_auto_create_lot/models/stock_move.py
+++ b/stock_picking_auto_create_lot/models/stock_move.py
@@ -17,7 +17,8 @@ class StockMove(models.Model):
     def _compute_display_assign_serial(self):
         super()._compute_display_assign_serial()
         moves_not_display = self.filtered(
-            lambda m: m.picking_type_id.auto_create_lot and m.product_id.auto_create_lot
+            lambda m: m.picking_type_id.auto_create_lot
+            and (m.product_id.auto_create_lot or m.product_id.categ_id.auto_create_lot)
         )
         for move in moves_not_display:
             move.display_assign_serial = False
@@ -31,7 +32,10 @@ class StockMove(models.Model):
                 continue
             if (
                 move.product_id.tracking == "none"
-                or not move.product_id.auto_create_lot
+                or not (
+                    move.product_id.auto_create_lot
+                    or move.product_id.categ_id.auto_create_lot
+                )
                 or not move.picking_type_id.auto_create_lot
             ):
                 continue

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -22,7 +22,9 @@ class StockPicking(models.Model):
                 ("lot_id", "=", False),
                 ("lot_name", "=", False),
                 ("product_id.tracking", "!=", "none"),
+                "|",
                 ("product_id.auto_create_lot", "=", True),
+                ("product_id.categ_id.auto_create_lot", "=", True),
             ]
 
         pickings = self.filtered(lambda p: p.picking_type_id.auto_create_lot)

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # Copyright 2020 ACSONE SA/NV
+# Copyright 2025 Moduon Team
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 from odoo.osv import expression
@@ -8,28 +9,22 @@ from odoo.osv import expression
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    def _prepare_auto_lot_domain(self, immediate=False):
+    def _prepare_auto_lot_domain(self):
         """Prepare the domain to search for stock.move.line records that require
         automatic lot assignment.
         The 'immediate' parameter influences the inclusion of 'qty_done' in the search criteria,
         depending on whether the transfer is immediate or planned.
         """
-        domain = [
-            ("picking_id", "in", self.ids),
-            ("lot_id", "=", False),
-            ("lot_name", "=", False),
-            ("product_id.tracking", "!=", "none"),
-            ("product_id.auto_create_lot", "=", True),
-        ]
-        if not immediate:
-            domain = expression.AND([domain, [("qty_done", ">", 0)]])
-        return domain
 
-    def _set_auto_lot(self):
-        """
-        Allows to be called either by button or through code.
-        """
-        lines_to_set = self.env["stock.move.line"]
+        def _build_auto_lot_domain(picking_ids):
+            return [
+                ("picking_id", "in", picking_ids),
+                ("lot_id", "=", False),
+                ("lot_name", "=", False),
+                ("product_id.tracking", "!=", "none"),
+                ("product_id.auto_create_lot", "=", True),
+            ]
+
         pickings = self.filtered(lambda p: p.picking_type_id.auto_create_lot)
         if not pickings:
             return
@@ -37,15 +32,22 @@ class StockPicking(models.Model):
         planned_domain = []
         immediate_pickings = pickings._check_immediate()
         if immediate_pickings:
-            immediate_domain = immediate_pickings._prepare_auto_lot_domain(
-                immediate=True
-            )
+            immediate_domain = _build_auto_lot_domain(immediate_pickings.ids)
         planned_pickings = pickings - immediate_pickings
         if planned_pickings:
-            planned_domain = planned_pickings._prepare_auto_lot_domain()
-        domain = expression.OR([immediate_domain, planned_domain])
-        lines_to_set = lines_to_set.search(domain)
-        for line in lines_to_set:
+            planned_domain = expression.AND(
+                [_build_auto_lot_domain(planned_pickings.ids), [("qty_done", ">", 0)]]
+            )
+        return expression.OR([immediate_domain, planned_domain])
+
+    def _set_auto_lot(self):
+        """
+        Allows to be called either by button or through code.
+        """
+        auto_lot_domain = self._prepare_auto_lot_domain()
+        if not auto_lot_domain:
+            return
+        for line in self.env["stock.move.line"].search(auto_lot_domain):
             line.lot_name = line._get_lot_sequence()
 
     def _action_done(self):
@@ -55,3 +57,19 @@ class StockPicking(models.Model):
     def button_validate(self):
         self._set_auto_lot()
         return super().button_validate()
+
+    def _get_lot_move_lines_for_sanity_check(
+        self, none_done_picking_ids, separate_pickings=True
+    ):
+        """Skip sanity check for auto-lot move lines.
+
+        When the picking is validated, the auto-lot move lines are created with the lot name.
+        """
+        res = super()._get_lot_move_lines_for_sanity_check(
+            none_done_picking_ids, separate_pickings=separate_pickings
+        )
+        auto_lot_domain = self._prepare_auto_lot_domain()
+        if not auto_lot_domain:
+            return res
+        auto_lot_move_lines = self.env["stock.move.line"].search(auto_lot_domain)
+        return res - auto_lot_move_lines

--- a/stock_picking_auto_create_lot/readme/CONFIGURE.rst
+++ b/stock_picking_auto_create_lot/readme/CONFIGURE.rst
@@ -5,3 +5,6 @@ To configure this module, you need to:
 
 #. Go to a *Inventory > Master Data > Products*.
 #. Set 'auto create lot' option for the products you need.
+
+#. Go to a *Inventory > Configuration > Products > Product Categories*.
+#. Set 'auto create lot' option for the categories you need.

--- a/stock_picking_auto_create_lot/readme/CONTRIBUTORS.rst
+++ b/stock_picking_auto_create_lot/readme/CONTRIBUTORS.rst
@@ -6,3 +6,5 @@
 * `Quartile <https://www.quartile.co>`__:
 
   * Aung Ko Ko Lin
+
+* Eduardo de Miguel <info@moduon.team>

--- a/stock_picking_auto_create_lot/readme/DESCRIPTION.rst
+++ b/stock_picking_auto_create_lot/readme/DESCRIPTION.rst
@@ -1,2 +1,2 @@
 This module extends the functionality of stock module to allow auto create
-lots for incoming pickings.
+lots for selected picking types.

--- a/stock_picking_auto_create_lot/readme/USAGE.rst
+++ b/stock_picking_auto_create_lot/readme/USAGE.rst
@@ -2,6 +2,6 @@ To use this module you need to:
 
 #. Go to a *Product > Inventory tab*.
 #. Set a tracking option for this product.
-#. Set auto create lot.
+#. Set auto create lot on the product or in the category.
 #. Go to *Inventory > Incoming* and create one.
 #. Validate picking without lot.

--- a/stock_picking_auto_create_lot/static/description/index.html
+++ b/stock_picking_auto_create_lot/static/description/index.html
@@ -371,7 +371,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/stock-logistics-workflow/tree/16.0/stock_picking_auto_create_lot"><img alt="OCA/stock-logistics-workflow" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/stock-logistics-workflow-16-0/stock-logistics-workflow-16-0-stock_picking_auto_create_lot"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/stock-logistics-workflow&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module extends the functionality of stock module to allow auto create
-lots for incoming pickings.</p>
+lots for selected picking types.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -436,6 +436,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Aung Ko Ko Lin</li>
 </ul>
 </li>
+<li>Eduardo de Miguel &lt;<a class="reference external" href="mailto:info&#64;moduon.team">info&#64;moduon.team</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_picking_auto_create_lot/static/description/index.html
+++ b/stock_picking_auto_create_lot/static/description/index.html
@@ -394,6 +394,8 @@ lots for selected picking types.</p>
 <li>Set ‘auto create lot’ option for this operation type.</li>
 <li>Go to a <em>Inventory &gt; Master Data &gt; Products</em>.</li>
 <li>Set ‘auto create lot’ option for the products you need.</li>
+<li>Go to a <em>Inventory &gt; Configuration &gt; Products &gt; Product Categories</em>.</li>
+<li>Set ‘auto create lot’ option for the categories you need.</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -402,7 +404,7 @@ lots for selected picking types.</p>
 <ol class="arabic simple">
 <li>Go to a <em>Product &gt; Inventory tab</em>.</li>
 <li>Set a tracking option for this product.</li>
-<li>Set auto create lot.</li>
+<li>Set auto create lot on the product or in the category.</li>
 <li>Go to <em>Inventory &gt; Incoming</em> and create one.</li>
 <li>Validate picking without lot.</li>
 </ol>

--- a/stock_picking_auto_create_lot/tests/common.py
+++ b/stock_picking_auto_create_lot/tests/common.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # Copyright 2020 ACSONE SA/NV
+# Copyright 2025 Moduon Team
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
@@ -21,6 +22,9 @@ class CommonStockPickingAutoCreateLot(object):
         cls.picking_type_in = cls.env.ref("stock.picking_type_in")
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
         cls.supplier = cls.env["res.partner"].create({"name": "Supplier - test"})
+        cls.auto_lot_category = cls.env["product.category"].create(
+            {"name": "Test Auto Lot Category", "auto_create_lot": True}
+        )
 
     @classmethod
     def _create_product(cls, tracking="lot", auto=True):

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # Copyright 2020 ACSONE SA/NV
+# Copyright 2025 Moduon Team
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.exceptions import UserError
 from odoo.tests import Form, TransactionCase
@@ -13,14 +14,19 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
         super().setUpClass()
         # Create 3 products with lot/serial and auto_create True/False
         cls.product = cls._create_product()
-        cls.product_serial = cls._create_product(tracking="serial")
+        cls.product_serial = cls._create_product(tracking="serial", auto=True)
         cls.product_serial_not_auto = cls._create_product(tracking="serial", auto=False)
+        cls.product_serial_categ_auto = cls._create_product(
+            tracking="serial", auto=False
+        )
+        cls.product_serial_categ_auto.categ_id = cls.auto_lot_category
         cls.picking_type_in.auto_create_lot = True
 
         cls._create_picking()
         cls._create_move(product=cls.product, qty=2.0)
         cls._create_move(product=cls.product_serial, qty=3.0)
         cls._create_move(product=cls.product_serial_not_auto, qty=4.0)
+        cls._create_move(product=cls.product_serial_categ_auto, qty=5.0)
 
     def test_manual_lot(self):
         self.picking.action_assign()
@@ -29,7 +35,10 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             lambda m: m.product_id == self.product_serial
         )
         self.assertFalse(move.display_assign_serial)
-
+        move = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_serial_categ_auto
+        )
+        self.assertFalse(move.display_assign_serial)
         move = self.picking.move_ids.filtered(
             lambda m: m.product_id == self.product_serial_not_auto
         )
@@ -46,6 +55,10 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             [("product_id", "=", self.product_serial.id)]
         )
         self.assertEqual(len(lot), 3)
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product_serial_categ_auto.id)]
+        )
+        self.assertEqual(len(lot), 5)
 
     def test_auto_create_lot(self):
         self.picking.action_assign()
@@ -54,7 +67,10 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             lambda m: m.product_id == self.product_serial
         )
         self.assertFalse(move.display_assign_serial)
-
+        move = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_serial_categ_auto
+        )
+        self.assertFalse(move.display_assign_serial)
         move = self.picking.move_ids.filtered(
             lambda m: m.product_id == self.product_serial_not_auto
         )
@@ -71,6 +87,10 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             [("product_id", "=", self.product_serial.id)]
         )
         self.assertEqual(len(lot), 3)
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product_serial_categ_auto.id)]
+        )
+        self.assertEqual(len(lot), 5)
 
     def test_auto_create_transfer_lot(self):
         self.picking.action_assign()
@@ -103,11 +123,23 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             [("product_id", "=", self.product_serial.id)]
         )
         self.assertEqual(len(lot), 3)
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product_serial_categ_auto.id)]
+        )
+        self.assertEqual(len(lot), 5)
 
         # Check if lots are unique per move and per product if managed
         # per serial
         move_lines_serial = self.picking.move_line_ids.filtered(
             lambda m: m.product_id.tracking == "serial" and m.product_id.auto_create_lot
+        )
+        serials = []
+        for move in move_lines_serial:
+            serials.append(move.lot_id.name)
+        self.assertUniqueIn(serials)
+        move_lines_serial = self.picking.move_line_ids.filtered(
+            lambda m: m.product_id.tracking == "serial"
+            and m.product_id.categ_id.auto_create_lot
         )
         serials = []
         for move in move_lines_serial:
@@ -130,7 +162,7 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
 
         moves = pickings.mapped("move_ids").filtered(
             lambda m: m.product_id == self.product_serial
-            and m.product_id.auto_create_lot
+            and (m.product_id.auto_create_lot or m.product_id.categ_id.auto_create_lot)
         )
         for line in moves.mapped("move_line_ids"):
             self.assertFalse(line.lot_name)

--- a/stock_picking_auto_create_lot/views/product_category_views.xml
+++ b/stock_picking_auto_create_lot/views/product_category_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Moduon Team
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_category_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.category.auto.lot.form</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="stock.product_category_form_view_inherit" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='logistics']" position="inside">
+                <field name="auto_create_lot" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_picking_auto_create_lot/views/product_views.xml
+++ b/stock_picking_auto_create_lot/views/product_views.xml
@@ -3,7 +3,7 @@
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="view_template_property_form" model="ir.ui.view">
-        <field name="name">Product template Secondary Unit</field>
+        <field name="name">product.template.stock.property.form.auto.lot.inherit</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">


### PR DESCRIPTION
This module is incompatible if you perform batches or waves.

Now, on the sanity check, the move lines with auto-generate lots will be skipped.

MT-9566 @moduon @rafaelbn @yajo @fcvalgar @Gelojr @EmilioPascual @sergio-teruel please review if you want 😄 