### PR TITLE
[18.0][FIX] stock_move_line_qty_picked: Align move quantity with reserved

### DIFF
--- a/stock_move_line_qty_picked/models/stock_move.py
+++ b/stock_move_line_qty_picked/models/stock_move.py
@@ -1,8 +1,8 @@
 # Copyright 2025 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from collections import defaultdict
 
-from odoo import api, models
+from odoo import models
+from odoo.tools import float_compare
 
 
 class StockMove(models.Model):
@@ -13,45 +13,25 @@ class StockMove(models.Model):
             return self._sum_ml_qty_picked()
         return super()._get_picked_quantity()
 
-    @api.depends("move_line_ids.picked", "move_line_ids.qty_picked")
-    def _compute_quantity(self):
-        picked_moves_ids = []
-        for move in self:
-            if move.picked and any(ml.qty_picked for ml in move.move_line_ids):
-                picked_moves_ids.append(move.id)
-        picked_moves_ids = self.browse(picked_moves_ids)
-
-        # Copied from odoo and adapted for qty_picked
-        data = self.env["stock.move.line"]._read_group(
-            [("id", "in", picked_moves_ids.move_line_ids.ids)],
-            ["move_id", "product_uom_id"],
-            ["qty_picked:sum"],
-        )
-        sum_qty = defaultdict(float)
-        for move, product_uom, qty_sum in data:
-            uom = move.product_uom
-            sum_qty[move.id] += product_uom._compute_quantity(qty_sum, uom, round=False)
-
-        for move in picked_moves_ids:
-            move.quantity = sum_qty[move.id]
-
-        not_picked_moves = self - picked_moves_ids
-        return super(StockMove, not_picked_moves)._compute_quantity()
-
-    def _quantity_sml(self):
-        if self._ml_has_qty_picked():
-            return self._sum_ml_qty_picked()
-        return super()._quantity_sml()
-
     def _ml_has_qty_picked(self):
-        self.ensure_one()
         return self.picked and any(ml.qty_picked for ml in self.move_line_ids)
 
     def _sum_ml_qty_picked(self):
         self.ensure_one()
         quantity = 0
-        for move_line in self.move_line_ids:
+        for move_line in self.move_line_ids.filtered("picked"):
             quantity += move_line.product_uom_id._compute_quantity(
                 move_line.qty_picked, self.product_uom, round=False
             )
         return quantity
+
+    def _action_done(self, cancel_backorder=False):
+        for move in self:
+            for line in move.move_line_ids:
+                if line.picked and float_compare(
+                    line.qty_picked,
+                    line.quantity,
+                    precision_rounding=line.product_uom_id.rounding,
+                ):
+                    line.quantity = line.qty_picked
+        return super()._action_done(cancel_backorder=cancel_backorder)

--- a/stock_move_line_qty_picked/models/stock_move_line.py
+++ b/stock_move_line_qty_picked/models/stock_move_line.py
@@ -49,9 +49,3 @@ class StockMoveLine(models.Model):
             values["quantity"] = qty
         self.with_context(move_line_pick_qty=True).update(values)
         return True
-
-    def _action_done(self):
-        for ml in self:
-            if ml.qty_picked and ml.picked and ml.qty_picked != ml.quantity:
-                ml.quantity = ml.qty_picked
-        return super()._action_done()

--- a/stock_move_line_qty_picked/tests/test_stock_move_line_qty_picked.py
+++ b/stock_move_line_qty_picked/tests/test_stock_move_line_qty_picked.py
@@ -22,7 +22,13 @@ class TestStockMoveLineQtyPicked(TransactionCase):
         cls.internal_transfer_type = cls.env.ref("stock.picking_type_internal")
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
         cls.stock_location_2 = cls.stock_location.copy({"name": "stock 2"})
-        cls.product = cls.env.ref("product.product_product_9")
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test product", "is_storable": True}
+        )
+        cls.env["stock.quant"]._update_available_quantity(
+            cls.product, cls.stock_location, 100
+        )
+        cls.quant = cls.env["stock.quant"]._gather(cls.product, cls.stock_location)
 
     @classmethod
     def _create_move(cls, product, quantity, from_location, to_location, picking=None):
