### PR TITLE
[18.0][IMP] stock_move_quantity_product_uom: add init hook and migration roadmap

### DIFF
--- a/stock_move_quantity_product_uom/README.rst
+++ b/stock_move_quantity_product_uom/README.rst
@@ -36,6 +36,14 @@ product.
 .. contents::
    :local:
 
+Known issues / Roadmap
+======================
+
+This module was incorrectly placed in stock-logistics-workflow
+repository, during migration to v19, we should relocate the module at
+stock-logistics-warehouse. See
+https://github.com/OCA/stock-logistics-workflow/pull/1939#issuecomment-2879222438
+
 Bug Tracker
 ===========
 

--- a/stock_move_quantity_product_uom/__init__.py
+++ b/stock_move_quantity_product_uom/__init__.py
@@ -2,3 +2,4 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from . import models
+from .hook import pre_init_quantity_product_uom, post_init_quantity_product_uom

--- a/stock_move_quantity_product_uom/__manifest__.py
+++ b/stock_move_quantity_product_uom/__manifest__.py
@@ -12,4 +12,6 @@
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "depends": ["stock"],
     "installable": True,
+    "pre_init_hook": "pre_init_quantity_product_uom",
+    "post_init_hook": "post_init_quantity_product_uom",
 }

--- a/stock_move_quantity_product_uom/hook.py
+++ b/stock_move_quantity_product_uom/hook.py
@@ -1,0 +1,25 @@
+from odoo.tools.sql import column_exists, create_column
+
+
+def pre_init_quantity_product_uom(env):
+    if not column_exists(env.cr, "stock_move", "quantity_product_uom"):
+        create_column(env.cr, "stock_move", "quantity_product_uom", "float8")
+    env.cr.execute(
+        """
+        UPDATE stock_move sm
+        SET quantity_product_uom = sm.quantity
+        FROM product_product pp
+        JOIN product_template pt ON pt.id = pp.product_tmpl_id
+        WHERE sm.product_id = pp.id
+          AND pt.uom_id = sm.product_uom
+        """
+    )
+    env.cr.commit()
+    return True
+
+
+def post_init_quantity_product_uom(env):
+    env["stock.move"].search(
+        [("quantity_product_uom", "=", None)]
+    )._compute_quantity_product_uom()
+    env.cr.commit()

--- a/stock_move_quantity_product_uom/readme/ROADMAP.md
+++ b/stock_move_quantity_product_uom/readme/ROADMAP.md
@@ -1,0 +1,3 @@
+This module was incorrectly placed in stock-logistics-workflow repository,
+during migration to v19, we should relocate the module at stock-logistics-warehouse.
+See https://github.com/OCA/stock-logistics-workflow/pull/1939#issuecomment-2879222438

--- a/stock_move_quantity_product_uom/static/description/index.html
+++ b/stock_move_quantity_product_uom/static/description/index.html
@@ -375,17 +375,25 @@ product.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-1">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-1">Known issues / Roadmap</a></h1>
+<p>This module was incorrectly placed in stock-logistics-workflow
+repository, during migration to v19, we should relocate the module at
+stock-logistics-warehouse. See
+<a class="reference external" href="https://github.com/OCA/stock-logistics-workflow/pull/1939#issuecomment-2879222438">https://github.com/OCA/stock-logistics-workflow/pull/1939#issuecomment-2879222438</a></p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/stock-logistics-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -393,15 +401,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-2">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
 <li>ForgeFlow S.L.</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="mailto:contact&#64;forgeflow.com">ForgeFlow S.L.</a>:<ul>
 <li>Thiago Mulero</li>
@@ -410,7 +418,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />


### PR DESCRIPTION
This PR does 2 things:
- include init script proposed in v17 https://github.com/OCA/stock-logistics-workflow/pull/1939
- add a roadmap note to relocate the addon during migration to v19 as discussed https://github.com/OCA/stock-logistics-workflow/pull/1939#issuecomment-2893270729