### PR TITLE
[17.0][FIX] stock_picking_group_by_base: Uninstall hook

### DIFF
--- a/stock_picking_group_by_base/__init__.py
+++ b/stock_picking_group_by_base/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import uninstall_hook

--- a/stock_picking_group_by_base/hooks.py
+++ b/stock_picking_group_by_base/hooks.py
@@ -3,9 +3,11 @@
 from psycopg2.extensions import AsIs
 
 
-def uninstall_hook(cr, registry):
+def uninstall_hook(env):
     """
     This method will remove created index
     """
     index_name = "stock_picking_groupby_key_index"
-    cr.execute("DROP INDEX IF EXISTS %(index_name)s", dict(index_name=AsIs(index_name)))
+    env.cr.execute(
+        "DROP INDEX IF EXISTS %(index_name)s", dict(index_name=AsIs(index_name))
+    )


### PR DESCRIPTION
While cleaning the environment after #2001, I have detected this problem that the uninstall hook is not linked and it's outdated, so I have fixed it.

@Tecnativa 