### PR TITLE
[IMP] stock_move_line_qty_picked: sync `picked` and `qty_picked` fields

### DIFF
--- a/stock_move_line_qty_picked/models/stock_move_line.py
+++ b/stock_move_line_qty_picked/models/stock_move_line.py
@@ -7,13 +7,36 @@ from odoo.tools import float_compare
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    qty_picked = fields.Float()
+    picked = fields.Boolean(
+        # Override std field
+        inverse="_inverse_picked",
+        copy=False,
+    )
+    qty_picked = fields.Float(inverse="_inverse_qty_picked", copy=False)
+
+    def _inverse_picked(self):
+        if self.env.context.get("move_line_pick_qty"):
+            return
+        for rec in self:
+            # Reset picked qty to 0
+            if not rec.picked:
+                rec._pick_qty(0)
+                continue
+            # Pick full quantity when 'picked = True' and no qty were picked
+            if not rec.qty_picked:
+                rec._pick_qty(rec.quantity)
+
+    def _inverse_qty_picked(self):
+        if self.env.context.get("move_line_pick_qty"):
+            return
+        for rec in self:
+            rec._pick_qty(rec.qty_picked)
 
     def _pick_qty(self, qty):
         self.ensure_one()
         values = {
             "qty_picked": qty,
-            "picked": True,
+            "picked": bool(qty),
         }
         total_demand = self.move_id.product_uom_qty
         total_reserved = sum(self.move_id.move_line_ids.mapped("quantity"))
@@ -24,7 +47,7 @@ class StockMoveLine(models.Model):
             <= 0
         ):
             values["quantity"] = qty
-        self.write(values)
+        self.with_context(move_line_pick_qty=True).update(values)
         return True
 
     def _action_done(self):

--- a/stock_move_line_qty_picked/tests/test_stock_move_line_qty_picked.py
+++ b/stock_move_line_qty_picked/tests/test_stock_move_line_qty_picked.py
@@ -58,10 +58,17 @@ class TestStockMoveLineQtyPicked(TransactionCase):
         self.assertEqual(move_line.quantity, 5)
         self.assertEqual(move_line.qty_picked, 0)
         self.assertFalse(move_line.picked)
-        move_line._pick_qty(3)
+        # Pick partial qty
+        move_line.qty_picked = 3
         self.assertEqual(move_line.quantity, 5)
         self.assertEqual(move_line.qty_picked, 3)
         self.assertTrue(move_line.picked)
+        # Updating 'picked' to True should not reset the picked qty
+        move_line.picked = True
+        self.assertEqual(move_line.quantity, 5)
+        self.assertEqual(move_line.qty_picked, 3)
+        self.assertTrue(move_line.picked)
+        # When validating, only the picked qty is moved
         move.picking_id.with_context(skip_backorder=True).button_validate()
         self.assertEqual(move_line.quantity, 3)
 
@@ -74,7 +81,7 @@ class TestStockMoveLineQtyPicked(TransactionCase):
         self.assertEqual(move_line.quantity, 10)
         self.assertEqual(move_line.qty_picked, 0)
         self.assertFalse(move_line.picked)
-        move_line._pick_qty(5)
+        move_line.qty_picked = 5
         self.assertEqual(move_line.quantity, 10)
         self.assertEqual(move_line.qty_picked, 5)
         self.assertTrue(move_line.picked)
@@ -84,7 +91,27 @@ class TestStockMoveLineQtyPicked(TransactionCase):
         move_form.save()
         self.assertEqual(len(move.move_line_ids), 2)
         new_line = move.move_line_ids - move_line
-        new_line._pick_qty(3)
+        new_line.qty_picked = 3
         self.assertEqual(sum(ml.quantity for ml in move.move_line_ids), 10)
         move.picking_id.with_context(skip_backorder=True).button_validate()
         self.assertEqual(move.quantity, 8)
+
+    def test_move_unpick_qty(self):
+        move = self._create_move(
+            self.product, 5.0, self.stock_location, self.stock_location_2
+        )
+        move_line = move.move_line_ids
+        self.assertEqual(move.picking_id.state, "assigned")
+        self.assertEqual(move_line.quantity, 5)
+        self.assertEqual(move_line.qty_picked, 0)
+        self.assertFalse(move_line.picked)
+        # Pick
+        move_line.picked = True
+        self.assertEqual(move_line.quantity, 5)
+        self.assertEqual(move_line.qty_picked, 5)
+        self.assertTrue(move_line.picked)
+        # Unpick
+        move_line.picked = False
+        self.assertEqual(move_line.quantity, 5)
+        self.assertEqual(move_line.qty_picked, 0)
+        self.assertFalse(move_line.picked)


### PR DESCRIPTION
Updating the `picked` or `qty_picked` fields directly will now sync the expected values in both fields:

- `picked`: updates `qty_picked` to the full quantity if `True`, reset `qty_picked` to 0 if `False`
- `qty_picked`: set `picked` to  `True` if > 0, set `picked` to `False` otherwise

Also, do not copy these fields by default.