### PR TITLE
[16.0][ADD] stock_picking_bill_matching - Work in Progress

### DIFF
--- a/stock_picking_bill_matching/__init__.py
+++ b/stock_picking_bill_matching/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/stock_picking_bill_matching/__manifest__.py
+++ b/stock_picking_bill_matching/__manifest__.py
@@ -1,0 +1,35 @@
+{
+    "name": "Stock Picking Bill Matching",
+    "version": "16.0.1.0.0",
+    "category": "Warehouse",
+    "summary": "Match Vendor Bills with Incoming Pickings and their Stock Moves.",
+    "description": """
+This module allows for direct matching between vendor bill lines and stock moves from incoming pickings.
+
+Features:
+- A "Picking Matching" button on Vendor Bills to see and match available receipts.
+- A "Bill Matching" button on Incoming Pickings to see and match available vendor bills.
+- A dedicated matching interface leveraging the Many2many link from the stock_picking_invoice_link module.
+- Ability to create a new Bill from selected stock moves.
+- Ability to add bill lines (e.g., freight costs) to an existing picking as new stock moves.
+    """,
+    "author": "Akretion, Odoo Community Association",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "depends": [
+        "purchase_stock",
+        "stock_picking_invoice_link",
+        "purchase_stock_picking_invoice_link",  # Ensures purchase context is available
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/account_move_views.xml",
+        "views/stock_picking_views.xml",
+        "views/purchase_order_views.xml",
+        "views/picking_bill_line_match_views.xml",
+        "wizard/bill_to_picking_wizard_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+    "license": "AGPL-3",
+}

--- a/stock_picking_bill_matching/models/__init__.py
+++ b/stock_picking_bill_matching/models/__init__.py
@@ -1,0 +1,4 @@
+from . import account_move
+from . import stock_picking
+from . import picking_bill_line_match
+from . import purchase_order

--- a/stock_picking_bill_matching/models/account_move.py
+++ b/stock_picking_bill_matching/models/account_move.py
@@ -1,0 +1,72 @@
+from odoo import _, api, fields, models
+from odoo.tools import float_compare
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    is_picking_matched = fields.Boolean(
+        compute="_compute_is_picking_matched", store=True
+    )
+
+    @api.depends(
+        "invoice_line_ids",
+        "invoice_line_ids.move_line_ids",
+        "invoice_line_ids.move_line_ids.product_uom_qty",
+        "invoice_line_ids.quantity",
+    )
+    def _compute_is_picking_matched(self):
+        precision_digits = self.env["decimal.precision"].precision_get(
+            "Product Unit of Measure"
+        )
+        for move in self:
+            move.is_picking_matched = True
+            for line in move.invoice_line_ids:
+                qty_matched = sum(
+                    stock_move.product_uom_qty for stock_move in line.move_line_ids
+                )
+                if (
+                    float_compare(
+                        qty_matched, line.quantity, precision_rounding=precision_digits
+                    )
+                    < 0
+                ):
+                    move.is_picking_matched = False
+                    break
+
+    def action_picking_matching(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Picking Matching"),
+            "res_model": "picking.bill.line.match",
+            "domain": [
+                (
+                    "partner_id",
+                    "in",
+                    (self.partner_id | self.partner_id.commercial_partner_id).ids,
+                ),
+                ("company_id", "=", self.company_id.id),
+                ("account_move_id", "in", (self.id, False)),
+                ("product_id", "in", (self.invoice_line_ids.mapped("product_id").ids)),
+            ],
+            "view_mode": "tree",
+            "context": self.env.context,
+        }
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    unmatched_qty = fields.Float(compute="_compute_unmatched_qty", store=True)
+
+    move_line_ids = fields.Many2many(
+        readonly=False,
+    )
+
+    @api.depends("move_line_ids", "quantity", "move_line_ids.product_uom_qty")
+    def _compute_unmatched_qty(self):
+        for aml in self:
+            aml.unmatched_qty = aml.quantity - sum(
+                stock_move.product_uom_qty for stock_move in aml.move_line_ids
+            )

--- a/stock_picking_bill_matching/models/picking_bill_line_match.py
+++ b/stock_picking_bill_matching/models/picking_bill_line_match.py
@@ -1,0 +1,236 @@
+from collections import defaultdict
+
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class PickingBillLineMatch(models.Model):
+    _name = "picking.bill.line.match"
+    _description = "Stock Move and Vendor Bill line matching view"
+    _auto = False
+    _order = "product_id, aml_id, sm_id"
+
+    sm_id = fields.Many2one(comodel_name="stock.move", readonly=True)
+    aml_id = fields.Many2one(comodel_name="account.move.line", readonly=True)
+
+    company_id = fields.Many2one(comodel_name="res.company", readonly=True)
+    partner_id = fields.Many2one(comodel_name="res.partner", readonly=True)
+    product_id = fields.Many2one(comodel_name="product.product", readonly=True)
+    line_qty = fields.Float("Quantity", readonly=True)
+    unmatched_qty = fields.Float("Quantity", readonly=True)
+    line_uom_id = fields.Many2one(comodel_name="uom.uom", string="UoM", readonly=True)
+
+    picking_id = fields.Many2one(comodel_name="stock.picking", readonly=True)
+    account_move_id = fields.Many2one(comodel_name="account.move", readonly=True)
+
+    line_amount_untaxed = fields.Monetary(readonly=True)
+    currency_id = fields.Many2one(comodel_name="res.currency", readonly=True)
+    state = fields.Char(readonly=True)
+
+    reference = fields.Char(compute="_compute_reference")
+
+    @api.depends("picking_id.name", "account_move_id.name")
+    def _compute_reference(self):
+        for line in self:
+            if line.picking_id:
+                line.reference = line.picking_id.name
+                if line.picking_id.origin:
+                    line.reference += f" ({line.picking_id.origin})"
+            elif line.account_move_id:
+                line.reference = line.account_move_id.name
+                if line.account_move_id.invoice_origin:
+                    line.reference += f" ({line.account_move_id.invoice_origin})"
+
+    def _get_common_select_fields(self):
+        return """
+            id,
+            company_id,
+            partner_id,
+            product_id,
+            state,
+            currency_id,
+            line_qty,
+            line_uom_id,
+            line_amount_untaxed
+        """
+
+    @api.model
+    def _select_sm_line(self):
+        return """
+            SELECT
+                sm.id,
+                sm.company_id,
+                sp.partner_id,
+                sm.product_id,
+                sp.state,
+                NULL AS currency_id,
+                sm.product_uom_qty AS line_qty,
+                sm.unmatched_qty AS unmatched_qty,
+                sm.product_uom AS line_uom_id,
+                0 AS line_amount_untaxed,
+                sm.id as sm_id,
+                NULL as aml_id,
+                sm.picking_id as picking_id,
+                NULL as account_move_id
+            FROM
+                stock_move sm
+            JOIN
+                stock_picking sp ON sm.picking_id = sp.id
+            JOIN
+                stock_picking_type pt ON sp.picking_type_id = pt.id
+            WHERE
+                pt.code in ('incoming', 'outgoing')
+                AND sm.state != 'cancel'
+                AND sp.is_picking_matched IS False
+        """  # NOTE: should be accept returns?
+
+    @api.model
+    def _select_am_line(self):
+        return """
+            SELECT
+                -aml.id as id,
+                aml.company_id,
+                aml.partner_id,
+                aml.product_id,
+                am.state,
+                aml.currency_id,
+                aml.quantity AS line_qty,
+                aml.unmatched_qty AS unmatched_qty,
+                aml.product_uom_id AS line_uom_id,
+                aml.price_subtotal AS line_amount_untaxed,
+                NULL as sm_id,
+                aml.id as aml_id,
+                NULL as picking_id,
+                aml.move_id as account_move_id
+            FROM
+                account_move_line aml
+            JOIN
+                account_move am ON aml.move_id = am.id
+            WHERE
+                aml.display_type = 'product'
+                AND am.move_type in ('in_invoice', 'in_refund')
+                AND am.state in ('draft', 'posted')
+                AND am.is_picking_matched IS False
+        """
+
+    @property
+    def _table_query(self):
+        return "(%s) UNION ALL (%s)" % (self._select_sm_line(), self._select_am_line())
+
+    def action_open_line(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "account.move" if self.account_move_id else "stock.picking",
+            "view_mode": "form",
+            "target": "new",
+            "res_id": self.account_move_id.id
+            if self.account_move_id
+            else self.picking_id.id,
+        }
+
+    @api.model
+    def _action_create_bill_from_sm_lines(self, partner, stock_moves):
+        if not partner:
+            raise UserError(_("Cannot create a bill without a vendor."))
+
+        bill = (
+            self.env["account.move"]
+            .with_context(default_move_type="in_invoice")
+            .create(
+                {
+                    "partner_id": partner.id,
+                    "invoice_date": fields.Date.context_today(self),
+                }
+            )
+        )
+
+        for move in stock_moves:
+            self.env["account.move.line"].create(
+                {
+                    "move_id": bill.id,
+                    "product_id": move.product_id.id,
+                    "quantity": move.product_uom_qty,
+                    "product_uom_id": move.product_uom.id,
+                    "price_unit": move.purchase_line_id.price_unit
+                    if move.purchase_line_id
+                    else 0.0,
+                    "move_line_ids": [(4, move.id)],
+                }
+            )
+
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "account.action_move_in_invoice_type"
+        )
+        action.update(
+            {
+                "view_mode": "form",
+                "res_id": bill.id,
+                "views": [[self.env.ref("account.view_move_form").id, "form"]],
+            }
+        )
+        return action
+
+    def action_match_lines(self):
+        """Match selected Stock Moves with selected Bill Lines."""
+        if not self.sm_id and not self.aml_id:
+            raise UserError(
+                _("You must select at least one line to perform an action.")
+            )
+
+        if not self.aml_id:
+            # Create a new bill from stock moves
+            partner = self.sm_id.picking_id.partner_id
+            return self._action_create_bill_from_sm_lines(partner, self.sm_id)
+
+        if len(self.account_move_id) > 1:
+            raise UserError(
+                _("You cannot match lines from multiple Vendor Bills at once.")
+            )
+
+        # Group lines by product for matching
+        aml_by_product = defaultdict(lambda: self.env["account.move.line"])
+        for line in self.aml_id:
+            aml_by_product[line.product_id] |= line
+
+        sm_by_product = defaultdict(lambda: self.env["stock.move"])
+        for line in self.sm_id:
+            sm_by_product[line.product_id] |= line
+
+        for product, am_lines in aml_by_product.items():
+            stock_moves_to_link = sm_by_product.get(product)
+            if stock_moves_to_link:
+                # Link all selected stock moves for this product to the selected bill lines
+                for aml in am_lines:
+                    aml.move_line_ids = [
+                        Command.link(sm.id) for sm in stock_moves_to_link
+                    ]
+                    for move in stock_moves_to_link.filtered(
+                        lambda m: m.state in ("draft", "confirmed", "assigned")
+                    ):
+                        move.quantity_done = min(aml.quantity, move.product_uom_qty)
+                stock_moves_to_link.mapped("picking_id").filtered(
+                    lambda p: p.state in ("draft", "confirmed", "assigned")
+                ).with_context(skip_backorder=True).button_validate()
+
+    def action_add_to_picking(self):
+        """Add selected bill lines to an existing or new picking."""
+        if not self or not self.aml_id:
+            raise UserError(
+                _("Select at least one Vendor Bill line to add to a Picking.")
+            )
+
+        context = {
+            "default_partner_id": self.partner_id.id,
+            "dialog_size": "medium",
+            "active_model": "picking.bill.line.match",
+            "active_ids": self.ids,
+        }
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Add to Picking"),
+            "res_model": "bill.to.picking.wizard",
+            "target": "new",
+            "view_mode": "form",
+            "context": context,
+        }

