### PR TITLE
[18.0][FIX] stock_picking_group_by_partner_by_carrier: properly drop group from domain

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -5,6 +5,7 @@
 from collections import namedtuple
 
 from odoo import api, fields, models
+from odoo.osv import expression
 from odoo.tools import groupby
 
 
@@ -81,7 +82,11 @@ class StockMove(models.Model):
             return domain
 
         # remove group
-        domain = [x for x in domain if x[0] != "group_id"]
+        tree_domain = expression._tree_from_domain(domain)
+        tree_domain = [
+            x for x in tree_domain if expression.is_operator(x) or x[1] != "group_id"
+        ]
+        domain = expression._tree_as_domain(tree_domain)
 
         grouping_domain = self._assign_picking_group_domain()
 


### PR DESCRIPTION
batch picking module is adding & operators to the domain that were not there with only the stock module

convert domain to tree to remove an element and then convert back to domain

cc @sebalix 