### PR TITLE
[18.0][IMP] stock_picking_group_by_partner_by_carrier: key assign

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -118,8 +118,8 @@ class StockMove(models.Model):
 
     def _key_assign_picking(self):
         return (
-            self.sale_line_id.order_id.partner_shipping_id,
-            PickingPolicy(id=self.sale_line_id.order_id.picking_policy),
+            self.group_id.partner_id,
+            PickingPolicy(id=self.group_id.move_type),
         ) + super()._key_assign_picking()
 
 


### PR DESCRIPTION
Collect grouping info from the procurement group and not the sales order

Changing the carrier on the delivery is now reflected to the procurement group thanks to https://github.com/OCA/stock-logistics-workflow/pull/1985
That value from the procurement group should be used for merging deliveries. The value on the sales order is readonly and cannot be changed.

Same for the shipping address, it's propagated from the sales to the procurement group. So better take it from there.

@theangryangel @mt-software-de @sebalix @rousseldenis 