### PR TITLE
[16.0][FIX] stock_move_line_change_lot: Use id with browse

### DIFF
--- a/stock_move_line_change_lot/models/stock_move_line.py
+++ b/stock_move_line_change_lot/models/stock_move_line.py
@@ -85,7 +85,7 @@ class StockMoveLine(models.Model):
                 vals.get("location_id", move_line.location_id.id)
             )
             package = move_line.package_id.browse(
-                vals.get("package_id", move_line.package_id)
+                vals.get("package_id", move_line.package_id.id)
             )
 
             available_quantity = 0


### PR DESCRIPTION
Default value in vals.get() might be used by browse(), and should be an ID, not a record