--- a/stock_picking_bill_matching/models/purchase_order.py
+++ b/stock_picking_bill_matching/models/purchase_order.py
@@ -1,0 +1,74 @@
+from odoo import _, api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    is_picking_matched = fields.Boolean(
+        compute="_compute_is_picking_matched", store=True
+    )
+
+    @api.depends(
+        "order_line.move_ids.picking_id.is_picking_matched",
+    )
+    def _compute_is_picking_matched(self):
+        for po in self:
+            if all(
+                picking.is_picking_matched
+                for picking in po.order_line.move_ids.mapped("picking_id")
+            ):
+                po.is_picking_matched = True
+            else:
+                po.is_picking_matched = False
+
+    def action_bill_matching(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Bill Matching"),
+            "res_model": "picking.bill.line.match",
+            "domain": [
+                (
+                    "partner_id",
+                    "in",
+                    (self.partner_id | self.partner_id.commercial_partner_id).ids,
+                ),
+                ("company_id", "=", self.company_id.id),
+                (
+                    "picking_id",
+                    "in",
+                    self.order_line.mapped("move_ids").mapped("picking_id").ids
+                    + [False],
+                ),
+                (
+                    "product_id",
+                    "in",
+                    self.order_line.mapped("move_ids").mapped("product_id").ids,
+                ),
+            ],
+            "view_mode": "tree",
+            "context": self.env.context,
+        }
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    def _get_invoice_lines(self):
+        invoice_lines = super()._get_invoice_lines()
+        for move in self.move_ids:
+            for aml in move.invoice_line_ids:
+                invoice_lines |= aml
+        return invoice_lines
+
+    @api.depends(
+        "qty_received",
+        "product_uom_qty",
+        "order_id.state",
+        "move_ids.invoice_line_ids",
+        "move_ids.invoice_line_ids.quantity",
+        "move_ids.invoice_line_ids.move_id.state",
+    )
+    def _compute_qty_invoiced(self):
+        """Overriden to depend on stock move_ids"""
+        return super()._compute_qty_invoiced()

