### PR TITLE
[18.0][FIX] stock_dynamic_routing: package putaway

### DIFF
--- a/stock_dynamic_routing/models/stock_move.py
+++ b/stock_dynamic_routing/models/stock_move.py
@@ -123,7 +123,10 @@ class StockMove(models.Model):
             sql.SQL("SAVEPOINT {}").format(sql.Identifier(savepoint_name))
         )
         _logger.debug("Prepare pull re-routing")
-        super(StockMove, self.with_context(bypass_entire_pack=True))._action_assign()
+        super(
+            StockMove,
+            self.with_context(bypass_entire_pack=True, avoid_putaway_rules=True),
+        )._action_assign()
 
         moves_routing = self._routing_compute_rules()
         if not any(
@@ -137,6 +140,9 @@ class StockMove(models.Model):
                 sql.SQL("RELEASE SAVEPOINT {}").format(sql.Identifier(savepoint_name))
             )
             self.mapped("picking_id")._check_entire_pack()
+            self.filtered(
+                lambda move: move.state in ("assigned", "partially_available")
+            ).move_line_ids._apply_putaway_strategy()
             return {}
 
         _logger.debug("Rollback computation for applying pull re-routing")

--- a/stock_dynamic_routing/models/stock_picking.py
+++ b/stock_dynamic_routing/models/stock_picking.py
@@ -12,12 +12,6 @@ class StockPicking(models.Model):
         " canceled because it was left empty after a dynamic routing.",
     )
 
-    def _check_entire_pack(self):
-        # This can be dropped in v16 as part of odoo standard
-        if self.env.context.get("bypass_entire_pack"):
-            return
-        return super()._check_entire_pack()
-
     @api.depends("canceled_by_routing")
     def _compute_state(self):
         res = super()._compute_state()


### PR DESCRIPTION
Fix [PERF] dynamic routing
When there is no dynamic routing rule, the package putaway was not computed as we skip the result_package_id during the reservation. Now the putaway is also deferred and applied after the package is set on the stock move line.

cc @sebalix 