### PR TITLE
[WIP] [14.0] [IMP] stock_picking_invoice_link: add security group to restrict canceling stock moves linked to invoices/bills

### DIFF
--- a/stock_picking_invoice_link/README.rst
+++ b/stock_picking_invoice_link/README.rst
@@ -36,6 +36,10 @@ In standard, if you make a partial delivery and invoice it, then make remaining
 delivery and invoice it, it is impossible to known to what delivery the
 invoices relate to. You only have the quantity.
 
+Additionally, the cancellation of stock moves already linked to invoices or
+bills is restricted to users who belong to the "Allow to cancel stock moves
+linked to invoices/bills" group.
+
 This module is also useful if you want to present data on the invoice report
 grouped by deliveries.
 
@@ -55,6 +59,11 @@ Usage
 * Create an invoice of the goods delivered.
 * If you open invoice form, you must see a new Pickings tab with information
   about them.
+
+* Attempt to cancel a picking linked to invoices/bills.
+* If the user is not part of the group "Allow to cancel stock move linked to invoice/bill",
+  an error will be raised, preventing the cancellation.
+* Members of the group can proceed with the cancellation without restrictions.
 
 Bug Tracker
 ===========

--- a/stock_picking_invoice_link/__manifest__.py
+++ b/stock_picking_invoice_link/__manifest__.py
@@ -18,6 +18,10 @@
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "license": "AGPL-3",
     "depends": ["sale_stock"],
-    "data": ["views/stock_view.xml", "views/account_invoice_view.xml"],
+    "data": [
+        "security/stock_picking_invoice_link_security.xml",
+        "views/stock_view.xml",
+        "views/account_invoice_view.xml",
+    ],
     "installable": True,
 }

--- a/stock_picking_invoice_link/i18n/ca.po
+++ b/stock_picking_invoice_link/i18n/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-18 03:48+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2017-12-18 03:48+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
@@ -21,6 +21,11 @@ msgstr ""
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -132,4 +137,12 @@ msgstr ""
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""

--- a/stock_picking_invoice_link/i18n/de.po
+++ b/stock_picking_invoice_link/i18n/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-23 11:56+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2017-01-23 11:56+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
@@ -21,6 +21,11 @@ msgstr ""
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -132,4 +137,12 @@ msgstr "Lieferung vornehmen"
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""

--- a/stock_picking_invoice_link/i18n/es.po
+++ b/stock_picking_invoice_link/i18n/es.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-26 08:45+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2022-09-26 10:46+0200\n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>, 2017\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
@@ -24,6 +24,11 @@ msgstr ""
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
 msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
+msgstr "Permite cancelar movimientos de existencias vinculados a facturas"
 
 #. module: stock_picking_invoice_link
 #: model:ir.model.fields,field_description:stock_picking_invoice_link.field_account_move__display_name
@@ -139,6 +144,16 @@ msgstr "Transferir"
 #, python-format
 msgid "You can not modify an invoiced stock move"
 msgstr "No puede modificar un movimiento de existencias facturado"
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
+"No puede cancelar un movimiento de existencias vinculado a facturas. Solo los miembros del "
+"grupo \"%(group_name)s\" pueden realizar esta acción. Referencias: %(references)s"
 
 #~ msgid "Journal Entries"
 #~ msgstr "Asientos contables"

--- a/stock_picking_invoice_link/i18n/es_MX.po
+++ b/stock_picking_invoice_link/i18n/es_MX.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-18 03:48+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2017-12-18 03:48+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/"
@@ -22,6 +22,11 @@ msgstr ""
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -133,4 +138,12 @@ msgstr ""
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""