--- a/stock_picking_bill_matching/models/stock_picking.py
+++ b/stock_picking_bill_matching/models/stock_picking.py
@@ -1,0 +1,68 @@
+from odoo import _, api, fields, models
+from odoo.tools import float_compare
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    is_picking_matched = fields.Boolean(
+        compute="_compute_is_picking_matched", store=True
+    )
+
+    @api.depends(
+        "move_ids",
+        "move_ids.invoice_line_ids",
+        "move_ids.invoice_line_ids.quantity",
+        "move_ids.product_uom_qty",
+    )
+    def _compute_is_picking_matched(self):
+        precision_digits = self.env["decimal.precision"].precision_get(
+            "Product Unit of Measure"
+        )
+        for picking in self:
+            picking.is_picking_matched = True
+            for line in picking.move_ids:
+                qty_matched = sum(aml.quantity for aml in line.invoice_line_ids)
+                if (
+                    float_compare(
+                        qty_matched,
+                        line.product_uom_qty,
+                        precision_rounding=precision_digits,
+                    )
+                    < 0
+                ):
+                    picking.is_picking_matched = False
+                    break
+
+    def action_bill_matching(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Bill Matching"),
+            "res_model": "picking.bill.line.match",
+            "domain": [
+                (
+                    "partner_id",
+                    "in",
+                    (self.partner_id | self.partner_id.commercial_partner_id).ids,
+                ),
+                ("company_id", "=", self.company_id.id),
+                ("picking_id", "in", (self.id, False)),
+                ("product_id", "in", (self.move_ids.mapped("product_id").ids)),
+            ],
+            "view_mode": "tree",
+            "context": self.env.context,
+        }
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    unmatched_qty = fields.Float(compute="_compute_unmatched_qty", store=True)
+
+    @api.depends("invoice_line_ids", "product_uom_qty", "invoice_line_ids.quantity")
+    def _compute_unmatched_qty(self):
+        for move in self:
+            move.unmatched_qty = move.product_uom_qty - sum(
+                aml.quantity for aml in move.invoice_line_ids
+            )

