### PR TITLE
[14.0][FIX] delivery_procurement_group_carrier: Use new proc group for returns

### DIFF
--- a/delivery_procurement_group_carrier/__init__.py
+++ b/delivery_procurement_group_carrier/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/delivery_procurement_group_carrier/tests/__init__.py
+++ b/delivery_procurement_group_carrier/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_carrier
+from . import test_return

--- a/delivery_procurement_group_carrier/tests/common.py
+++ b/delivery_procurement_group_carrier/tests/common.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tests import SavepointCase
+from odoo.tests.common import Form
+
+
+class TestProcurementGroupCarrierCommon(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product = cls.env["product.product"].create(
+            {"type": "product", "name": "Test Product"}
+        )
+        cls.carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "My Test Carrier",
+                "product_id": cls.env.ref("delivery.product_product_delivery").id,
+            }
+        )
+        cls.carrier2 = cls.env["delivery.carrier"].create(
+            {
+                "name": "My Test Carrier2",
+                "product_id": cls.env.ref("delivery.product_product_delivery").id,
+            }
+        )
+        cls.carrier3 = cls.env["delivery.carrier"].create(
+            {
+                "name": "My Test Carrier3",
+                "product_id": cls.env.ref("delivery.product_product_delivery").id,
+            }
+        )
+
+        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
+
+    @classmethod
+    def _add_carrier_to_order(cls, order, carrier):
+        order.set_delivery_line(carrier, 1)
+
+    @classmethod
+    def _create_sale_order(cls, product_qty, carrier=None):
+        with Form(cls.env["sale.order"]) as order_form:
+            order_form.partner_id = cls.partner
+            for product, qty in product_qty:
+                with order_form.order_line.new() as line:
+                    line.product_id = product
+                    line.product_uom_qty = qty
+
+        order = order_form.save()
+        if carrier:
+            cls._add_carrier_to_order(order, carrier)
+        return order

--- a/delivery_procurement_group_carrier/tests/test_carrier.py
+++ b/delivery_procurement_group_carrier/tests/test_carrier.py
@@ -3,58 +3,13 @@
 # Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests import SavepointCase, tagged
-from odoo.tests.common import Form
+from odoo.tests import tagged
+
+from .common import TestProcurementGroupCarrierCommon
 
 
 @tagged("post_install", "-at_install")
