### PR TITLE
[18.0][IMP] delivery_total_weight_from_packaging: Add hooks

### DIFF
--- a/delivery_total_weight_from_packaging/models/stock_move.py
+++ b/delivery_total_weight_from_packaging/models/stock_move.py
@@ -14,3 +14,17 @@ class StockMove(models.Model):
             move.weight = move.product_id.get_total_weight_from_packaging(
                 move.product_qty
             )
+
+    def _get_processible_quantity(self):
+        self.ensure_one()
+        if self.product_id:
+            return self.quantity
+        return 0
+
+    def _get_estimated_weight(self):
+        self.ensure_one()
+        product = self.product_id
+        if product:
+            quantity = self._get_processible_quantity()
+            return product.get_total_weight_from_packaging(quantity)
+        return 0

--- a/delivery_total_weight_from_packaging/models/stock_picking.py
+++ b/delivery_total_weight_from_packaging/models/stock_picking.py
@@ -23,10 +23,7 @@ class StockPicking(models.Model):
         """Override to calculate the estimated total weight of all
         move lines in the record using product packaging."""
         self.ensure_one()
-        weight = 0.0
-        for move_line in self.move_line_ids:
-            if move_line.product_id:
-                weight += move_line.product_id.get_total_weight_from_packaging(
-                    move_line.quantity
-                )
+        weight = 0
+        for move in self.move_ids:
+            weight += move._get_estimated_weight()
         return weight


### PR DESCRIPTION
Make use of stock.move.quantity which already aggregates stock.move.line.quantity, and add hooks allowing to use a different quantity I.E. stock_available_to_promise_release.