### PR TITLE
[18.0][FIX] stock_picking_group_by_partner_by_carrier: improperly ported method _create_backorder on stock.picking

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -85,12 +85,19 @@ class StockPicking(models.Model):
         else:
             return super().action_cancel()
 
-    def _create_backorder(self):
+    def _create_backorder(self, backorder_moves=None):
         backorders = self.browse()
         for picking in self:
             if not picking._is_grouping_disabled():
                 picking = picking.with_context(picking_no_copy_if_can_group=1)
-            backorder = super(StockPicking, picking)._create_backorder()
+            picking_backorder_moves = None
+            if backorder_moves:
+                picking_backorder_moves = backorder_moves.filtered(
+                    lambda x, picking=picking: x.picking_id == picking
+                )
+            backorder = super(StockPicking, picking)._create_backorder(
+                backorder_moves=picking_backorder_moves
+            )
             if backorder and not picking._is_grouping_disabled():
                 backorder._merge_procurement_groups()
                 backorder._update_merged_origin()


### PR DESCRIPTION
Without this fix raising backorders from a `stock.picking` can fail under certain circumstances.

I'm sorry I should've picked this up during the initial port.