### PR TITLE
[18.0][IMP] stock_picking_group_by_partner_by_carrier: allow to group when policy is one

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
-# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from collections import namedtuple
@@ -73,7 +73,10 @@ class StockMove(models.Model):
         if (
             not self.picking_type_id.group_pickings
             or self.partner_id.disable_picking_grouping
-            or self.group_id.sale_id.picking_policy == "one"
+            or (
+                not self.picking_type_id.group_pickings_one
+                and self.group_id.move_type == "one"
+            )
         ):
             return domain
 

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
-# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from itertools import groupby

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking_type.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking_type.py
@@ -6,9 +6,13 @@ class StockPickingType(models.Model):
 
     group_pickings = fields.Boolean(
         "Group pickings",
-        help="Group pickings for the same partner and carrier. "
-        "Pickings with shipping policy set to "
-        "'When all products are ready' are never grouped.",
+        help="Group transfers for the same partner and carrier. ",
+    )
+    group_pickings_one = fields.Boolean(
+        "Also group when policy is 'one'",
+        help="Also group transfers with a shipping policy "
+        "'When all products are ready'. Transfers with different shipping "
+        "policies are not grouped",
     )
 
     show_group_pickings = fields.Boolean(compute="_compute_show_group_pickings")

--- a/stock_picking_group_by_partner_by_carrier/models/stock_warehouse.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_warehouse.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from odoo import fields, models
 
 
@@ -5,10 +8,10 @@ class StockWarehouse(models.Model):
     _inherit = "stock.warehouse"
 
     group_shippings = fields.Boolean(
-        "Group shippings",
         related="out_type_id.group_pickings",
         readonly=False,
-        help="Group shippings for the same partner and carrier. "
-        "Shippings with shipping policy set to "
-        "'When all products are ready' are never grouped.",
+    )
+    group_shippings_one = fields.Boolean(
+        related="out_type_id.group_pickings_one",
+        readonly=False,
     )

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
@@ -69,7 +69,7 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         self.assertFalse(so2.picking_ids.carrier_id)
         self.assertNotEqual(so1.picking_ids, so2.picking_ids)
 
-    def test_sale_stock_no_merge_same_carrier_picking_policy_one(self):
+    def test_sale_stock_no_merge_same_carrier_picking_policy_one_disabled(self):
         """2 sale orders for the same partner, with same carrier, deliver at
         once picking policy
 
@@ -90,6 +90,28 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         self.assertTrue(so1.name in so1.picking_ids[0].origin)
         self.assertTrue(so2.name in so2.picking_ids[0].origin)
 
+    def test_sale_stock_no_merge_same_carrier_picking_policy_one_enabled(self):
+        """2 sale orders for the same partner, with same carrier, deliver at
+        once picking policy
+
+        -> the pickings are merged
+
+        """
+        self.env.ref("stock.warehouse0").group_shippings_one = True
+        so1 = self._get_new_sale_order(carrier=self.carrier1)
+        so1.picking_policy = "one"
+        so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
+        so2.picking_policy = "one"
+        so1.action_confirm()
+        so2.action_confirm()
+        # there is a picking for each the sales, different
+        self.assertTrue(so1.picking_ids)
+        self.assertTrue(so2.picking_ids)
+        self.assertEqual(so1.picking_ids, so2.picking_ids)
+        # the origin of the picking mentions both sales names
+        self.assertTrue(so1.name in so1.picking_ids[0].origin)
+        self.assertTrue(so2.name in so2.picking_ids[0].origin)
+
     def test_sale_stock_no_merge_same_carrier_mixed_picking_policy(self):
         """2 sale orders for the same partner, with same carrier, deliver at once
         picking policy for the 1st sale order.
@@ -97,6 +119,7 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         -> the pickings are not merged
 
         """
+        self.env.ref("stock.warehouse0").group_shippings_one = True
         so1 = self._get_new_sale_order(carrier=self.carrier1)
         so1.picking_policy = "one"
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping_push_rules.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping_push_rules.py
@@ -61,7 +61,7 @@ class TestGroupByPushRules(TestGroupByBase, TransactionCase):
         self.assertFalse(so2.picking_ids.carrier_id)
         self.assertNotEqual(so1.picking_ids, so2.picking_ids)
 
-    def test_sale_stock_no_merge_same_carrier_picking_policy_one(self):
+    def test_sale_stock_no_merge_same_carrier_picking_policy_one_disabled(self):
         """2 sale orders for the same partner, with same carrier, deliver at
         once picking policy
 
@@ -82,6 +82,28 @@ class TestGroupByPushRules(TestGroupByBase, TransactionCase):
         self.assertTrue(so1.name in so1.picking_ids[0].origin)
         self.assertTrue(so2.name in so2.picking_ids[0].origin)
 
+    def test_sale_stock_no_merge_same_carrier_picking_policy_one_enabled(self):
+        """2 sale orders for the same partner, with same carrier, deliver at
+        once picking policy
+
+        -> the pickings are merged
+
+        """
+        self.env.ref("stock.warehouse0").group_shippings_one = True
+        so1 = self._get_new_sale_order(carrier=self.carrier1)
+        so1.picking_policy = "one"
+        so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
+        so2.picking_policy = "one"
+        so1.action_confirm()
+        so2.action_confirm()
+        # there is a picking for each the sales, different
+        self.assertTrue(so1.picking_ids)
+        self.assertTrue(so2.picking_ids)
+        self.assertEqual(so1.picking_ids, so2.picking_ids)
+        # the origin of the picking mentions both sales names
+        self.assertTrue(so1.name in so1.picking_ids[0].origin)
+        self.assertTrue(so2.name in so2.picking_ids[0].origin)
+
     def test_sale_stock_no_merge_same_carrier_mixed_picking_policy(self):
         """2 sale orders for the same partner, with same carrier, deliver at once
         picking policy for the 1st sale order.
@@ -89,6 +111,7 @@ class TestGroupByPushRules(TestGroupByBase, TransactionCase):
         -> the pickings are not merged
 
         """
+        self.env.ref("stock.warehouse0").group_shippings_one = True
         so1 = self._get_new_sale_order(carrier=self.carrier1)
         so1.picking_policy = "one"
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)

--- a/stock_picking_group_by_partner_by_carrier/views/stock_picking_type.xml
+++ b/stock_picking_group_by_partner_by_carrier/views/stock_picking_type.xml
@@ -8,6 +8,10 @@
             <xpath expr="//group[@name='first']/group[2]" position="inside">
                 <field name="show_group_pickings" invisible="True" />
                 <field name="group_pickings" invisible="not show_group_pickings" />
+                <field
+                    name="group_pickings_one"
+                    invisible="not show_group_pickings or not group_pickings"
+                />
             </xpath>
         </field>
     </record>

--- a/stock_picking_group_by_partner_by_carrier/views/stock_warehouse.xml
+++ b/stock_picking_group_by_partner_by_carrier/views/stock_warehouse.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="out_type_id" position="after">
                 <field name="group_shippings" />
+                <field name="group_shippings_one" invisible="not group_shippings" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Allow to also group when policy is "When all are ready".

Mixed policies are currently not merged. Not on purpose, just to make it easy. Could be improved in the future if someone needs that feature.

@theangryangel @mt-software-de @sebalix @rousseldenis