### PR TITLE
[16.0][IMP] stock_picking_partner_note propagate from partner to picking

### DIFF
--- a/stock_picking_partner_note/models/res_partner.py
+++ b/stock_picking_partner_note/models/res_partner.py
@@ -12,3 +12,15 @@ class ResPartner(models.Model):
         comodel_name="stock.picking.note",
         string="Picking Notes",
     )
+
+    def write(self, vals):
+        # Update notes on open pickings
+        res = super().write(vals)
+        if "stock_picking_note_ids" in vals:
+            self.env["stock.picking"].search(
+                [
+                    ("partner_id", "child_of", self.ids),
+                    ("state", "in", ("draft", "waiting", "confirmed", "assigned")),
+                ]
+            )._compute_note()
+        return res

--- a/stock_picking_partner_note/tests/test_stock_picking_partner_note.py
+++ b/stock_picking_partner_note/tests/test_stock_picking_partner_note.py
@@ -66,3 +66,27 @@ class StockPickingPartnerNote(common.TransactionCase):
         # We cannot delete a note that is already in use
         with self.assertRaises(UserError):
             partner_b.stock_picking_note_ids.unlink()
+
+    def test_update_partner_note_propagated_to_open_picking(self):
+        """Test that update of partner note is propagated to open pickings."""
+        with Form(self.env["sale.order"]) as order_form:
+            order_form.partner_id = self.partner_a
+            with order_form.order_line.new() as line_form:
+                line_form.product_id = self.product_a
+                line_form.product_uom_qty = 1
+
+        self.order = order_form.save()
+        self.order.warehouse_id.out_type_id.partner_note_type_ids = [
+            (6, 0, (self.note_type1 | self.note_type2).ids)
+        ]
+        self.order.action_confirm()
+        self.partner_a.write(
+            {
+                "stock_picking_note_ids": [
+                    (0, 0, {"name": "Note 3", "note_type_id": self.note_type1.id}),
+                ]
+            }
+        )
+        self.assertIn(
+            "<p>Note 1<br>Note 2<br>Note 3</p>", self.order.picking_ids[0].note
+        )


### PR DESCRIPTION
Partner notes are computed when picking is created. 
When partner notes change we update open pickings notes