### PR TITLE
[WIP][18.0][FIX] stock_move_quantity_product_uom: fix pre_init_hook to avoid computation of `quantity_product_uom`

### DIFF
--- a/stock_move_quantity_product_uom/hook.py
+++ b/stock_move_quantity_product_uom/hook.py
@@ -3,7 +3,7 @@ from odoo.tools.sql import column_exists, create_column
 
 def pre_init_quantity_product_uom(env):
     if not column_exists(env.cr, "stock_move", "quantity_product_uom"):
-        create_column(env.cr, "stock_move", "quantity_product_uom", "float8")
+        create_column(env.cr, "stock_move", "quantity_product_uom", "double precision")
     env.cr.execute(
         """
         UPDATE stock_move sm


### PR DESCRIPTION
Despite the pre init hook, installation of the module on big databases is taking quite some time. It happens the column type set in the pre init hook is the wrong one, so Odoo is updating it afterwards, which takes time if the `stock_move` table is big enough.

From `odoo/fields.py`, column are created with the second element of type tuple:
```python
    def update_db_column(self, model, column):
        """ Create/update the column corresponding to ``self``.

            :param model: an instance of the field's model
            :param column: the column's configuration (dict) if it exists, or ``None``
        """
        if not column:
            # the column does not exist, create it
            sql.create_column(model._cr, model._table, self.name, self.column_type[1], self.string)
```
Still in `odoo/fields.py`, `class Float`, the right type to use on `fields.Float` without `digits` set is `double precision`, which is the 2nd element in the tuple:
```python
    @property
    def _column_type(self):
        # Explicit support for "falsy" digits (0, False) to indicate a NUMERIC
        # field with no fixed precision. The values are saved in the database
        # with all significant digits.
        # FLOAT8 type is still the default when there is no precision because it
        # is faster for most operations (sums, etc.)
        return ('numeric', 'numeric') if self._digits is not None else \
               ('float8', 'double precision')
```