--- a/stock_picking_bill_matching/security/ir.model.access.csv
+++ b/stock_picking_bill_matching/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_picking_bill_line_match,picking.bill.line.match,model_picking_bill_line_match,account.group_account_invoice,1,1,1,1
+access_bill_to_picking_wizard,bill.to.picking.wizard,model_bill_to_picking_wizard,account.group_account_invoice,1,1,1,1

--- a/stock_picking_bill_matching/tests/__init__.py
+++ b/stock_picking_bill_matching/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_bill_matching

--- a/stock_picking_bill_matching/tests/test_stock_bill_matching.py
+++ b/stock_picking_bill_matching/tests/test_stock_bill_matching.py
@@ -1,0 +1,104 @@
+from odoo import fields
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestStockBillMatching(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner_a = cls.env["res.partner"].create({"name": "Test Vendor Partner"})
+        cls.product_a = cls.env["product.product"].create(
+            {
+                "name": "Test Product A",
+                "type": "product",
+                "standard_price": 50.0,
+            }
+        )
+        cls.product_b = cls.env["product.product"].create(
+            {
+                "name": "Test Product B",
+                "type": "product",
+                "standard_price": 100.0,
+            }
+        )
+
+        # Get the default incoming picking type for the main company
+        cls.picking_type_in = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "incoming"),
+                ("warehouse_id.company_id", "=", cls.env.company.id),
+            ],
+            limit=1,
+        )
+        if not cls.picking_type_in:
+            # If no default one, create one
+            warehouse = cls.env["stock.warehouse"].search(
+                [("company_id", "=", cls.env.company.id)], limit=1
+            )
+            if not warehouse:
+                warehouse = cls.env["stock.warehouse"].create(
+                    {"name": "Test WH", "code": "TWH", "company_id": cls.env.company.id}
+                )
+            cls.picking_type_in = cls.env["stock.picking.type"].create(
+                {
+                    "name": "Test Receipts",
+                    "code": "incoming",
+                    "warehouse_id": warehouse.id,
+                }
+            )
+
+    def create_picking(self, products_info):
+        """Helper to create and process an incoming picking."""
+        picking = self.env["stock.picking"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "picking_type_id": self.picking_type_in.id,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": self.picking_type_in.default_location_dest_id.id,
+            }
+        )
+        for product, qty in products_info:
+            self.env["stock.move"].create(
+                {
+                    "name": product.name,
+                    "product_id": product.id,
+                    "product_uom_qty": qty,
+                    "product_uom": product.uom_id.id,
+                    "picking_id": picking.id,
+                    "location_id": picking.location_id.id,
+                    "location_dest_id": picking.location_dest_id.id,
+                }
+            )
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_lines:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
+        return picking
+
+    def create_bill(self, products_info):
+        """Helper to create a draft vendor bill."""
+        bill = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "move_type": "in_invoice",
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "quantity": qty,
+                            "price_unit": price,
+                        },
+                    )
+                    for product, qty, price in products_info
+                ],
+            }
+        )
+        return bill
+
+    # TODO finish

