### PR TITLE
[REF] stock_restrict_lot: refactor test for compatibility

### DIFF
--- a/stock_restrict_lot/tests/test_restrict_lot.py
+++ b/stock_restrict_lot/tests/test_restrict_lot.py
@@ -242,6 +242,7 @@ class TestRestrictLot(SavepointCase):
         )
 
     def test_compute_quantites(self):
+        initial_outgoint_qty = self.product.outgoing_qty
         move = self.env["stock.move"].create(
             {
                 "product_id": self.product.id,
@@ -264,7 +265,7 @@ class TestRestrictLot(SavepointCase):
         move2._action_confirm()
 
         product = move.product_id
-        self.assertEqual(product.outgoing_qty, 2)
+        self.assertEqual(product.outgoing_qty, initial_outgoint_qty + 2)
         product.invalidate_cache()
         product = product.with_context(lot_id=self.lot.id)
         self.assertEqual(product.outgoing_qty, 1)


### PR DESCRIPTION
Small change to a test. In certain cases, other modules may introduce data, including demo data, that creates a failure in the test.

Specifically, we encountered an error when installing `website_sale` before this module, since in the demo data a Sales Order is created and confirmed using product `product.product_product_16`

https://github.com/odoo/odoo/blob/14.0/addons/website_sale/data/demo.xml#L568-L575
https://github.com/odoo/odoo/blob/14.0/addons/website_sale/data/demo.xml#L645

This means that the `outgoing_qty` is already 1 when the test starts, instead of the expected 0, and the next checks fail.