--- a/stock_picking_invoice_link/i18n/fi.po
+++ b/stock_picking_invoice_link/i18n/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: stock-logistics-workflow (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-13 22:02+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2016-09-15 12:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/oca/OCA-stock-logistics-"
@@ -21,6 +21,11 @@ msgstr ""
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -132,4 +137,12 @@ msgstr ""
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""

--- a/stock_picking_invoice_link/i18n/fr.po
+++ b/stock_picking_invoice_link/i18n/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-23 11:56+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2024-07-26 15:58+0000\n"
 "Last-Translator: Julie LeBrun <julie.lebrun@numigi.com>\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
@@ -23,6 +23,11 @@ msgstr ""
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
 msgstr "Renversement de la pièce comptable"
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
+msgstr ""
 
 #. module: stock_picking_invoice_link
 #: model:ir.model.fields,field_description:stock_picking_invoice_link.field_account_move__display_name
@@ -138,3 +143,11 @@ msgstr "Transfert"
 #, python-format
 msgid "You can not modify an invoiced stock move"
 msgstr "Vous ne pouvez pas modifier un mouvement de stock facturé"
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""

--- a/stock_picking_invoice_link/i18n/hr.po
+++ b/stock_picking_invoice_link/i18n/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-28 03:51+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2021-10-08 12:34+0000\n"
 "Last-Translator: Matija Krolo <matija.krolo@ecodica.eu>\n"
 "Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
@@ -17,13 +17,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.3.2\n"
 
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -137,6 +142,14 @@ msgstr "Prijenos"
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""
 
 #~ msgid "Invoice"

--- a/stock_picking_invoice_link/i18n/it.po
+++ b/stock_picking_invoice_link/i18n/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-15 11:08+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2024-02-08 10:33+0000\n"
 "Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
 "Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
@@ -23,6 +23,11 @@ msgstr ""
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
 msgstr "Storno movimento conto"
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
+msgstr ""
 
 #. module: stock_picking_invoice_link
 #: model:ir.model.fields,field_description:stock_picking_invoice_link.field_account_move__display_name
@@ -138,6 +143,14 @@ msgstr "Trasferimento"
 #, python-format
 msgid "You can not modify an invoiced stock move"
 msgstr "Non si può modificare un movimento di magazzino fatturato"
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
 
 #~ msgid "Invoice"
 #~ msgstr "Fattura"

--- a/stock_picking_invoice_link/i18n/nl_NL.po
+++ b/stock_picking_invoice_link/i18n/nl_NL.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-18 03:48+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2017-12-18 03:48+0000\n"
 "Last-Translator: Peter Hageman <hageman.p@gmail.com>, 2017\n"
 "Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/"
@@ -22,6 +22,11 @@ msgstr ""
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -133,4 +138,12 @@ msgstr "Verplaats"
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""

--- a/stock_picking_invoice_link/i18n/pt.po
+++ b/stock_picking_invoice_link/i18n/pt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-18 03:48+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2023-01-04 18:44+0000\n"
 "Last-Translator: Pedro Castro Silva <pedrocs@exo.pt>\n"
 "Language-Team: Portuguese (https://www.transifex.com/oca/teams/23907/pt/)\n"
@@ -23,6 +23,11 @@ msgstr ""
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
 msgstr "Reversão do Movimento Contabilístico"
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
+msgstr ""
 
 #. module: stock_picking_invoice_link
 #: model:ir.model.fields,field_description:stock_picking_invoice_link.field_account_move__display_name
@@ -138,6 +143,14 @@ msgstr "Transferência"
 #, python-format
 msgid "You can not modify an invoiced stock move"
 msgstr "Não pode modificar um movimento de stock faturado"
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
 
 #~ msgid "Journal Entries"
 #~ msgstr "Lançamentos do Diário"

--- a/stock_picking_invoice_link/i18n/pt_BR.po
+++ b/stock_picking_invoice_link/i18n/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-15 11:08+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2019-08-30 15:23+0000\n"
 "Last-Translator: Rodrigo Macedo <rmsolucoeseminformatic4@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/"
@@ -23,6 +23,11 @@ msgstr ""
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -138,6 +143,14 @@ msgstr "Transferir"
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""
 
 #~ msgid "Invoice"

--- a/stock_picking_invoice_link/i18n/sl.po
+++ b/stock_picking_invoice_link/i18n/sl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-23 11:56+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2017-01-23 11:56+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
@@ -16,12 +16,17 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
 
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -133,4 +138,12 @@ msgstr ""
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""

--- a/stock_picking_invoice_link/i18n/stock_picking_invoice_link.pot
+++ b/stock_picking_invoice_link/i18n/stock_picking_invoice_link.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
+"PO-Revision-Date: 2025-04-30 03:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,6 +18,11 @@ msgstr ""
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -127,4 +134,13 @@ msgstr ""
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the"
+" \"%(group_name)s\" group can perform this action. References: "
+"%(references)s"
 msgstr ""

--- a/stock_picking_invoice_link/i18n/tr.po
+++ b/stock_picking_invoice_link/i18n/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-18 03:48+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2023-11-20 19:33+0000\n"
 "Last-Translator: İmat Yahya Çataklı <yahyacatakli@gmail.com>\n"
 "Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
@@ -23,6 +23,11 @@ msgstr ""
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
 msgstr "Hesap Hareketi Ters Kayıt"
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
+msgstr ""
 
 #. module: stock_picking_invoice_link
 #: model:ir.model.fields,field_description:stock_picking_invoice_link.field_account_move__display_name
@@ -138,3 +143,11 @@ msgstr "Teslimat"
 #, python-format
 msgid "You can not modify an invoiced stock move"
 msgstr "Faturalanmış bir stok hareketini değiştiremezsiniz"
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""

--- a/stock_picking_invoice_link/i18n/tr_TR.po
+++ b/stock_picking_invoice_link/i18n/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-18 03:48+0000\n"
+"POT-Creation-Date: 2025-04-30 03:06+0000\n"
 "PO-Revision-Date: 2017-12-18 03:48+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Turkish (Turkey) (https://www.transifex.com/oca/teams/23907/"
@@ -22,6 +22,11 @@ msgstr ""
 #. module: stock_picking_invoice_link
 #: model:ir.model,name:stock_picking_invoice_link.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: model:res.groups,name:stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill
+msgid "Allow to cancel stock moves linked to invoices/bills"
 msgstr ""
 
 #. module: stock_picking_invoice_link
@@ -133,4 +138,12 @@ msgstr ""
 #: code:addons/stock_picking_invoice_link/models/stock_move.py:0
 #, python-format
 msgid "You can not modify an invoiced stock move"
+msgstr ""
+
+#. module: stock_picking_invoice_link
+#: code:addons/stock_picking_invoice_link/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""

--- a/stock_picking_invoice_link/models/stock_move.py
+++ b/stock_picking_invoice_link/models/stock_move.py
@@ -63,3 +63,27 @@ class StockMove(models.Model):
                 or (x.location_dest_id.usage == "internal" and x.to_refund)
             )
         )