--- a/stock_picking_bill_matching/views/account_move_views.xml
+++ b/stock_picking_bill_matching/views/account_move_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_move_form_inherit_stock_bill_matching" model="ir.ui.view">
+        <field name="name">account.move.inherit.stock.bill.matching</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button
+                    class="oe_stat_button"
+                    name="action_picking_matching"
+                    type="object"
+                    groups="stock.group_stock_user"
+                    icon="fa-bullseye"
+                    attrs="{'invisible': ['|', ('move_type', 'not in', ('in_invoice', 'in_refund')), ('is_picking_matched', '=', True)]}"
+                >
+                    <div class="o_field_statinfo">
+                        <span class="o_stat_text">Picking Matching</span>
+                    </div>
+                </button>
+                <field name="is_picking_matched" invisible="1" />
+            </div>
+        </field>
+    </record>
+
+    <record id="invoice_form" model="ir.ui.view">
+        <field name="name">related.pickings.account.invoice.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='invoice_line_ids']/form/sheet/field[@name='name']"
+                position="after"
+            >
+                <field name="move_line_ids" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_picking_bill_matching/views/picking_bill_line_match_views.xml
+++ b/stock_picking_bill_matching/views/picking_bill_line_match_views.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="picking_bill_line_match_tree" model="ir.ui.view">
+        <field name="name">picking.bill.line.match.tree</field>
+        <field name="model">picking.bill.line.match</field>
+        <field name="arch" type="xml">
+            <tree
+                string="Picking Bill Lines Matching"
+                decoration-info="sm_id != False"
+                decoration-muted="state in ['draft', 'cancel']"
+                create="0"
+                delete="0"
+            >
+                <header>
+                    <button
+                        name="action_match_lines"
+                        type="object"
+                        string="Match / Create Bill"
+                        class="btn btn-primary"
+                    />
+                    <button
+                        name="action_add_to_picking"
+                        type="object"
+                        string="Add to Picking"
+                    />
+                </header>
+                <field name="product_id" invisible="1" />
+                <field name="sm_id" invisible="1" />
+                <field name="aml_id" invisible="1" />
+                <field name="state" invisible="1" />
+
+                <field name="reference" />
+                <button name="action_open_line" type="object" string="View Details" />
+                <field name="product_id" string="Product" />
+                <field name="line_qty" string="Line Qty" />
+                <field name="unmatched_qty" string="Line Qty - matched Qty" />
+                <field name="line_uom_id" string="UoM" />
+                <field
+                    name="line_amount_untaxed"
+                    string="Amount Untaxed"
+                    widget="monetary"
+                    sum="Total"
+                />
+                <field name="currency_id" invisible="1" />
+                <field name="partner_id" string="Partner" optional="hide" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/stock_picking_bill_matching/views/purchase_order_views.xml
+++ b/stock_picking_bill_matching/views/purchase_order_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_purchase_form_inherit_stock_bill_matching" model="ir.ui.view">
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button
+                    class="oe_stat_button"
+                    name="action_bill_matching"
+                    type="object"
+                    groups="account.group_account_invoice"
+                    icon="fa-bullseye"
+                    attrs="{'invisible': ['|', ('state', 'not in', ('purchase', 'done')), ('is_picking_matched', '=', True)]}"
+                >
+                    <div class="o_field_statinfo">
+                        <span class="o_stat_text">Picking Matching</span>
+                    </div>
+                </button>
+                <field name="is_picking_matched" invisible="1" />
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/stock_picking_bill_matching/views/stock_picking_views.xml
+++ b/stock_picking_bill_matching/views/stock_picking_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_form_inherit_stock_bill_matching" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit.stock.bill.matching</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button
+                    class="oe_stat_button"
+                    name="action_bill_matching"
+                    type="object"
+                    groups="account.group_account_invoice"
+                    icon="fa-bullseye"
+                    attrs="{'invisible': ['|', ('picking_type_code', '!=', 'incoming'), ('is_picking_matched', '=', True)]}"
+                >
+                     <div class="o_field_statinfo">
+                         <span class="o_stat_text">Bill Matching</span>
+                     </div>
+                </button>
+                <field name="is_picking_matched" invisible="1" />
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/stock_picking_bill_matching/wizard/__init__.py
+++ b/stock_picking_bill_matching/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import bill_to_picking_wizard