-class TestProcurementGroupCarrier(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.product = cls.env["product.product"].create(
-            {"type": "product", "name": "Test Product"}
-        )
-        cls.carrier = cls.env["delivery.carrier"].create(
-            {
-                "name": "My Test Carrier",
-                "product_id": cls.env.ref("delivery.product_product_delivery").id,
-            }
-        )
-        cls.carrier2 = cls.env["delivery.carrier"].create(
-            {
-                "name": "My Test Carrier2",
-                "product_id": cls.env.ref("delivery.product_product_delivery").id,
-            }
-        )
-        cls.carrier3 = cls.env["delivery.carrier"].create(
-            {
-                "name": "My Test Carrier3",
-                "product_id": cls.env.ref("delivery.product_product_delivery").id,
-            }
-        )
-
-        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
-
-    @classmethod
-    def _add_carrier_to_order(cls, order, carrier):
-        order.set_delivery_line(carrier, 1)
-
-    @classmethod
-    def _create_sale_order(cls, product_qty, carrier=None):
-        with Form(cls.env["sale.order"]) as order_form:
-            order_form.partner_id = cls.partner
-            for product, qty in product_qty:
-                with order_form.order_line.new() as line:
-                    line.product_id = product
-                    line.product_uom_qty = qty
-
-        order = order_form.save()
-        if carrier:
-            cls._add_carrier_to_order(order, carrier)
-        return order
-
+class TestProcurementGroupCarrier(TestProcurementGroupCarrierCommon):
     def test_sale_procurement_group_carrier(self):
         """Check the SO procurement group contains the carrier on SO confirmation"""
         order = self._create_sale_order([(self.product, 1.0)], carrier=self.carrier)

--- a/delivery_procurement_group_carrier/tests/test_return.py
+++ b/delivery_procurement_group_carrier/tests/test_return.py
@@ -1,0 +1,48 @@
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tests import tagged
+
+from .common import TestProcurementGroupCarrierCommon
+
+
+@tagged("post_install", "-at_install")
+class TestProcurementGroupCarrier(TestProcurementGroupCarrierCommon):
+    @classmethod
+    def create_return(cls, move, qty_to_return):
+        picking = move.picking_id
+        return_picking_type = picking.picking_type_id.return_picking_type_id
+        wiz_values = {
+            "picking_id": picking.id,
+            "location_id": return_picking_type.default_location_dest_id.id,
+            "product_return_moves": [
+                (
+                    0,
+                    0,
+                    {
+                        "move_id": move.id,
+                        "product_id": move.product_id.id,
+                        "quantity": qty_to_return,
+                        "uom_id": move.product_uom.id,
+                    },
+                )
+            ],
+        }
+        return_wiz = cls.env["stock.return.picking"].create(wiz_values)
+        action = return_wiz.create_returns()
+        cancel_picking = move.picking_id.browse(action["res_id"])
+        return cancel_picking
+
+    def test_return_new_group(self):
+        order = self._create_sale_order([(self.product, 10.0)], carrier=self.carrier)
+        order.action_confirm()
+        out_picking = order.picking_ids
+        out_group = out_picking.group_id
+        out_carrier = out_picking.carrier_id
+
+        move = order.picking_ids.move_lines
+        cancel_picking = self.create_return(move, 5)
+        self.assertTrue(cancel_picking.group_id)
+        self.assertNotEqual(cancel_picking.group_id, out_group)
+        self.assertFalse(cancel_picking.group_id.carrier_id)
+        self.assertFalse(cancel_picking.carrier_id)
+        self.assertEqual(out_picking.carrier_id, out_carrier)

--- a/delivery_procurement_group_carrier/wizards/__init__.py
+++ b/delivery_procurement_group_carrier/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_return_picking

--- a/delivery_procurement_group_carrier/wizards/stock_return_picking.py
+++ b/delivery_procurement_group_carrier/wizards/stock_return_picking.py
@@ -10,6 +10,10 @@ class StockReturnPicking(models.TransientModel):
         vals = super()._prepare_move_default_values(return_line, new_picking)
         group = new_picking.move_lines.group_id
         if not group:
-            group = self.env["procurement.group"].create({"name": new_picking.name})
+            group_vals = {"name": new_picking.name, "carrier_id": False}
+            if return_line.move_id.group_id:
+                group = return_line.move_id.group_id.copy(group_vals)
+            else:
+                group = self.env["procurement.group"].create(group_vals)
         vals["group_id"] = group.id
         return vals

--- a/delivery_procurement_group_carrier/wizards/stock_return_picking.py
+++ b/delivery_procurement_group_carrier/wizards/stock_return_picking.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockReturnPicking(models.TransientModel):
+    _inherit = "stock.return.picking"
+
+    def _prepare_move_default_values(self, return_line, new_picking):
+        vals = super()._prepare_move_default_values(return_line, new_picking)
+        group = new_picking.move_lines.group_id
+        if not group:
+            group = self.env["procurement.group"].create({"name": new_picking.name})
+        vals["group_id"] = group.id
+        return vals


### PR DESCRIPTION
When a return is created for an outgoing transfer, by default the same procurement group is used.
This isn't good because here https://github.com/odoo/odoo/blob/cc0060e889603eb2e47fa44a8a22a70d7d784185/addons/delivery/models/stock_picking.py#L317 the carrier gets set to False. 
Which sets the carrier on all other transfers as well to False. 

By creating a procurement.group per return this isn't the case. 
cc @jbaudoux @mmequignon @i-vyshnevska @raumschmiede-joshuaL