### PR TITLE
[18.0][FIX] stock_picking_type_force_move_type: Applied forced move_type in _get_new_picking_values

### DIFF
--- a/stock_picking_type_force_move_type/models/__init__.py
+++ b/stock_picking_type_force_move_type/models/__init__.py
@@ -1,2 +1,3 @@
 from . import stock_picking
+from . import stock_move
 from . import stock_picking_type

--- a/stock_picking_type_force_move_type/models/stock_move.py
+++ b/stock_picking_type_force_move_type/models/stock_move.py
@@ -1,0 +1,18 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_new_picking_values(self):
+        res = super()._get_new_picking_values()
+        # We explicitly set `move_type` here because during the picking creation,
+        # if 'move_type' is not present in `vals` and a `group_id` is provided,
+        # the compute method is not triggered. This is due to the logic in
+        # stock.picking's `create()` method.
+        # Therefore, to ensure the correct `move_type` is set based on the picking type,
+        # we must explicitly assign it here.
+        picking_type = self.mapped("picking_type_id")
+        if picking_type.force_move_type:
+            res["move_type"] = picking_type.move_type
+        return res


### PR DESCRIPTION
- Applied `force_move_type` in `_get_new_picking_values`. This fix ensures that the move_type is correctly set based on the operation type's configuration when the force_move_type flag is enabled.

- Steps to Reproduce:
1) Enable 'Multi-Step Routes' and configure a 2-step delivery at the warehouse level.
2) Go to the Operation Type "Pick" and:
    - Enable the 'Force Shipping Policy' (force_move_type)
    - Set 'Shipping Policy' (move_type) to "When all products are ready"

Note: By default, at the procurement level, the delivery type (move_type) is set to "Partial"

3) Create and confirm a Sale Order.

- Issue: The first delivery created with type "Pick" does not follow the configured shipping policy.
Instead of applying "When all products are ready", the delivery shows "As soon as possible" as the shipping policy.