### PR TITLE
[14.0][IMP] delivery_procurement_group_carrier: Align Carrier once per group

### DIFF
--- a/delivery_procurement_group_carrier/models/stock_picking.py
+++ b/delivery_procurement_group_carrier/models/stock_picking.py
@@ -1,34 +1,39 @@
 # Copyright 2025 Camptocamp SA
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import models
+from odoo.tools import groupby
 
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     def _align_group_carrier(self):
-        for picking in self:
-            picking_carrier = picking.carrier_id
-            picking_group = picking.group_id
-            if picking_group and picking_carrier != picking_group.carrier_id:
-                picking_group.carrier_id = picking_carrier
-                need_align_pickings = self.search(
-                    [
-                        ("group_id", "=", picking_group.id),
+        for group, pickings in groupby(self, lambda pick: pick.group_id):
+            if not group:
+                continue
+            pickings = self.browse().union(*pickings)
+            carrier = pickings.carrier_id
+            carrier.ensure_one()
+            need_align_pickings = self.search(
+                [
+                    ("group_id", "=", group.id),
+                    (
+                        "state",
+                        "not in",
                         (
-                            "state",
-                            "not in",
-                            (
-                                "done",
-                                "cancel",
-                            ),
+                            "done",
+                            "cancel",
                         ),
-                        ("carrier_id", "!=", picking_carrier.id),
-                        ("carrier_id", "!=", False),
-                    ]
-                )
-                need_align_pickings.carrier_id = picking_carrier
+                    ),
+                    ("carrier_id", "!=", carrier.id),
+                    ("carrier_id", "!=", False),
+                ]
+            )
+            group.carrier_id = carrier
+            if need_align_pickings:
+                need_align_pickings.carrier_id = carrier
 
     def write(self, values):
         if "carrier_id" not in values or self.env.context.get(
@@ -43,5 +48,6 @@ class StockPicking(models.Model):
         updated_pickings = self.filtered(
             lambda p: p.carrier_id != carrier_mapping.get(p.id)
         )
-        updated_pickings._align_group_carrier()
+        if updated_pickings:
+            updated_pickings._align_group_carrier()
         return res

--- a/delivery_procurement_group_carrier/tests/test_carrier.py
+++ b/delivery_procurement_group_carrier/tests/test_carrier.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
 # Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests import SavepointCase, tagged
@@ -21,6 +22,19 @@ class TestProcurementGroupCarrier(SavepointCase):
                 "product_id": cls.env.ref("delivery.product_product_delivery").id,
             }
         )
+        cls.carrier2 = cls.env["delivery.carrier"].create(
+            {
+                "name": "My Test Carrier2",
+                "product_id": cls.env.ref("delivery.product_product_delivery").id,
+            }
+        )
+        cls.carrier3 = cls.env["delivery.carrier"].create(
+            {
+                "name": "My Test Carrier3",
+                "product_id": cls.env.ref("delivery.product_product_delivery").id,
+            }
+        )
+
         cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
 
     @classmethod
@@ -51,16 +65,38 @@ class TestProcurementGroupCarrier(SavepointCase):
     def test_sale_picking_group_carrier_aligned(self):
         # Create an order without carrier
         order = self._create_sale_order([(self.product, 1.0)])
+        order.warehouse_id.delivery_steps = "pick_ship"
+        order.carrier_id = self.carrier
         order.action_confirm()
-        picking = order.picking_ids
-        move_group = picking.move_lines.group_id
-        self.assertFalse(order.carrier_id)
-        self.assertFalse(picking.carrier_id)
-        self.assertFalse(move_group.carrier_id)
+        out_transfer = order.picking_ids.filtered(
+            lambda pick: pick.location_dest_id.usage == "customer"
+        )
+        pick_transfer = order.picking_ids - out_transfer
+        move_group = order.procurement_group_id
+        self.assertEqual(out_transfer.carrier_id, self.carrier)
+        self.assertEqual(move_group.carrier_id, self.carrier)
+        self.assertFalse(pick_transfer.carrier_id)
+
+        # Change the carrier on the out transfer
+        # Carrier on group needs to be changed
+        # but not on the pick transfer
+        out_transfer.carrier_id = self.carrier2
+        self.assertEqual(move_group.carrier_id, self.carrier2)
+        self.assertFalse(pick_transfer.carrier_id)
+
         # Now change carrier on order (odoo allows it)
-        self._add_carrier_to_order(order, self.carrier)
-        # In odoo standard both picking and order references the new carrier
-        move_group = picking.move_lines.group_id
-        self.assertEqual(order.carrier_id, self.carrier)
-        self.assertEqual(picking.carrier_id, self.carrier)
+        # In odoo standard all pickings and order references the new carrier
+        self._add_carrier_to_order(order, self.carrier3)
+        move_group = order.procurement_group_id
+        self.assertEqual(order.carrier_id, self.carrier3)
+        self.assertEqual(out_transfer.carrier_id, self.carrier3)
+        self.assertEqual(pick_transfer.carrier_id, self.carrier3)
+        self.assertEqual(move_group.carrier_id, self.carrier3)
+
+        # Now since the carrier is set on out and pick tranfer
+        # updating the carrier on the out transfer
+        # should also change the carrier on the pick transfer
+        out_transfer.carrier_id = self.carrier
+        self.assertEqual(out_transfer.carrier_id, self.carrier)
+        self.assertEqual(pick_transfer.carrier_id, self.carrier)
         self.assertEqual(move_group.carrier_id, self.carrier)


### PR DESCRIPTION
I checked the tests and figured out that the test never has hit https://github.com/OCA/stock-logistics-workflow/blob/fc42bed4eebbf2b937c6c2ef3b89ddde4e37d7e5/delivery_procurement_group_carrier/models/stock_picking.py#L31 with a picking. 

That's because by default `set_delivery_line` sets the new carrier on all pickings of the proc group of the sale.order.

As result i extended the test to ensure the carrier is just set on the other transfers of the group if they have a carrier set. I changed the align carrier method to ensure it gets only once called per group. 

@jbaudoux @mmequignon 