### PR TITLE
[18.0][IMP] stock_picking_progress: the progress should not be marked as 100% when the move is not done yet

### DIFF
--- a/stock_picking_progress/models/stock_move.py
+++ b/stock_picking_progress/models/stock_move.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import api, fields, models
-from odoo.tools.float_utils import float_is_zero
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 
 class StockMove(models.Model):
@@ -22,7 +22,24 @@ class StockMove(models.Model):
                 record.progress = 100
                 continue
             rounding = record.product_uom.rounding
+            # If demanded quantity is effectively 0 then nothing
+            # was asked to be moved, so it's 'completed' by definition.
+            # Otherwise compute percent = done / demanded * 100.
             if float_is_zero(record.product_uom_qty, precision_rounding=rounding):
                 record.progress = 100
             else:
-                record.progress = (record.quantity / record.product_uom_qty) * 100
+                # We also need to keep in mind that the 'quantity' and 'product_uom_qty'
+                # can be equal while the move is not done yet, for example
+                # when transfer is ready to be processed (picking state is 'assigned').
+                # In this case, we can wrongly consider the move as 100% done.
+                # The idea is to have the move as 'almost done' in this case.
+                percentage = (record.quantity / record.product_uom_qty) * 100
+                # If percentage ever computes negative (bad data, returns, sign issues),
+                # this forces it up to 0.0
+                percentage = max(0.0, percentage)
+
+                # Only moves that are 'done' can have a progress of 100%.
+                if float_compare(percentage, 100.0, precision_digits=4) >= 0:
+                    record.progress = 99.9  # aka 'almost done'
+                else:
+                    record.progress = min(99.9, percentage)

--- a/stock_picking_progress/tests/test_progress.py
+++ b/stock_picking_progress/tests/test_progress.py
@@ -40,40 +40,54 @@ class TestPickingProgress(TransactionCase):
     def test_progress(self):
         # No move, progress is 100%
         self.assertEqual(self.picking.progress, 100.0)
-        # Add a new move, no qty done: progress 0%
+        # Add a new move, no qty done -> picking 0%
         move1 = self.add_move("Move 1")
         self.assertEqual(self.picking.progress, 0.0)
-        # Set quantity to 5.0 (half done), both move and picking are 50% done
-        self.set_quantity(move1, 5.0)
-        self.assertEqual(self.picking.progress, 50.0)
-        self.assertEqual(move1.progress, 50.0)
-        # Add a new move:
-        # move1 progress is still 50%
-        # move2 progress is 0%
-        # picking progress is 25%
+        # Add a second move:
         move2 = self.add_move("Move 2")
-        self.assertEqual(self.picking.progress, 25.0)
-        self.assertEqual(move1.progress, 50.0)
-        self.assertEqual(move2.progress, 0.0)
-        # Set quantity = 10.0 on move 2
-        # move1 progress is still 50%
-        # move2 progress is 100%
-        # picking progress is 75%
-        self.set_quantity(move2)
-        self.assertEqual(self.picking.progress, 75.0)
-        self.assertEqual(move2.progress, 100.0)
-        # Set quantity = 10.0 on move 1
-        # move1 progress is 100%
-        # move2 progress is still 100%
-        # picking progress is 100%
-        self.set_quantity(move1)
-        self.assertEqual(self.picking.progress, 100.0)
-        self.assertEqual(move1.progress, 100.0)
-        # Set quantity = 0.0 on both move
-        # move1 progress is 0%
-        # move2 progress is still 0%
-        # picking progress is 0%
+        # Set quantity = 0.0 on both moves
+        # Both moves = 0%, picking = 0%
         self.set_quantity(self.picking.move_ids, 0.0)
         self.assertEqual(move1.progress, 0.0)
         self.assertEqual(move2.progress, 0.0)
         self.assertEqual(self.picking.progress, 0.0)
+        # Set quantity to 5.0 (half done)
+        # move1 = 50%, move2 = 0%, picking = (50 + 0) / 2 = 25%
+        self.set_quantity(move1, 5.0)
+        self.assertEqual(move1.progress, 50.0)
+        self.assertEqual(move2.progress, 0.0)
+        self.assertEqual(self.picking.progress, 25.0)
+        # Set quantity on move2 to 5.0 (half done)
+        # move1 = 50%, move2 = 50%, picking = (50 + 50) / 2 = 50%
+        self.set_quantity(move2, 5.0)
+        self.assertEqual(move1.progress, 50.0)
+        self.assertEqual(move2.progress, 50.0)
+        self.assertEqual(self.picking.progress, 50.0)
+        # Set quantity on move2 to its full demanded qty (10.0)
+        # Since it's NOT done, move2 caps at 99.9 (not 100)
+        # picking = (50 + 99.9) / 2 = 74.95
+        self.set_quantity(move2)
+        self.assertEqual(self.picking.state, "assigned")
+        self.assertEqual(move1.state, "partially_available")
+        self.assertEqual(move2.state, "assigned")
+        self.assertEqual(move2.progress, 99.9)
+        self.assertAlmostEqual(self.picking.progress, 74.95, places=2)
+        # Set quantity on move1 to full demanded qty
+        # Both moves = 99.9 (not done), picking = 99.9
+        self.set_quantity(move1)
+        self.assertEqual(self.picking.state, "assigned")
+        self.assertEqual(move1.state, "assigned")
+        self.assertEqual(move2.state, "assigned")
+        self.assertEqual(move1.progress, 99.9)
+        self.assertEqual(move2.progress, 99.9)
+        self.assertEqual(self.picking.progress, 99.9)
+        # Set picking to done
+        self.picking.button_validate()
+        self.picking._action_done()
+        # Both moves = 100%, picking = 100%
+        self.assertEqual(self.picking.state, "done")
+        self.assertEqual(move1.state, "done")
+        self.assertEqual(move2.state, "done")
+        self.assertEqual(move1.progress, 100.0)
+        self.assertEqual(move2.progress, 100.0)
+        self.assertEqual(self.picking.progress, 100.0)


### PR DESCRIPTION
When the transfer is ready to be processed (state in partially_available, assigned, confirmed) and move is not done yet the move's demanded quantity and done quantity can be equal. 
In such case current implementation will result in 100% progress which is wrong.
Only DONE moves can have 100% progress.
So, we introduce "almost done -> 99.9" progress.