### PR TITLE
[IMP][18.0] stock_partner_delivery_window: Add weekdays

### DIFF
--- a/stock_partner_delivery_window/README.rst
+++ b/stock_partner_delivery_window/README.rst
@@ -77,6 +77,7 @@ Contributors
 
 - Akim Juillerat <akim.juillerat@camptocamp.com>
 - Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
+- Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Trobz
 

--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import Command, api, fields, models
@@ -69,6 +70,24 @@ class ResPartner(models.Model):
                 ].browse()
             res[window.partner_id.id] |= window
         return res
+
+    @property
+    def delivery_time_weekdays(self):
+        self.ensure_one()
+        if self.delivery_time_preference == "anytime":
+            weekdays = set(range(7))
+        elif self.delivery_time_preference == "workdays":
+            weekdays = set(range(5))
+        else:
+            weekdays = set(
+                map(
+                    int,
+                    self.delivery_time_window_ids.time_window_weekday_ids.mapped(
+                        "name"
+                    ),
+                )
+            )
+        return weekdays
 
     def is_in_delivery_window(self, date_time):
         """

--- a/stock_partner_delivery_window/readme/CONTRIBUTORS.md
+++ b/stock_partner_delivery_window/readme/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 - Akim Juillerat \<<akim.juillerat@camptocamp.com>\>
 - Matthieu Méquignon \<<matthieu.mequignon@camptocamp.com>\>
+- Jacques-Etienne Baudoux (BCIM) \<<je@bcim.be>\>
 
 Trobz
 

--- a/stock_partner_delivery_window/static/description/index.html
+++ b/stock_partner_delivery_window/static/description/index.html
@@ -423,6 +423,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Akim Juillerat &lt;<a class="reference external" href="mailto:akim.juillerat&#64;camptocamp.com">akim.juillerat&#64;camptocamp.com</a>&gt;</li>
 <li>Matthieu Méquignon &lt;<a class="reference external" href="mailto:matthieu.mequignon&#64;camptocamp.com">matthieu.mequignon&#64;camptocamp.com</a>&gt;</li>
+<li>Jacques-Etienne Baudoux (BCIM) &lt;<a class="reference external" href="mailto:je&#64;bcim.be">je&#64;bcim.be</a>&gt;</li>
 </ul>
 <p>Trobz</p>
 <ul class="simple">

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from freezegun import freeze_time
 
@@ -183,3 +184,16 @@ class TestPartnerDeliveryWindow(BaseCommon):
         self.assertEqual(len(copied_partner.delivery_time_window_ids), expecting)
         copied_partner = self.customer_working_days.copy()
         self.assertFalse(copied_partner.delivery_time_window_ids)
+
+    def test_weekdays_anytime(self):
+        self.assertEqual(
+            self.customer_anytime.delivery_time_weekdays, {0, 1, 2, 3, 4, 5, 6}
+        )
+
+    def test_weekdays_working_days(self):
+        self.assertEqual(
+            self.customer_working_days.delivery_time_weekdays, {0, 1, 2, 3, 4}
+        )
+
+    def test_weekdays_time_window(self):
+        self.assertEqual(self.customer_time_window.delivery_time_weekdays, {3, 5})


### PR DESCRIPTION
Forward-port the fix from [#1940](https://github.com/OCA/stock-logistics-workflow/pull/1940) (merged in v16 after v18 migration) to restore missing functionality in `stock_partner_delivery_window` for v18.