### PR TITLE
[16.0][IMP] stock_picking_auto_create_lot: lot on print

### DIFF
--- a/stock_picking_auto_create_lot/README.rst
+++ b/stock_picking_auto_create_lot/README.rst
@@ -50,6 +50,29 @@ To configure this module, you need to:
 #. Go to a *Inventory > Configuration > Products > Product Categories*.
 #. Set 'auto create lot' option for the categories you need.
 
+It's possible to configure by code a way to force the setting of the auto lot when
+printing the detailed operation labels. To do so, pass the context key `force_auto_lot`
+to the report. This is a simple example with a server action, but it can be done with
+overriding methods as well:
+
+.. code-block:: xml
+
+     <record id="action_print_detailed_operation" model="ir.actions.server">
+          <field name="name">Print detailed operations</field>
+          <field name="model_id" ref="stock.model_stock_move_line" />
+          <field
+                name="binding_model_id"
+                ref="stock.model_stock_move_line"
+          />
+          <field name="binding_view_types">list</field>
+          <field name="state">code</field>
+          <field name="code">
+     if records:
+          report = env["ir.actions.report"].sudo()._get_report("my_custom_module.my_custom_report_xml_id")
+          action = report.with_context(force_auto_lot=True).report_action(records.ids)
+          </field>
+     </record>
+
 Usage
 =====
 

--- a/stock_picking_auto_create_lot/models/__init__.py
+++ b/stock_picking_auto_create_lot/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import ir_actions_report
 from . import product
 from . import product_category
 from . import stock_picking

--- a/stock_picking_auto_create_lot/models/ir_actions_report.py
+++ b/stock_picking_auto_create_lot/models/ir_actions_report.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Moduon Team
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class IrActionReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def report_action(self, docids, data=None, config=True):
+        # Catch a context to force lot creation on print so it can be used in different
+        # scenarios without the need of defining glue modules.
+        if self.env.context.get("force_auto_lot") and self.model == "stock.move.line":
+            move_lines = self.env["stock.move.line"].browse(docids)
+            domain = move_lines.picking_id._prepare_auto_lot_domain()
+            if domain:
+                move_lines = move_lines.filtered_domain(domain)
+                for line in move_lines:
+                    line.lot_name = line._get_lot_sequence()
+                move_lines.with_context(
+                    bypass_reservation_update=True
+                )._create_and_assign_production_lot()
+        return super().report_action(docids, data, config)

--- a/stock_picking_auto_create_lot/readme/CONFIGURE.rst
+++ b/stock_picking_auto_create_lot/readme/CONFIGURE.rst
@@ -8,3 +8,26 @@ To configure this module, you need to:
 
 #. Go to a *Inventory > Configuration > Products > Product Categories*.
 #. Set 'auto create lot' option for the categories you need.
+
+It's possible to configure by code a way to force the setting of the auto lot when
+printing the detailed operation labels. To do so, pass the context key `force_auto_lot`
+to the report. This is a simple example with a server action, but it can be done with
+overriding methods as well:
+
+.. code-block:: xml
+
+     <record id="action_print_detailed_operation" model="ir.actions.server">
+          <field name="name">Print detailed operations</field>
+          <field name="model_id" ref="stock.model_stock_move_line" />
+          <field
+                name="binding_model_id"
+                ref="stock.model_stock_move_line"
+          />
+          <field name="binding_view_types">list</field>
+          <field name="state">code</field>
+          <field name="code">
+     if records:
+          report = env["ir.actions.report"].sudo()._get_report("my_custom_module.my_custom_report_xml_id")
+          action = report.with_context(force_auto_lot=True).report_action(records.ids)
+          </field>
+     </record>

--- a/stock_picking_auto_create_lot/static/description/index.html
+++ b/stock_picking_auto_create_lot/static/description/index.html
@@ -397,6 +397,27 @@ lots for selected picking types.</p>
 <li>Go to a <em>Inventory &gt; Configuration &gt; Products &gt; Product Categories</em>.</li>
 <li>Set ‘auto create lot’ option for the categories you need.</li>
 </ol>