@@ -49,28 +55,46 @@ class TestStockMoveLineQtyPicked(TransactionCase):
         picking_form.location_dest_id = to_location
         return picking_form.save()
 
-    def test_move_pick_qty(self):
+    def test_move_pick_qty_reservation(self):
         move = self._create_move(
             self.product, 5.0, self.stock_location, self.stock_location_2
         )
         move_line = move.move_line_ids
         self.assertEqual(move.picking_id.state, "assigned")
+        self.assertEqual(move.quantity, 5)
         self.assertEqual(move_line.quantity, 5)
         self.assertEqual(move_line.qty_picked, 0)
         self.assertFalse(move_line.picked)
+        self.assertEqual(self.quant.reserved_quantity, 5)
         # Pick partial qty
+        move_line.qty_picked = 4
+        self.assertEqual(move.quantity, 5)
+        self.assertEqual(move_line.quantity, 5)
+        self.assertEqual(move_line.qty_picked, 4)
+        self.assertTrue(move_line.picked)
+        self.assertEqual(self.quant.reserved_quantity, 5)
+        # Decrease picked qty on move line
         move_line.qty_picked = 3
+        self.assertEqual(move.quantity, 5)
         self.assertEqual(move_line.quantity, 5)
         self.assertEqual(move_line.qty_picked, 3)
         self.assertTrue(move_line.picked)
-        # Updating 'picked' to True should not reset the picked qty
-        move_line.picked = True
-        self.assertEqual(move_line.quantity, 5)
+        self.assertEqual(self.quant.reserved_quantity, 5)
+        # Decrease reserved qty on move
+        move.quantity = 2
+        self.assertEqual(move.quantity, 2)
+        self.assertEqual(move_line.quantity, 2)
+        self.assertEqual(self.quant.reserved_quantity, 2)
         self.assertEqual(move_line.qty_picked, 3)
         self.assertTrue(move_line.picked)
-        # When validating, only the picked qty is moved
+        # When validating, only the picked qty is moved, quantity is updated on
+        #  stock.move and another move line is created to match qty_picked
         move.picking_id.with_context(skip_backorder=True).button_validate()
