### PR TITLE
[17.0] [FIX] stock_picking_invoice_link: add colspan attribute to invoice_line_ids field in stock.move form

### DIFF
--- a/stock_picking_invoice_link/views/stock_view.xml
+++ b/stock_picking_invoice_link/views/stock_view.xml
@@ -26,22 +26,22 @@
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_form" />
         <field name="arch" type="xml">
-            <group name="linked_group" position="after">
+            <xpath expr="//group" position="after">
                 <field name="invoice_line_ids" invisible="1" />
                 <group
                     name="invoice_line"
                     string="Invoice Lines"
-                    colspan="2"
                     invisible="invoice_line_ids == []"
                 >
                     <field
                         name="invoice_line_ids"
                         nolabel="1"
+                        colspan="2"
                         groups="account.group_account_invoice"
                         widget="one2many_list"
                     />
                 </group>
-            </group>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This pull request includes a minor update to the `stock_view.xml` file. The change adds a `colspan` attribute with a value of `2` to the `invoice_line_ids` field, improving the layout of the field in the user interface. Previously:

![image](https://github.com/user-attachments/assets/b40ea83d-42c6-4346-b504-dbcc9a3d9aac)
