### PR TITLE
[14.0][FIX] delivery_procurement_group_carrier: Do not align carrier again, allow to set carrier to False

### DIFF
--- a/delivery_procurement_group_carrier/models/stock_picking.py
+++ b/delivery_procurement_group_carrier/models/stock_picking.py
@@ -15,7 +15,6 @@ class StockPicking(models.Model):
                 continue
             pickings = self.browse().union(*pickings)
             carrier = pickings.carrier_id
-            carrier.ensure_one()
             group.carrier_id = carrier
             domain = [
                 ("group_id", "=", group.id),

--- a/delivery_procurement_group_carrier/models/stock_picking.py
+++ b/delivery_procurement_group_carrier/models/stock_picking.py
@@ -16,22 +16,23 @@ class StockPicking(models.Model):
             pickings = self.browse().union(*pickings)
             carrier = pickings.carrier_id
             carrier.ensure_one()
-            need_align_pickings = self.search(
-                [
-                    ("group_id", "=", group.id),
-                    (
-                        "state",
-                        "not in",
-                        (
-                            "done",
-                            "cancel",
-                        ),
-                    ),
-                    ("carrier_id", "!=", carrier.id),
-                    ("carrier_id", "!=", False),
-                ]
-            )
             group.carrier_id = carrier
+            domain = [
+                ("group_id", "=", group.id),
+                (
+                    "state",
+                    "not in",
+                    (
+                        "done",
+                        "cancel",
+                    ),
+                ),
+                ("carrier_id", "!=", carrier.id),
+                ("carrier_id", "!=", False),
+            ]
+            need_align_pickings = self.search(domain).with_context(
+                skip_align_group_carrier=True
+            )
             if need_align_pickings:
                 need_align_pickings.carrier_id = carrier
 

--- a/delivery_procurement_group_carrier/tests/test_carrier.py
+++ b/delivery_procurement_group_carrier/tests/test_carrier.py
@@ -100,3 +100,9 @@ class TestProcurementGroupCarrier(SavepointCase):
         self.assertEqual(out_transfer.carrier_id, self.carrier)
         self.assertEqual(pick_transfer.carrier_id, self.carrier)
         self.assertEqual(move_group.carrier_id, self.carrier)
+
+        # Ensure carrier can be set to False
+        out_transfer.carrier_id = False
+        self.assertFalse(out_transfer.carrier_id)
+        self.assertFalse(pick_transfer.carrier_id)
+        self.assertFalse(move_group.carrier_id)


### PR DESCRIPTION
Right now it not is not possible to set the carrier on a picking to False, since there is the `ensure_one` check. 
Also the method `_align_group_carrier` gets called multiple times, if the carrier gets set in `_align_group_carrier`, with using the already existing context key this will not happen. 

cc @jbaudoux @mmequignon @i-vyshnevska @raumschmiede-joshuaL