--- a/stock_picking_bill_matching/wizard/bill_to_picking_wizard.py
+++ b/stock_picking_bill_matching/wizard/bill_to_picking_wizard.py
@@ -1,0 +1,75 @@
+from odoo import Command, _, fields, models
+from odoo.exceptions import UserError
+
+
+class BillToPickingWizard(models.TransientModel):
+    _name = "bill.to.picking.wizard"
+    _description = "Wizard to add bill lines to Picking"
+
+    picking_id = fields.Many2one(
+        "stock.picking",
+        string="Existing Picking",
+        domain="[('partner_id', '=', partner_id), ('state', 'not in', ['done', 'cancel']), ('picking_type_code', '=', 'incoming')]",
+    )
+    partner_id = fields.Many2one("res.partner", string="Vendor", required=True)
+
+    def _get_active_lines(self):
+        active_ids = self.env.context.get("active_ids", [])
+        return self.env["picking.bill.line.match"].browse(active_ids)
+
+    def action_add_to_picking(self):
+        self.ensure_one()
+        lines = self._get_active_lines()
+        aml_ids = lines.aml_id.filtered("product_id")
+
+        if not self.picking_id:
+            self.picking_id = self.env["stock.picking"].create(
+                {
+                    "company_id": lines.aml_id[0].company_id.id,
+                    "picking_type_id": self.env["stock.picking.type"]
+                    .search(
+                        [
+                            ("code", "=", "incoming"),
+                            ("company_id", "=", lines.aml_id[0].company_id.id),
+                        ],
+                        limit=1,
+                    )
+                    .id,
+                    "partner_id": self.partner_id.id,
+                }
+            )
+
+        if not aml_ids:
+            raise UserError(
+                _(
+                    "No bill lines with products were selected to be added to the picking."
+                )
+            )
+
+        for aml in aml_ids:
+            self.env["stock.move"].create(
+                {
+                    "name": aml.name,
+                    "product_id": aml.product_id.id,
+                    "product_uom_qty": aml.unmatched_qty,
+                    "quantity_done": aml.unmatched_qty,
+                    "product_uom": aml.product_uom_id.id,
+                    "picking_id": self.picking_id.id,
+                    "location_id": self.picking_id.location_id.id,
+                    "location_dest_id": self.picking_id.location_dest_id.id,
+                    "invoice_line_ids": [Command.link(aml.id)],
+                }
+            )
+        self.picking_id.button_validate()
+
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "stock.action_picking_tree_all"
+        )
+        action.update(
+            {
+                "view_mode": "form",
+                "res_id": self.picking_id.id,
+                "views": [[self.env.ref("stock.view_picking_form").id, "form"]],
+            }
+        )
+        return action

