### PR TITLE
[16.0] [FIX] stock_picking_invoice_link: remove duplicated element in stock.move form view

### DIFF
--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -44,26 +44,4 @@
             </group>
         </field>
     </record>
-    <record id="view_move_picking_form" model="ir.ui.view">
-        <field name="name">stock_picking_invoice_link.stock.move.picking.form</field>
-        <field name="model">stock.move</field>
-        <field name="inherit_id" ref="stock.view_move_form" />
-        <field name="arch" type="xml">
-            <group position="after">
-                <field name="invoice_line_ids" inivisible="1" />
-                <group
-                    name="invoice_line"
-                    string="Invoice Lines"
-                    attrs="{'invisible':[('invoice_line_ids', '=', [])]}"
-                >
-                    <field
-                        name="invoice_line_ids"
-                        nolabel="1"
-                        groups="account.group_account_invoice"
-                        widget="one2many_list"
-                    />
-                </group>
-            </group>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
This pull request removes a custom form view for stock moves (`view_move_picking_form`) that included invoice line details. The view was inherited from the `stock.view_move_form`.

Why? at: #1785 

@BinhexTeam