### PR TITLE
[16.0][FIX] fix '_Cancel' typo

### DIFF
--- a/stock_picking_import_serial_number/wizard/import_serial_number_view.xml
+++ b/stock_picking_import_serial_number/wizard/import_serial_number_view.xml
@@ -24,7 +24,7 @@
                         type="object"
                         class="oe_highlight"
                     />
-                    <button string="_Cancel" class="btn-secondary" special="cancel" />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
                 </footer>
             </form>
         </field>


### PR DESCRIPTION
Just a typo fix on the "_Cancel" button:

<img width="352" height="252" alt="immagine" src="https://github.com/user-attachments/assets/1ae92ae1-d932-4bba-9c27-6dcdb18d0689" />

I've also updated related translations.