### PR TITLE
[FIX] stock_picking_invoice_link: correct invoice_line_ids field in stock.move form view

### DIFF
--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -27,7 +27,7 @@
         <field name="inherit_id" ref="stock.view_move_form" />
         <field name="arch" type="xml">
             <group name="linked_group" position="after">
-                <field name="invoice_line_ids" inivisible="1" />
+                <field name="invoice_line_ids" invisible="1" />
                 <group
                     name="invoice_line"
                     string="Invoice Lines"
@@ -37,6 +37,7 @@
                     <field
                         name="invoice_line_ids"
                         nolabel="1"
+                        colspan="2"
                         groups="account.group_account_invoice"
                         widget="one2many_list"
                     />


### PR DESCRIPTION
This pull request includes a small fix to correct a typo in the `stock_view.xml` file. The attribute `inivisible` was replaced with the correct spelling `invisible`. This is causing the `invoice_line_ids` field is rendered twice.

The second one needs also a colspan.

![image](https://github.com/user-attachments/assets/7b84dd79-b15c-485f-b547-18994c10f5ca)

@BinhexTeam