### PR TITLE
[18.0] [REF] `stock_split_picking`: Split off moves in a new picking

### DIFF
--- a/stock_split_picking/models/stock_picking.py
+++ b/stock_split_picking/models/stock_picking.py
@@ -3,8 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models
-from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_compare, float_is_zero
 
 from ..exceptions import NotPossibleToSplitPickError, SplitPickNotAllowedInStateError
 
@@ -14,101 +12,43 @@ class StockPicking(models.Model):
 
     _inherit = "stock.picking"
 
-    def _check_split_process(self):
-        # Check the picking state and condition before split
-        if self.state == "draft":
-            raise UserError(self.env._("Mark as todo this picking please."))
-        if all(
-            float_is_zero(ml.quantity, precision_rounding=ml.product_uom_id.rounding)
-            for ml in self.move_line_ids
-        ):
-            raise UserError(
-                self.env._(
-                    "You must enter quantity in order to split your "
-                    "picking in several ones."
-                )
-            )
-
-    def split_process(self):
-        """Use to trigger the wizard from button with correct context"""
-        for picking in self:
-            picking._check_split_process()
-
-            # Split moves considering the quantity on moves
-            new_moves = self.env["stock.move"]
-            moves2remove = self.env["stock.move"]
-            for move in picking.move_ids:
-                rounding = move.product_uom.rounding
-                quantity = move.quantity
-                qty_initial = move.product_uom_qty
-                qty_diff_compare = float_compare(
-                    quantity, qty_initial, precision_rounding=rounding
-                )
-                if qty_diff_compare < 0:
-                    qty_split = qty_initial - quantity
-                    qty_uom_split = move.product_uom._compute_quantity(
-                        qty_split, move.product_id.uom_id, rounding_method="HALF-UP"
-                    )
-                    # Empty list is returned for moves with zero qty_done.
-                    new_move_vals = move.with_context(cancel_backorder=False)._split(
-                        qty_uom_split
-                    )
-                    if new_move_vals:
-                        new_move = self.env["stock.move"].create(new_move_vals)
-                    else:
-                        new_move = move
-                    new_moves |= new_move
-                    # Remove the move if the quantity is 0
-                    if float_is_zero(quantity, precision_rounding=rounding):
-                        moves2remove |= move
-
-            # If we have new moves to move, create the backorder picking
-            if new_moves:
-                backorder_picking = picking._create_split_backorder()
-                new_moves.write({"picking_id": backorder_picking.id})
-                new_moves.mapped("move_line_ids").write(
-                    {"picking_id": backorder_picking.id}
-                )
-                new_moves._action_confirm(merge=False)
-
-            for move2remove in moves2remove:
-                if move2remove.exists():
-                    # You can not delete moves linked to another operation,
-                    # first cancel the move and then delete it.
-                    move2remove._action_cancel()
-                    move2remove.unlink()
-
-    def _create_split_backorder(self, default=None):
-        """Copy current picking with defaults passed, post message about
-        backorder"""
+    def _create_split_order(self, default=None):
+        """Create the split order for the extracted moves"""
         self.ensure_one()