+<p>It’s possible to configure by code a way to force the setting of the auto lot when
+printing the detailed operation labels. To do so, pass the context key <cite>force_auto_lot</cite>
+to the report. This is a simple example with a server action, but it can be done with
+overriding methods as well:</p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;record</span><span class="w"> </span><span class="na">id=</span><span class="s">&quot;action_print_detailed_operation&quot;</span><span class="w"> </span><span class="na">model=</span><span class="s">&quot;ir.actions.server&quot;</span><span class="nt">&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;name&quot;</span><span class="nt">&gt;</span>Print<span class="w"> </span>detailed<span class="w"> </span>operations<span class="nt">&lt;/field&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;model_id&quot;</span><span class="w"> </span><span class="na">ref=</span><span class="s">&quot;stock.model_stock_move_line&quot;</span><span class="w"> </span><span class="nt">/&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w">
+           </span><span class="na">name=</span><span class="s">&quot;binding_model_id&quot;</span><span class="w">
+           </span><span class="na">ref=</span><span class="s">&quot;stock.model_stock_move_line&quot;</span><span class="w">
+     </span><span class="nt">/&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;binding_view_types&quot;</span><span class="nt">&gt;</span>list<span class="nt">&lt;/field&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;state&quot;</span><span class="nt">&gt;</span>code<span class="nt">&lt;/field&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;code&quot;</span><span class="nt">&gt;</span><span class="w">
+</span>if<span class="w"> </span>records:<span class="w">
+     </span>report<span class="w"> </span>=<span class="w"> </span>env[&quot;ir.actions.report&quot;].sudo()._get_report(&quot;my_custom_module.my_custom_report_xml_id&quot;)<span class="w">
+     </span>action<span class="w"> </span>=<span class="w"> </span>report.with_context(force_auto_lot=True).report_action(records.ids)<span class="w">
+     </span><span class="nt">&lt;/field&gt;</span><span class="w">
+</span><span class="nt">&lt;/record&gt;</span>
+</pre>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -225,3 +225,53 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             [("product_id", "=", self.product_serial.id)]
         )
         self.assertEqual(len(lot), 1)
+
+    def test_auto_create_lot_force_with_on_print(self):
+        """We can force the auto-creation of the lot on a report print. This can be
+        handy when printing labels before picking validation"""
+        self.picking.action_assign()
+        # Create a report for stock.move.line
+        self.env["ir.ui.view"].create(
+            {
+                "type": "qweb",
+                "name": "stock_picking_auto_create_lot.test_report",
+                "key": "stock_picking_auto_create_lot.test_report",
+                # There's no need to test the arch
+                "arch": "<div />",
+            }
+        )
+        self.env["ir.actions.report"].create(
+            {
+                "name": "Test Stock Move Line Report",
+                "report_name": "stock_picking_auto_create_lot.test_report",
+                "model": "stock.move.line",
+            }
+        )
+        # Create a server action to print the report
+        server_action = self.env["ir.actions.server"].create(
+            {
+                "name": "Test Report Server Action",
+                "model_id": self.env.ref("stock.model_stock_move_line").id,
+                "state": "code",
+                "code": """
+if records:
+    report = env['ir.actions.report'].sudo()._get_report(
+        "stock_picking_auto_create_lot.test_report"
+    )
+    action = report.with_context(force_auto_lot=True).report_action(records.ids)
+""",
+            }
+        )
+        move = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_serial
+        )
+        self.assertEqual(move.product_uom_qty, 3.0)
+        self.assertFalse(move.display_assign_serial)
+        server_action.with_context(
+            active_ids=move.move_line_ids.ids, active_model="stock.move.line"
+        ).run()
+        # Search for serials
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product_serial.id)]
+        )
+        self.assertEqual(len(lot), 3)


### PR DESCRIPTION
There could be several ways to print a detailed operation report label. For example #1922 or even custom report triggered from a report action or a server action.

To support these different scenarios, a context can be injected to the report_action method in order to allow forcing the creation of the detailed operations lots prior to the label printing.

MT-9803

cc @moduon @sergio-teruel @Shide 