### PR TITLE
[IMP] stock_picking_grn_mandatory: enforce GRN check in _action_done

### DIFF
--- a/stock_picking_grn_mandatory/models/stock_picking.py
+++ b/stock_picking_grn_mandatory/models/stock_picking.py
@@ -9,7 +9,7 @@ class StockPicking(models.Model):
 
     _inherit = "stock.picking"
 
-    def button_validate(self) -> bool or dict:
+    def _check_grn_mandatory(self):
         """
         Check if the GRN is well set when validating picking
         """
@@ -18,4 +18,11 @@ class StockPicking(models.Model):
             for picking in self.filtered(lambda p: p.picking_type_id.is_grn_mandatory)
         ):
             raise UserError(_("The picking must be linked to a Goods Received Note"))
+
+    def button_validate(self) -> bool or dict:
+        self._check_grn_mandatory()
         return super().button_validate()
+
+    def _action_done(self):
+        self._check_grn_mandatory()
+        return super()._action_done()

--- a/stock_picking_grn_mandatory/tests/test_grn_mandatory.py
+++ b/stock_picking_grn_mandatory/tests/test_grn_mandatory.py
@@ -49,6 +49,9 @@ class TestStockGrnMandatory(TransactionCase):
         with self.assertRaises(UserError, msg=msg):
             self.move.picking_id.button_validate()
 
+        with self.assertRaises(UserError, msg=msg):
+            self.move.picking_id._action_done()
+
         # Fill in the GRN
         delivery_note_supplier_number = "DN TEST"
         grn = self.grn_model.create(


### PR DESCRIPTION
some processes bypass the button_validate method and call _action_done directly to validate pickings, which skips the GRN requirement check

this PR ensures consistency by applying the same GRN check in _action_done as in button_validate