### PR TITLE
[18.0][FIX] stock_picking_tier_validation: Adapt to base change

### DIFF
--- a/stock_picking_tier_validation/models/stock_picking.py
+++ b/stock_picking_tier_validation/models/stock_picking.py
@@ -19,7 +19,7 @@ class StockPicking(models.Model):
                 # try to validate operation
                 reviews = rec.request_validation()
                 rec._validate_tier(reviews)
-                if not self._calc_reviews_validated(reviews):
+                if self.validation_status != "validated":
                     raise ValidationError(
                         _(
                             "This action needs to be validated for at least "


### PR DESCRIPTION
Method `_calc_reviews_validated` has been removed in OCA/server-ux#1138, so this commit adapts the needed changes to it.

Fixes #2064

@Tecnativa 