-        self.assertEqual(move_line.quantity, 3)
+        self.assertEqual(move.quantity, 3)
+        self.assertEqual(sum(move.move_line_ids.mapped("quantity")), 3)
+        # Ensure 3 were moved on the quant and 2 are reserved on backorder
+        self.assertEqual(self.quant.quantity, 97)
+        self.assertEqual(self.quant.reserved_quantity, 2)
 
     def test_move_concurrent_pick_qty(self):
         move = self._create_move(
@@ -115,3 +139,99 @@ class TestStockMoveLineQtyPicked(TransactionCase):
         self.assertEqual(move_line.quantity, 5)
         self.assertEqual(move_line.qty_picked, 0)
         self.assertFalse(move_line.picked)
+
+    def test_mls_picked_and_not_picked(self):
+        product = self.env["product.product"].create(
+            {"name": "Test product", "is_storable": True, "tracking": "lot"}
+        )
+
+        lot_map = {}
+        for lot_name in ["LOT-001", "LOT-002", "LOT-003", "LOT-004"]:
+            lot = self.env["stock.lot"].create(
+                {
+                    "name": lot_name,
+                    "product_id": product.id,
+                }
+            )
+            lot_map[lot_name] = lot
+            self.env["stock.quant"]._update_available_quantity(
+                product, self.stock_location, 10, lot_id=lot
+            )
+        move = self._create_move(
+            product, 40.0, self.stock_location, self.stock_location_2
+        )
+        self.assertEqual(move.picking_id.state, "assigned")
+        self.assertEqual(move.quantity, 40)
+        self.assertFalse(move.picked)
+        self.assertEqual(len(move.move_line_ids), 4)
+        for line in move.move_line_ids:
+            self.assertEqual(line.quantity, 10)
+            self.assertEqual(line.qty_picked, 0)
+            self.assertFalse(line.picked)
+        # Setting picked on either move or move line will:
+        #  - mark picked on both move and move lines through compute and inverse
+        #  - set qty_picked = quantity
+        move.picked = True
+
+        # Remove picked flag on LOT-001
+        lot_1_line = move.move_line_ids.filtered(lambda li: li.lot_id.name == "LOT-001")
+        lot_1_line.picked = False
+        # Change quantity picked on LOT-002
+        lot_2_line = move.move_line_ids.filtered(lambda li: li.lot_id.name == "LOT-002")
+        lot_2_line.qty_picked = 8
+        # Keep qty_picked to 10 and picked=True on LOT-003
+        lot_3_line = move.move_line_ids.filtered(lambda li: li.lot_id.name == "LOT-003")
+        # Set qty_picked to 0 on LOT-004
+        lot_4_line = move.move_line_ids.filtered(lambda li: li.lot_id.name == "LOT-004")
+        lot_4_line.qty_picked = 0
+
+        self.assertEqual(lot_1_line.quantity, 10)
+        self.assertEqual(lot_1_line.qty_picked, 0)
+        self.assertFalse(lot_1_line.picked)
+
+        self.assertEqual(lot_2_line.quantity, 10)
+        self.assertEqual(lot_2_line.qty_picked, 8)
+        self.assertTrue(lot_2_line.picked)
+
+        self.assertEqual(lot_3_line.quantity, 10)
+        self.assertEqual(lot_3_line.qty_picked, 10)
+        self.assertTrue(lot_3_line.picked)
+
+        self.assertEqual(lot_4_line.quantity, 10)
+        self.assertEqual(lot_4_line.qty_picked, 0)
+        self.assertFalse(lot_4_line.picked)
+
+        # When validating we must have
+        #  - LOT-001: not moved because picked is False
+        #  - LOT-002: 8pces moved according to qty_picked
+        #  - LOT-003: 10pces moved because picked is True and qty_picked
+        #  - LOT-004: not moved because qty_picked = 0
+        move.picking_id.with_context(skip_backorder=True).button_validate()
+
+        lot_1_quant = self.env["stock.quant"]._gather(
+            product, self.stock_location, lot_id=lot_map["LOT-001"]
+        )
+        self.assertEqual(lot_1_quant.quantity, 10)
+
+        lot_2_quant = self.env["stock.quant"]._gather(
+            product, self.stock_location, lot_id=lot_map["LOT-002"]
+        )
+        self.assertEqual(lot_2_quant.quantity, 2)
+        lot_2_quant_2 = self.env["stock.quant"]._gather(
+            product, self.stock_location_2, lot_id=lot_map["LOT-002"]
+        )
+        self.assertEqual(lot_2_quant_2.quantity, 8)
+
+        lot_3_quant = self.env["stock.quant"]._gather(
+            product, self.stock_location, lot_id=lot_map["LOT-003"]
+        )
+        self.assertEqual(lot_3_quant.quantity, 0)
+        lot_3_quant_2 = self.env["stock.quant"]._gather(
+            product, self.stock_location_2, lot_id=lot_map["LOT-003"]
+        )
+        self.assertEqual(lot_3_quant_2.quantity, 10)
+
+        lot_4_quant = self.env["stock.quant"]._gather(
+            product, self.stock_location, lot_id=lot_map["LOT-004"]
+        )
+        self.assertEqual(lot_4_quant.quantity, 10)


### PR DESCRIPTION
In the previous version of this module the computation of stock.move.line.quantity was modified to reflect the picked quantity.

However, stock.move.line.quantity must reflect the reserved quantity on the move lines since there is an inverse function that is going to increase or decrease the quantity on stock.move.line.quantity accordingly.

The stock.move.quantity must only be updated to reflect the sum of stock.move.line.qty_picked when stock.move._action_done is called, to avoid the creation of a backorder.