--- a/stock_picking_bill_matching/wizard/bill_to_picking_wizard_views.xml
+++ b/stock_picking_bill_matching/wizard/bill_to_picking_wizard_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="bill_to_picking_wizard_form" model="ir.ui.view">
+        <field name="name">bill.to.picking.wizard.form</field>
+        <field name="model">bill.to.picking.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Add to Picking">
+                <sheet>
+                    <group>
+                        <field name="partner_id" invisible="1" />
+                        <field name="picking_id" />
+                    </group>
+                    <footer>
+                        <button
+                            name="action_add_to_picking"
+                            type="object"
+                            string="Add to Picking"
+                            class="btn-primary"
+                        />
+                        <button
+                            string="Cancel"
+                            class="btn-secondary"
+                            special="cancel"
+                        />
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Inspired by Odoo v18 "bill matching" feature, but working at the incoming picking level (and in v16 here; will be ported to v18):

1. you start from a vendor bill (usually EDI imported)
2. you click on the top match button to match it against incoming pickings. If you validated some purchase order for this supplier and these products, you will see the incoming picking listed in the match selection

    - eventually select the incoming pickings lines to match with your vendor bill lines and click on the "match" button
    - if there is no existing picking line line to match,  you can simply click on "add to Picking" and the selected bill lines will be added to an existing picking or to a new picking if you select no existing picking.

The move of the picking will be set to done and eventually the whole picking will be set to done.

In case of mistake, you can "unmatch" any incoming move from a bill line in the form view (so you should work with the line popup form) where you can see the related incoming stock moves and unmatch them eventually. If you do so the vendor bill will be set to be matched again.

Work in progress