+
+    def _action_cancel(self):
+        res = super()._action_cancel()
+        allowed_group = self.env.ref(
+            "stock_picking_invoice_link.group_allow_to_cancel_stock_move_linked_to_invoice_bill"
+        )
+        moves = self.filtered("invoice_line_ids")
+        if moves:
+            if allowed_group not in self.env.user.groups_id:
+                move_references = ",".join(
+                    moves.mapped(
+                        lambda it: f"{it.reference}({it.product_id.default_code})"
+                    )
+                )
+                raise UserError(
+                    _(
+                        "You cannot cancel a stock move linked to invoices/bills. "
+                        'Only members of the "%(group_name)s" group can perform '
+                        "this action. References: %(references)s",
+                        group_name=allowed_group.name,
+                        move_references=move_references,
+                    )
+                )
+        return res

--- a/stock_picking_invoice_link/readme/DESCRIPTION.rst
+++ b/stock_picking_invoice_link/readme/DESCRIPTION.rst
@@ -6,6 +6,10 @@ In standard, if you make a partial delivery and invoice it, then make remaining
 delivery and invoice it, it is impossible to known to what delivery the
 invoices relate to. You only have the quantity.
 
+Additionally, the cancellation of stock moves already linked to invoices or
+bills is restricted to users who belong to the "Allow to cancel stock moves
+linked to invoices/bills" group.
+
 This module is also useful if you want to present data on the invoice report
 grouped by deliveries.
 