-        backorder_picking = self.copy(
+        split_picking = self.copy(
             dict(
                 {
                     "name": "/",
                     "move_ids": [],
                     "move_line_ids": [],
-                    "backorder_id": self.id,
                 },
                 **(default or {}),
             )
         )
         self.message_post(
             body=self.env._(
-                "The backorder %s has been created.", backorder_picking._get_html_link()
+                "The split order %s has been created.", split_picking._get_html_link()
             )
         )
-        return backorder_picking
+        split_picking.message_post(
+            body=self.env._("Split off from %s", self._get_html_link())
+        )
+        return split_picking
 
     def _split_off_moves(self, moves):
-        """Remove moves from pickings in self and put them into a new one"""
+        """Remove moves from pickings in self and put them into a new one
+
+        :return: The new picking created for the split off moves
+        """
         new_picking = self.env["stock.picking"]
-        for this in self:
-            if this.state in ("done", "cancel"):
-                raise SplitPickNotAllowedInStateError(self.env, this)
-            new_picking = new_picking or this._create_split_backorder()
-            if not this.move_ids - moves:
-                raise NotPossibleToSplitPickError(self.env, this)
+        for picking in self:
+            if picking.state in ("done", "cancel"):
+                raise SplitPickNotAllowedInStateError(self.env, picking)
+            new_picking = new_picking or picking._create_split_order()
+            if not picking.move_ids - moves:
+                raise NotPossibleToSplitPickError(self.env, picking)
         moves.write({"picking_id": new_picking.id})
         moves.mapped("move_line_ids").write({"picking_id": new_picking.id})
+        if picking.state in ("confirmed", "waiting", "assigned"):
+            new_picking.move_ids._action_confirm(merge=False)
         return new_picking

--- a/stock_split_picking/models/stock_picking.py
+++ b/stock_split_picking/models/stock_picking.py
@@ -4,7 +4,7 @@
 
 from odoo import models
 from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_compare
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 from ..exceptions import NotPossibleToSplitPickError, SplitPickNotAllowedInStateError
 
@@ -18,7 +18,10 @@ class StockPicking(models.Model):
         # Check the picking state and condition before split
         if self.state == "draft":
             raise UserError(self.env._("Mark as todo this picking please."))
-        if all([x.quantity == 0.0 for x in self.move_line_ids]):
+        if all(
+            float_is_zero(ml.quantity, precision_rounding=ml.product_uom_id.rounding)
+            for ml in self.move_line_ids
+        ):
             raise UserError(
                 self.env._(
                     "You must enter quantity in order to split your "
@@ -56,7 +59,7 @@ class StockPicking(models.Model):
                         new_move = move
                     new_moves |= new_move
                     # Remove the move if the quantity is 0
-                    if float_compare(quantity, 0, precision_rounding=rounding) == 0:
+                    if float_is_zero(quantity, precision_rounding=rounding):
                         moves2remove |= move
 
             # If we have new moves to move, create the backorder picking

--- a/stock_split_picking/models/stock_picking.py
+++ b/stock_split_picking/models/stock_picking.py
@@ -2,7 +2,7 @@
 # Copyright 2018 Camptocamp SA - Julien Coux
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, models
+from odoo import models
 from odoo.exceptions import UserError
 from odoo.tools.float_utils import float_compare
 
@@ -17,10 +17,10 @@ class StockPicking(models.Model):
     def _check_split_process(self):
         # Check the picking state and condition before split
         if self.state == "draft":
-            raise UserError(_("Mark as todo this picking please."))
+            raise UserError(self.env._("Mark as todo this picking please."))
         if all([x.quantity == 0.0 for x in self.move_line_ids]):
             raise UserError(
-                _(
+                self.env._(
                     "You must enter quantity in order to split your "
                     "picking in several ones."
                 )
@@ -91,7 +91,7 @@ class StockPicking(models.Model):
             )
         )
         self.message_post(
-            body=_(
+            body=self.env._(
                 "The backorder %s has been created.", backorder_picking._get_html_link()
             )
         )

--- a/stock_split_picking/tests/common.py
+++ b/stock_split_picking/tests/common.py
@@ -63,3 +63,12 @@ class TestStockSplitPickingCase(TransactionCase):
                 "location_dest_id": cls.dest_location.id,
             }
         )
+
+    @classmethod
+    def _split_picking(cls, picking, **wizard_vals):
+        return (
+            cls.env["stock.split.picking"]
+            .with_context(active_ids=picking.ids)
+            .create(wizard_vals)
+            .action_apply()
+        )

--- a/stock_split_picking/tests/common.py
+++ b/stock_split_picking/tests/common.py
@@ -51,13 +51,13 @@ class TestStockSplitPickingCase(TransactionCase):
         )
 
     @classmethod
-    def _create_stock_move(cls, product, picking):
+    def _create_stock_move(cls, product, picking, qty=10):
         return cls.env["stock.move"].create(
             {
                 "name": "/",
                 "picking_id": picking.id,
                 "product_id": product.id,
-                "product_uom_qty": 10,
+                "product_uom_qty": qty,
                 "product_uom": product.uom_id.id,
                 "location_id": cls.src_location.id,
                 "location_dest_id": cls.dest_location.id,

--- a/stock_split_picking/tests/test_stock_split_picking.py
+++ b/stock_split_picking/tests/test_stock_split_picking.py
@@ -9,21 +9,27 @@ from .common import TestStockSplitPickingCase
 
 
 class TestStockSplitPicking(TestStockSplitPickingCase):
-    def test_stock_split_picking(self):
+    def test_stock_split_picking_in_draft(self):
         # Picking state is draft
         self.assertEqual(self.picking.state, "draft")
         # We can't split a draft picking
-        with self.assertRaisesRegex(UserError, "Mark as todo this picking"):
+        with self.assertRaisesRegex(UserError, "Nothing to split. Fill the quantities"):
             self._split_picking(self.picking, mode="quantity")
 
-    def test_check_quantity_stock_split_picking(self):
-        # Confirm picking
+    def test_stock_split_picking_without_quantities(self):
+        # Picking state is draft
         self.picking.action_confirm()
         # We can't split a draft picking
-        with self.assertRaisesRegex(
-            UserError,
-            "ou must enter quantity in order to split your picking in several ones",
-        ):
+        with self.assertRaisesRegex(UserError, "Nothing to split. Fill the quantities"):
+            self._split_picking(self.picking, mode="quantity")
+
+    def test_stock_split_picking_with_nothing_left_to_split(self):
+        # Confirm picking
+        self.picking.action_confirm()
+        for move in self.picking.move_ids:
+            move.quantity = move.product_uom_qty
+        # We can't split a draft picking
+        with self.assertRaisesRegex(UserError, "Nothing to split, all demand is done."):
             self._split_picking(self.picking, mode="quantity")
 
     def test_stock_split_picking_consumable(self):

--- a/stock_split_picking/tests/test_stock_split_picking.py
+++ b/stock_split_picking/tests/test_stock_split_picking.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
+from odoo.tests import RecordCapturer
 
 from .common import TestStockSplitPickingCase
 
@@ -13,7 +14,7 @@ class TestStockSplitPicking(TestStockSplitPickingCase):
         self.assertEqual(self.picking.state, "draft")
         # We can't split a draft picking
         with self.assertRaisesRegex(UserError, "Mark as todo this picking"):
-            self.picking.split_process()
+            self._split_picking(self.picking, mode="quantity")
 
     def test_check_quantity_stock_split_picking(self):
         # Confirm picking
@@ -23,179 +24,109 @@ class TestStockSplitPicking(TestStockSplitPickingCase):
             UserError,
             "ou must enter quantity in order to split your picking in several ones",
         ):
-            self.picking.split_process()
+            self._split_picking(self.picking, mode="quantity")
 
     def test_stock_split_picking_consumable(self):
         # Confirm picking
         self.picking_consu.action_confirm()
-        move_line = self.env["stock.move.line"].search(
-            [
-                ("picking_id", "=", self.picking_consu.id),
-                ("product_id", "=", self.product_consu.id),
-            ],
-            limit=1,
-        )
-        move_line_2 = self.env["stock.move.line"].search(
-            [
-                ("picking_id", "=", self.picking_consu.id),
-                ("product_id", "=", self.product_consu_2.id),
-            ],
-            limit=1,
-        )
+
+        # Split picking: 4 and 6
         self.move_consu.quantity = 4.0
         self.move_consu_2.quantity = 0.0
-        # Split picking: 4 and 6
-        self.picking_consu.split_process()
 
-        # We have a picking with 4 units in state assigned
-        self.assertAlmostEqual(move_line.quantity, 4.0)
-        self.assertAlmostEqual(move_line.quantity_product_uom, 4.0)
+        with (
+            RecordCapturer(self.env["stock.picking"], []) as rc_picking,
+            RecordCapturer(self.env["stock.move"], []) as rc_move,
+        ):
+            self._split_picking(self.picking_consu, mode="quantity")
+            new_picking = rc_picking.records
+            new_moves = rc_move.records
 
-        self.assertAlmostEqual(self.move_consu.quantity, 4.0)
-        self.assertAlmostEqual(self.move_consu.product_qty, 4.0)
-        self.assertAlmostEqual(self.move_consu.product_uom_qty, 4.0)
-
-        self.assertEqual(move_line.picking_id, self.picking_consu)
-        self.assertEqual(self.move_consu.picking_id, self.picking_consu)
-
-        # move/move_line with no qty should no longer exist
-        self.assertFalse(move_line_2.exists())
-        self.assertFalse(self.move_consu_2.exists())
-
-        self.assertEqual(self.picking_consu.state, "assigned")
-        # Another one with 6 units in state assigned
-        new_picking = self.env["stock.picking"].search(
-            [("backorder_id", "=", self.picking_consu.id)], limit=1
-        )
-        move_line = self.env["stock.move.line"].search(
-            [
-                ("picking_id", "=", new_picking.id),
-                ("product_id", "=", self.product_consu.id),
-            ],
-            limit=1,
-        )
-        move_line_2 = self.env["stock.move.line"].search(
-            [
-                ("picking_id", "=", new_picking.id),
-                ("product_id", "=", self.product_consu_2.id),
-            ],
-            limit=1,
-        )
-
-        self.assertAlmostEqual(move_line.quantity, 6.0)
-        self.assertAlmostEqual(move_line.quantity_product_uom, 6.0)
-        self.assertAlmostEqual(move_line_2.quantity, 10.0)
-        self.assertAlmostEqual(move_line_2.quantity_product_uom, 10.0)
-
-        move = self.env["stock.move"].search(
-            [
-                ("picking_id", "=", new_picking.id),
-                ("product_id", "=", self.product_consu.id),
-            ],
-            limit=1,
-        )
-        move_2 = self.env["stock.move"].search(
-            [
-                ("picking_id", "=", new_picking.id),
-                ("product_id", "=", self.product_consu_2.id),
-            ],
-            limit=1,
-        )
-
-        self.assertAlmostEqual(move.quantity, 6.0)
-        self.assertAlmostEqual(move.product_qty, 6.0)
-        self.assertAlmostEqual(move.product_uom_qty, 6.0)
-        self.assertAlmostEqual(move_2.quantity, 10.0)
-        self.assertAlmostEqual(move_2.product_qty, 10.0)
-        self.assertAlmostEqual(move_2.product_uom_qty, 10.0)
-
+        # We have a new picking with 4 units in state assigned
         self.assertEqual(new_picking.state, "assigned")
+        self.assertEqual(
+            new_picking.move_ids,
+            new_moves,
+            "The new picking should have the new moves",
+        )
+        self.assertEqual(len(new_moves), 1, "Only one new move should be created")
+        self.assertAlmostEqual(
+            new_moves.quantity,
+            4.0,
+            "The new move should have the selected quantities",
+        )
+        self.assertAlmostEqual(
+            new_moves.product_uom_qty,
+            4.0,
+            "The new move should have the selected quantities",
+        )
+
+        # And the backorder one is the original one, with the remaining quantities
+        self.assertEqual(self.picking_consu.state, "confirmed")
+        self.assertEqual(
+            self.move_consu.picking_id,
+            self.picking_consu,
+            "The original move should be in the original picking",
+        )
+        self.assertEqual(
+            self.move_consu_2.picking_id,
+            self.picking_consu,
+            "The original move should be in the original picking",
+        )
+        self.assertAlmostEqual(self.move_consu.quantity, 0.0)
+        self.assertAlmostEqual(self.move_consu.product_uom_qty, 6.0)
+        self.assertAlmostEqual(self.move_consu_2.quantity, 0.0)
+        self.assertAlmostEqual(self.move_consu_2.product_uom_qty, 10.0)
 
     def test_stock_split_picking_product_wo_stock(self):
-        # Picking state is draft
-        self.assertEqual(self.picking.state, "draft")
-        # We can't split a draft picking
-        with self.assertRaisesRegex(UserError, "Mark as todo this picking"):
-            self.picking.split_process()
         # Confirm picking
         self.picking.action_confirm()
-        self.assertFalse(
-            self.env["stock.move.line"].search(
-                [
-                    ("picking_id", "=", self.picking.id),
-                    ("product_id", "=", self.product.id),
-                ],
-                limit=1,
-            )
-        )
-        self.assertFalse(
-            self.env["stock.move.line"].search(
-                [
-                    ("picking_id", "=", self.picking.id),
-                    ("product_id", "=", self.product_2.id),
-                ],
-                limit=1,
-            )
-        )
+
+        # Split picking: 4 and 6
         self.move.quantity = 4.0
         self.move_2.quantity = 0.0
-        # Split picking: 4 and 6
-        self.picking.split_process()
 
-        # We have a picking with 4 units in state assigned
-        self.assertAlmostEqual(self.move.quantity, 4.0)
-        self.assertAlmostEqual(self.move.product_qty, 4.0)
-        self.assertAlmostEqual(self.move.product_uom_qty, 4.0)
+        with (
+            RecordCapturer(self.env["stock.picking"], []) as rc_picking,
+            RecordCapturer(self.env["stock.move"], []) as rc_move,
+        ):
+            self._split_picking(self.picking, mode="quantity")
+            new_picking = rc_picking.records
+            new_moves = rc_move.records
 
-        self.assertEqual(self.move.picking_id, self.picking)
-
-        # move/move_line with no qty should no longer exist
-        self.assertFalse(self.move_2.exists())
-
-        self.assertEqual(self.picking.state, "assigned")
-        # Another one with 6 units in state assigned
-        new_picking = self.env["stock.picking"].search(
-            [("backorder_id", "=", self.picking.id)], limit=1
+        # We have a new picking with 4 units in state assigned
+        self.assertEqual(new_picking.state, "assigned")
+        self.assertEqual(
+            new_picking.move_ids,
+            new_moves,
+            "The new picking should have the new moves",
         )
-        self.assertFalse(
-            self.env["stock.move.line"].search(
-                [
-                    ("picking_id", "=", new_picking.id),
-                    ("product_id", "=", self.product.id),
-                ],
-                limit=1,
-            )
+        self.assertEqual(len(new_moves), 1, "Only one new move should be created")
+        self.assertAlmostEqual(
+            new_moves.quantity, 4.0, "The new move should have the selected quantities"
         )
-        self.assertFalse(
-            self.env["stock.move.line"].search(
-                [
-                    ("picking_id", "=", new_picking.id),
-                    ("product_id", "=", self.product_2.id),
-                ],
-                limit=1,
-            )
+        self.assertAlmostEqual(
+            new_moves.product_uom_qty,
+            4.0,
+            "The new move should have the selected quantities",
         )
 
-        move = self.env["stock.move"].search(
-            [("picking_id", "=", new_picking.id), ("product_id", "=", self.product.id)],
-            limit=1,
+        # And the backorder one is the original one, with the remaining quantities
+        self.assertEqual(self.picking.state, "confirmed")
+        self.assertEqual(
+            self.move.picking_id,
+            self.picking,
+            "The original move should be in the original picking",
         )
-        move_2 = self.env["stock.move"].search(
-            [
-                ("picking_id", "=", new_picking.id),
-                ("product_id", "=", self.product_2.id),
-            ],
-            limit=1,
+        self.assertEqual(
+            self.move_2.picking_id,
+            self.picking,
+            "The original move should be in the original picking",
         )
-
-        self.assertAlmostEqual(move.quantity, 0.0)
-        self.assertAlmostEqual(move.product_qty, 6.0)
-        self.assertAlmostEqual(move.product_uom_qty, 6.0)
-        self.assertAlmostEqual(move_2.quantity, 0.0)
-        self.assertAlmostEqual(move_2.product_qty, 10.0)
-        self.assertAlmostEqual(move_2.product_uom_qty, 10.0)
-
-        self.assertEqual(new_picking.state, "confirmed")
+        self.assertAlmostEqual(self.move.quantity, 0.0)
+        self.assertAlmostEqual(self.move.product_uom_qty, 6.0)
+        self.assertAlmostEqual(self.move_2.quantity, 0.0)
+        self.assertAlmostEqual(self.move_2.product_uom_qty, 10.0)
 
     def test_stock_split_picking_product_with_stock(self):
         self.env["stock.quant"].create(
@@ -212,125 +143,147 @@ class TestStockSplitPicking(TestStockSplitPickingCase):
                 "quantity": 4,
             }
         )
-        # Picking state is draft
-        self.assertEqual(self.picking.state, "draft")
-        # We can't split a draft picking
-        with self.assertRaisesRegex(UserError, "Mark as todo this picking"):
-            self.picking.split_process()
+
         # Confirm picking
         self.picking.action_confirm()
-        move_line = self.env["stock.move.line"].search(
-            [
-                ("picking_id", "=", self.picking.id),
-                ("product_id", "=", self.product.id),
-            ],
-            limit=1,
-        )
-        move_line_2 = self.env["stock.move.line"].search(
-            [
-                ("picking_id", "=", self.picking.id),
-                ("product_id", "=", self.product_2.id),
-            ],
-            limit=1,
-        )
+
+        # Split picking: 4 and 6
         self.move.quantity = 4.0
         self.move_2.quantity = 0.0
-        # Split picking: 4 and 6
-        self.picking.split_process()
 
-        # We have a picking with 4 units in state assigned
-        self.assertAlmostEqual(move_line.quantity, 4.0)
-        self.assertAlmostEqual(move_line.quantity_product_uom, 4.0)
+        with (
+            RecordCapturer(self.env["stock.picking"], []) as rc_picking,
+            RecordCapturer(self.env["stock.move"], []) as rc_move,
+        ):
+            self._split_picking(self.picking, mode="quantity")
+            new_picking = rc_picking.records
+            new_moves = rc_move.records
 
-        self.assertAlmostEqual(self.move.quantity, 4.0)
-        self.assertAlmostEqual(self.move.product_qty, 4.0)
-        self.assertAlmostEqual(self.move.product_uom_qty, 4.0)
-
-        self.assertEqual(move_line.picking_id, self.picking)
-        self.assertEqual(self.move.picking_id, self.picking)
-
-        # move/move_line with no qty should no longer exist
-        self.assertFalse(move_line_2.exists())
-        self.assertFalse(self.move_2.exists())
-
-        self.assertEqual(self.picking.state, "assigned")
-        # Another one with 6 units in state assigned
-        new_picking = self.env["stock.picking"].search(
-            [("backorder_id", "=", self.picking.id)], limit=1
-        )
-        self.assertFalse(
-            self.env["stock.move.line"].search(
-                [
-                    ("picking_id", "=", new_picking.id),
-                    ("product_id", "=", self.product.id),
-                ],
-                limit=1,
-            )
-        )
-        move_line_2 = self.env["stock.move.line"].search(
-            [
-                ("picking_id", "=", new_picking.id),
-                ("product_id", "=", self.product_2.id),
-            ],
-            limit=1,
-        )
-        self.assertAlmostEqual(move_line_2.quantity, 4.0)
-        self.assertAlmostEqual(move_line_2.quantity_product_uom, 4.0)
-
-        move = self.env["stock.move"].search(
-            [("picking_id", "=", new_picking.id), ("product_id", "=", self.product.id)],
-            limit=1,
-        )
-        move_2 = self.env["stock.move"].search(
-            [
-                ("picking_id", "=", new_picking.id),
-                ("product_id", "=", self.product_2.id),
-            ],
-            limit=1,
-        )
-
-        self.assertAlmostEqual(move.quantity, 0.0)
-        self.assertAlmostEqual(move.product_qty, 6.0)
-        self.assertAlmostEqual(move.product_uom_qty, 6.0)
-        self.assertAlmostEqual(move_2.quantity, 4.0)
-        self.assertAlmostEqual(move_2.product_qty, 10.0)
-        self.assertAlmostEqual(move_2.product_uom_qty, 10.0)
-
+        # We have a new picking with 4 units in state assigned
         self.assertEqual(new_picking.state, "assigned")
+        self.assertEqual(
+            new_picking.move_ids,
+            new_moves,
+            "The new picking should have the new moves",
+        )
+        self.assertEqual(len(new_moves), 1, "Only one new move should be created")
+        self.assertAlmostEqual(
+            new_moves.quantity,
+            4.0,
+            "The new move should have the selected quantities",
+        )
+        self.assertAlmostEqual(
+            new_moves.product_uom_qty,
+            4.0,
+            "The new move should have the selected quantities",
+        )
+
+        # And the backorder one is the original one, with the remaining quantities
+        self.assertEqual(self.picking.state, "confirmed")
+        self.assertEqual(
+            self.move.picking_id,
+            self.picking,
+            "The original move should be in the original picking",
+        )
+        self.assertEqual(
+            self.move_2.picking_id,
+            self.picking,
+            "The original move should be in the original picking",
+        )
+        self.assertAlmostEqual(self.move.quantity, 0.0)
+        self.assertAlmostEqual(self.move.product_uom_qty, 6.0)
+        self.assertAlmostEqual(self.move_2.quantity, 0.0)
+        self.assertAlmostEqual(self.move_2.product_uom_qty, 10.0)
+
+    def test_stock_split_picking_extract_entire_move(self):
+        # Confirm picking
+        self.picking_consu.action_confirm()
+
+        # Split picking: the first move fully set, nothing on the second
+        self.move_consu.quantity = self.move_consu.product_uom_qty
+        self.move_consu_2.quantity = 0.0
+
+        with (
+            RecordCapturer(self.env["stock.picking"], []) as rc_picking,
+            RecordCapturer(self.env["stock.move"], []) as rc_move,
+        ):
+            self._split_picking(self.picking_consu, mode="quantity")
+            new_picking = rc_picking.records
+            new_moves = rc_move.records
+
+        # No new moves should have been created
+        self.assertFalse(new_moves, "No new moves should have been created")
+
+        # We have a new picking with the previous move that was fully set
+        self.assertTrue(new_picking, "A new picking should have been created")
+        self.assertEqual(new_picking.state, "assigned")
+        self.assertEqual(
+            new_picking.move_ids,
+            self.move_consu,
+            "The new picking should have the original move that was fully set",
+        )
+
+        # The moves quantities should be the same
+        self.assertAlmostEqual(self.move_consu.quantity, 10.0)
+        self.assertAlmostEqual(self.move_consu.product_uom_qty, 10.0)
+
+        # And the backorder one is the original one, with the remaining quantities
+        self.assertEqual(self.picking_consu.state, "confirmed")
+        self.assertEqual(
+            self.picking_consu.move_ids,
+            self.move_consu_2,
+            "The only remaining move should be in the original picking",
+        )
+        self.assertAlmostEqual(self.move_consu_2.quantity, 0.0)
+        self.assertAlmostEqual(self.move_consu_2.product_uom_qty, 10.0)
 
     def test_stock_split_picking_wizard_move_consumable(self):
         self.move2 = self.move_consu.copy()
         self.assertEqual(self.move2.picking_id, self.picking_consu)
-        wizard = (
-            self.env["stock.split.picking"]
-            .with_context(active_ids=self.picking_consu.ids)
-            .create({"mode": "move"})
+        self._split_picking(self.picking_consu, mode="move")
+        self.assertEqual(
+            self.move2.picking_id,
+            self.picking_consu,
+            "Remaining move should be in original picking",
         )
-        wizard.action_apply()
-        self.assertNotEqual(self.move2.picking_id, self.picking_consu)
-        self.assertEqual(self.move_consu.picking_id, self.picking_consu)
+        self.assertNotEqual(
+            self.move_consu.picking_id,
+            self.picking_consu,
+            "Extracted move should be in new picking",
+        )
 
     def test_stock_split_picking_wizard_move_product(self):
         self.move2 = self.move.copy()
         self.assertEqual(self.move2.picking_id, self.picking)
-        wizard = (
-            self.env["stock.split.picking"]
-            .with_context(active_ids=self.picking.ids)
-            .create({"mode": "move"})
+        self._split_picking(self.picking, mode="move")
+        self.assertEqual(
+            self.move2.picking_id,
+            self.picking,
+            "Remaining move should be in original picking",
         )
-        wizard.action_apply()
-        self.assertNotEqual(self.move2.picking_id, self.picking)
-        self.assertEqual(self.move.picking_id, self.picking)
+        self.assertNotEqual(
+            self.move.picking_id,
+            self.picking,
+            "Extracted move should be in new picking",
+        )
+
+    def test_stock_split_picking_wizard_move_single_move(self):
+        """Test move mode when picking has only one move"""
+        # Create a picking with only one move
+        picking = self._create_picking()
+        self._create_stock_move(self.product, picking)
+        picking.action_confirm()
+
+        with RecordCapturer(self.env["stock.picking"], []) as rc_picking:
+            result = self._split_picking(picking, mode="move")
+
+        self.assertFalse(rc_picking.records, "No new pickings should be created")
+        self.assertEqual(result, True, "No action should be returned")
 
     def test_stock_split_picking_wizard_selection(self):
         self.move2 = self.move.copy()
         self.assertEqual(self.move2.picking_id, self.picking)
-        wizard = (
-            self.env["stock.split.picking"]
-            .with_context(active_ids=self.picking.ids)
-            .create({"mode": "selection", "move_ids": [(6, False, self.move2.ids)]})
-        )
-        wizard.action_apply()
+        self._split_picking(self.picking, mode="selection", move_ids=self.move2)
         self.assertNotEqual(self.move2.picking_id, self.picking)
         self.assertEqual(self.move.picking_id, self.picking)
 

--- a/stock_split_picking/tests/test_stock_split_picking.py
+++ b/stock_split_picking/tests/test_stock_split_picking.py
@@ -243,6 +243,58 @@ class TestStockSplitPicking(TestStockSplitPickingCase):
         self.assertAlmostEqual(self.move_consu_2.quantity, 0.0)
         self.assertAlmostEqual(self.move_consu_2.product_uom_qty, 10.0)
 
+    def test_stock_split_picking_ignore_cancelled_moves(self):
+        # Confirm picking
+        self.picking.action_confirm()
+
+        # Split picking: 4 units on the first move, second is cancelled
+        self.move.quantity = 4.0
+        self.move_2._action_cancel()
+
+        with (
+            RecordCapturer(self.env["stock.picking"], []) as rc_picking,
+            RecordCapturer(self.env["stock.move"], []) as rc_move,
+        ):
+            self._split_picking(self.picking, mode="quantity")
+            new_picking = rc_picking.records
+            new_moves = rc_move.records
+
+        # We have a new picking with 4 units in state assigned
+        self.assertEqual(new_picking.state, "assigned")
+        self.assertEqual(
+            new_picking.move_ids,
+            new_moves,
+            "The new picking should have the new moves",
+        )
+        self.assertEqual(len(new_moves), 1, "Only one new move should be created")
+        self.assertAlmostEqual(
+            new_moves.quantity,
+            4.0,
+            "The new move should have the selected quantities",
+        )
+        self.assertAlmostEqual(
+            new_moves.product_uom_qty,
+            4.0,
+            "The new move should have the selected quantities",
+        )
+
+        # And the backorder one is the original one, with the remaining quantities
+        # and the cancelled move
+        self.assertEqual(self.picking.state, "confirmed")
+        self.assertEqual(
+            self.move.picking_id,
+            self.picking,
+            "The original move should be in the original picking",
+        )
+        self.assertEqual(
+            self.move_2.picking_id,
+            self.picking,
+            "The original move should be in the original picking",
+        )
+        self.assertAlmostEqual(self.move.quantity, 0.0)
+        self.assertAlmostEqual(self.move.product_uom_qty, 6.0)
+        self.assertEqual(self.move_2.state, "cancel")
+
     def test_stock_split_picking_wizard_move_consumable(self):
         self.move2 = self.move_consu.copy()
         self.assertEqual(self.move2.picking_id, self.picking_consu)
@@ -285,6 +337,62 @@ class TestStockSplitPicking(TestStockSplitPickingCase):
 
         self.assertFalse(rc_picking.records, "No new pickings should be created")
         self.assertEqual(result, True, "No action should be returned")
+
+    def test_stock_split_picking_wizard_move_with_cancelled_move(self):
+        """Test move mode when picking has cancelled moves"""
+        # Create a picking where the first move is cancelled
+        picking = self._create_picking()
+        move1 = self._create_stock_move(self.product, picking)
+        move1._action_cancel()
+        move2 = self._create_stock_move(self.product, picking)
+        move3 = self._create_stock_move(self.product_2, picking)
+        picking.action_confirm()
+
+        with RecordCapturer(self.env["stock.picking"], []) as rc_picking:
+            self._split_picking(picking, mode="move")
+            new_picking = rc_picking.records
+
+        self.assertTrue(new_picking, "A new picking should be created")
+        self.assertEqual(new_picking.state, "confirmed", "the new picking is confirmed")
+        self.assertEqual(new_picking.move_ids, move2, "with the 1st non-cancelled move")
+        self.assertEqual(move1.picking_id, picking, "the cancelled remains in original")
+        self.assertEqual(move3.picking_id, picking, "the last one remains there, too")
+        self.assertEqual(picking.state, "confirmed", "the picking remains confirmed")
+
+    def test_stock_split_picking_wizard_move_with_only_one_cancelled_move(self):
+        """Test move mode when picking has only one cancelled move remaining"""
+        # Create a picking where the first move is cancelled
+        picking = self._create_picking()
+        move1 = self._create_stock_move(self.product, picking)
+        move1._action_cancel()
+        move2 = self._create_stock_move(self.product_2, picking)
+        picking.action_confirm()
+
+        with RecordCapturer(self.env["stock.picking"], []) as rc_picking:
+            self._split_picking(picking, mode="move")
+            new_picking = rc_picking.records
+
+        self.assertTrue(new_picking, "A new picking should be created")
+        self.assertEqual(new_picking.state, "confirmed", "the new picking is confirmed")
+        self.assertEqual(new_picking.move_ids, move2, "with the 1st non-cancelled move")
+        self.assertEqual(picking.move_ids, move1, "the cancelled remains in original")
+        self.assertEqual(picking.state, "cancel", "the picking is cancelled")
+
+    def test_stock_split_picking_wizard_move_with_only_cancelled_moves(self):
+        """Test move mode when picking has only cancelled moves"""
+        # Create a picking where the first move is cancelled
+        picking = self._create_picking()
+        move1 = self._create_stock_move(self.product, picking)
+        move2 = self._create_stock_move(self.product_2, picking)
+        (move1 + move2)._action_cancel()
+        picking.action_confirm()
+
+        with RecordCapturer(self.env["stock.picking"], []) as rc_picking:
+            self._split_picking(picking, mode="move")
+            new_picking = rc_picking.records
+
+        self.assertFalse(new_picking, "No new picking should be created")
+        self.assertEqual(picking.state, "cancel", "the picking is cancelled")
 
     def test_stock_split_picking_wizard_selection(self):
         self.move2 = self.move.copy()

--- a/stock_split_picking/wizards/stock_split_picking.py
+++ b/stock_split_picking/wizards/stock_split_picking.py
@@ -83,6 +83,9 @@ class StockSplitPicking(models.TransientModel):
             moves_to_recompute_state = self.env["stock.move"]
             for move in picking.move_ids:
                 rounding = move.product_uom.rounding
+                # Do not split moves that are done or cancelled
+                if move.state in ("done", "cancel"):
+                    continue
                 # If there aren't assigned quantities, there's nothing to split
                 if float_is_zero(move.quantity, precision_rounding=rounding):
                     continue
@@ -135,9 +138,17 @@ class StockSplitPicking(models.TransientModel):
         """
         new_pickings = self.env["stock.picking"]
         for picking in self.picking_ids:
+            # If the picking only has one move, there's nothing to split
             if len(picking.move_ids) <= 1:
                 continue
-            new_pickings += picking._split_off_moves(picking.move_ids[0])
+            # Get the moves that can be split off (not done nor cancelled)
+            todo = picking.move_ids.filtered(
+                lambda move: move.state not in ("done", "cancel")
+            ).sorted()
+            if not todo:
+                continue
+            # Split off the first one
+            new_pickings += picking._split_off_moves(todo[0])
         return new_pickings
 
     def _apply_selection(self):

--- a/stock_split_picking/wizards/stock_split_picking.py
+++ b/stock_split_picking/wizards/stock_split_picking.py
@@ -35,18 +35,31 @@ class StockSplitPicking(models.TransientModel):
 
     def _check_can_split_by_quantity(self):
         for picking in self.picking_ids:
-            if picking.state == "draft":
-                raise UserError(self.env._("Mark as todo this picking please."))
-            if not any(
-                not float_is_zero(
-                    move.quantity, precision_rounding=move.product_uom.rounding
-                )
-                for move in picking.move_ids
+            if all(
+                float_is_zero(m.quantity, precision_rounding=m.product_uom.rounding)
+                for m in picking.move_ids
             ):
                 raise UserError(
                     self.env._(
-                        "You must enter quantity in order to split your "
-                        "picking in several ones."
+                        "%s: Nothing to split. Fill the quantities you want in a new "
+                        "transfer in the done quantities",
+                        picking.display_name,
+                    )
+                )
+            if all(
+                float_compare(
+                    m.quantity,
+                    m.product_uom_qty,
+                    precision_rounding=m.product_uom.rounding,
+                )
+                >= 0
+                for m in picking.move_ids
+            ):
+                raise UserError(
+                    self.env._(
+                        "%s: Nothing to split, all demand is done. For split you need "
+                        "at least one line not fully fulfilled",
+                        picking.display_name,
                     )
                 )
 

--- a/stock_split_picking/wizards/stock_split_picking.py
+++ b/stock_split_picking/wizards/stock_split_picking.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Hunki Enterprises BV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import Command, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 
 class StockSplitPicking(models.TransientModel):
@@ -28,28 +30,112 @@ class StockSplitPicking(models.TransientModel):
         return self.env["stock.picking"].browse(self.env.context.get("active_ids", []))
 
     def action_apply(self):
-        return getattr(self, f"_apply_{self[:1].mode}")()
-
-    def _apply_quantity(self):
-        return self.mapped("picking_ids").split_process()
-
-    def _apply_move(self):
-        """Create new pickings for every move line, keep first
-        move line in original picking
-        """
-        new_pickings = self.env["stock.picking"]
-        for picking in self.mapped("picking_ids"):
-            for move in picking.move_ids[1:]:
-                new_pickings += picking._split_off_moves(move)
+        new_pickings = getattr(self, f"_apply_{self[:1].mode}")()
         return self._picking_action(new_pickings)
 
+    def _check_can_split_by_quantity(self):
+        for picking in self.picking_ids:
+            if picking.state == "draft":
+                raise UserError(self.env._("Mark as todo this picking please."))
+            if not any(
+                not float_is_zero(
+                    move.quantity, precision_rounding=move.product_uom.rounding
+                )
+                for move in picking.move_ids
+            ):
+                raise UserError(
+                    self.env._(
+                        "You must enter quantity in order to split your "
+                        "picking in several ones."
+                    )
+                )
+
+    def _apply_quantity(self):
+        """Apply mode `quantity`: Split pickings by quantity
+
+        Done quantities will be moved to a new picking, the remaining pending
+        moves will stay in the original picking.
+
+        This is similar to the core method `action_split_transfer`, with one important
+        difference: the core method keeps the assigned quantities in the original record
+        and creates a backorder for the remaining quantities. This method, on the other
+        hand, extracts the selected quantities in a new picking, and keeps the original
+        one as backorder.
+        """
+        self._check_can_split_by_quantity()
+        new_pickings = self.env["stock.picking"]
+        for picking in self.picking_ids:
+            new_moves_vals = []
+            moves_to_split_off = self.env["stock.move"]
+            moves_to_recompute_state = self.env["stock.move"]
+            for move in picking.move_ids:
+                rounding = move.product_uom.rounding
+                # If there aren't assigned quantities, there's nothing to split
+                if float_is_zero(move.quantity, precision_rounding=rounding):
+                    continue
+                # If it's completely assigned, extract the move entirely
+                if (
+                    float_compare(
+                        move.quantity, move.product_uom_qty, precision_rounding=rounding
+                    )
+                    >= 0
+                ):
+                    moves_to_split_off += move
+                    continue
+                # Otherwise, we split the done quantities and leave the remaining
+                # quantities in the original move.
+                split_moves_vals = move.with_context(cancel_backorder=False)._split(
+                    move.product_uom._compute_quantity(
+                        move.quantity, move.product_id.uom_id, rounding_method="HALF-UP"
+                    )
+                )
+                if not split_moves_vals:
+                    continue  # pragma: no cover
+                # Adopt the move lines from the original move
+                split_moves_vals[0]["move_line_ids"] = [
+                    Command.set(move.move_line_ids.ids)
+                ]
+                new_moves_vals += split_moves_vals
+                moves_to_recompute_state += move
+            # Create the partially split off moves
+            if new_moves_vals:
+                new_moves = self.env["stock.move"].create(new_moves_vals)
+                new_moves.with_context(
+                    bypass_entire_pack=True, bypass_procurement_creation=True
+                )._action_confirm(merge=False)
+                moves_to_split_off += new_moves
+            # Recompute the state of the remaining moves
+            moves_to_recompute_state._recompute_state()
+            # If all the picking moves are the ones to be split, then it means
+            # we haven't created any backorder move. We keep the picking as-is.
+            if picking.move_ids == moves_to_split_off or not moves_to_split_off:
+                continue  # pragma: no cover
+            # Create the split orders for the extracted moves, and split them off
+            new_pickings += picking._split_off_moves(moves_to_split_off)
+        return new_pickings
+
+    def _apply_move(self):
+        """Apply mode `mode`: One picking per move
+
+        Extract the first move from the picking and move it to a new one.
+        Keep the rest in the original picking.
+        """
+        new_pickings = self.env["stock.picking"]
+        for picking in self.picking_ids:
+            if len(picking.move_ids) <= 1:
+                continue
+            new_pickings += picking._split_off_moves(picking.move_ids[0])
+        return new_pickings
+
     def _apply_selection(self):
-        """Create one picking for all selected moves"""
+        """Apply mode `selection`: Split off selected moves"""
         moves = self.mapped("move_ids")
         new_picking = moves.mapped("picking_id")._split_off_moves(moves)
-        return self._picking_action(new_picking)
+        return new_picking
 
     def _picking_action(self, pickings):
+        if not pickings:
+            return True
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "stock.action_picking_tree_all",
         )

--- a/stock_split_picking/wizards/stock_split_picking.xml
+++ b/stock_split_picking/wizards/stock_split_picking.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <form>
                 <group>
-                    <field name="mode" />
+                    <field name="mode" widget="radio" />
                     <field name="picking_ids" invisible="True" />
                     <field
                         name="move_ids"

--- a/stock_split_picking/wizards/stock_split_picking.xml
+++ b/stock_split_picking/wizards/stock_split_picking.xml
@@ -12,7 +12,7 @@
                         name="move_ids"
                         invisible="mode != 'selection'"
                         required="mode == 'selection'"
-                        domain="[('picking_id', 'in', picking_ids)]"
+                        domain="[('picking_id', 'in', picking_ids), ('state', 'not in', ('done', 'cancel'))]"
                     >
                         <list create="true" edit="true" delete="true">
                             <field name="product_id" />


### PR DESCRIPTION
When a transfer is being partially processed by a user and you want to validate only that, you should create a new split order containing the done lines and keep remaining lines in the original transfer.

In business terms, a split order represent an extraction of an original order that is being partially processed. A back order is the remaining of an order that was not entirely available.

Implements #1882