--- a/stock_picking_invoice_link/readme/USAGE.rst
+++ b/stock_picking_invoice_link/readme/USAGE.rst
@@ -3,3 +3,8 @@
 * Create an invoice of the goods delivered.
 * If you open invoice form, you must see a new Pickings tab with information
   about them.
+
+* Attempt to cancel a picking linked to invoices/bills.
+* If the user is not part of the group "Allow to cancel stock move linked to invoice/bill",
+  an error will be raised, preventing the cancellation.
+* Members of the group can proceed with the cancellation without restrictions.

--- a/stock_picking_invoice_link/security/stock_picking_invoice_link_security.xml
+++ b/stock_picking_invoice_link/security/stock_picking_invoice_link_security.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record
+        id="group_allow_to_cancel_stock_move_linked_to_invoice_bill"
+        model="res.groups"
+    >
+        <field name="name">Allow to cancel stock moves linked to invoices/bills</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+        <field name="users" eval="[(4, ref('base.user_root'))]" />
+    </record>
+
+    <record id="stock.group_stock_manager" model="res.groups">
+        <field
+            name="implied_ids"
+            eval="[(4, ref('group_allow_to_cancel_stock_move_linked_to_invoice_bill'))]"
+        />
+    </record>
+</odoo>

--- a/stock_picking_invoice_link/static/description/index.html
+++ b/stock_picking_invoice_link/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -376,6 +376,9 @@ which deliveries an invoice relates to.</p>
 <p>In standard, if you make a partial delivery and invoice it, then make remaining
 delivery and invoice it, it is impossible to known to what delivery the
 invoices relate to. You only have the quantity.</p>
+<p>Additionally, the cancellation of stock moves already linked to invoices or
+bills is restricted to users who belong to the “Allow to cancel stock moves
+linked to invoices/bills” group.</p>
 <p>This module is also useful if you want to present data on the invoice report
 grouped by deliveries.</p>
 <p>Note that the links are only for products with an invoicing policy set on
@@ -401,6 +404,10 @@ delivery.</p>
 <li>Create an invoice of the goods delivered.</li>
 <li>If you open invoice form, you must see a new Pickings tab with information
 about them.</li>
+<li>Attempt to cancel a picking linked to invoices/bills.</li>
+<li>If the user is not part of the group “Allow to cancel stock move linked to invoice/bill”,
+an error will be raised, preventing the cancellation.</li>
+<li>Members of the group can proceed with the cancellation without restrictions.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
@@ -458,7 +465,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
This PR introduces a restriction to prevent the cancellation of stock moves that are already linked to invoices or vendor bills. Only users who are members of the "Allow to cancel stock moves linked to invoices/bills" group will be authorized to perform this action.

## Why Restrict Cancelling Stock Moves Linked to Invoices/Bills

- **Data Integrity**: Prevents inconsistencies between inventory and accounting.
- **Controlled Access**: Cancellation is still allowed, but only for users in the designated security group.
- **Legal and Financial Compliance**: Avoids issues with invoiced or billed records.
- **Auditability**: Maintains a clear and traceable record of exceptional actions.
- **Best Practice**: Encourages using proper workflows like credit notes or returns.

## ROADMAP

- [x] create security group
- [x] restrict cancellation at the stock move model level
- [x] update translations
- [ ] create a test

@BinhexTeam