### PR TITLE
[18.0][FIX] stock_picking_progress: use picked quantity

### DIFF
--- a/stock_picking_progress/models/stock_move.py
+++ b/stock_picking_progress/models/stock_move.py
@@ -11,18 +11,27 @@ class StockMove(models.Model):
     progress = fields.Float(compute="_compute_progress", store=True, aggregator="avg")
 
     @api.depends(
-        "product_uom_qty",
+        "picked",
         "product_uom",
-        "quantity",
+        "product_uom_qty",
         "state",
+        # Move line's fields used by method ``_get_picked_quantity()``: we add them
+        # to make sure the progress is recomputed when the picked quantity changes
+        "move_line_ids.picked",
+        "move_line_ids.product_uom_id",
+        "move_line_ids.quantity",
     )
     def _compute_progress(self):
-        for record in self:
-            if record.state == "done":
-                record.progress = 100
-                continue
-            rounding = record.product_uom.rounding
-            if float_is_zero(record.product_uom_qty, precision_rounding=rounding):
-                record.progress = 100
+        for move in self:
+            qty = move.product_uom_qty
+            # Done moves or moves with no demanded quantity are considered as 100% done
+            if move.state == "done" or float_is_zero(
+                qty, precision_rounding=move.product_uom.rounding
+            ):
+                move.progress = 100
+            # Picked moves' progress is computed using the picked qty
+            elif move.picked:
+                move.progress = 100 * move._get_picked_quantity() / qty
+            # All other moves have 0% progress
             else:
-                record.progress = (record.quantity / record.product_uom_qty) * 100
+                move.progress = 0

--- a/stock_picking_progress/models/stock_picking.py
+++ b/stock_picking_progress/models/stock_picking.py
@@ -9,15 +9,12 @@ class StockPicking(models.Model):
 
     progress = fields.Float(compute="_compute_progress", store=True, aggregator="avg")
 
-    @api.depends("move_ids", "move_ids.progress")
+    @api.depends("state", "move_ids.progress")
     def _compute_progress(self):
-        for record in self:
-            if record.state == "done":
-                record.progress = 100
-                continue
-            moves_progress = record.move_ids.mapped("progress")
-            # Avoid dividing by 0
-            if moves_progress:
-                record.progress = sum(moves_progress) / len(moves_progress)
+        for picking in self:
+            if picking.state == "done" or not (
+                moves_progress := picking.move_ids.mapped("progress")
+            ):
+                picking.progress = 100
             else:
-                record.progress = 100
+                picking.progress = sum(moves_progress) / len(moves_progress)

--- a/stock_picking_progress/tests/test_progress.py
+++ b/stock_picking_progress/tests/test_progress.py
@@ -37,43 +37,87 @@ class TestPickingProgress(TransactionCase):
                 quantity = qty
             move.quantity = quantity
 
-    def test_progress(self):
+    def test_move_progress_creation(self):
+        move = self.add_move("test_move_progress_on_creation")
+        self.assertEqual(move.state, "draft")
+        self.assertFalse(move.move_line_ids)
+        self.assertFalse(move.picked)
+        self.assertEqual(move.product_uom_qty, 10.0)
+        self.assertEqual(move._get_picked_quantity(), 0.0)
+        self.assertEqual(move.progress, 0.0)
+
+    def test_move_progress_done_move(self):
+        move = self.add_move("test_move_progress_done_move")
+        # Need some qty and a picked move line before setting the move to done
+        self.set_quantity(move, 1.0)
+        move.move_line_ids.picked = True
+        move._action_done(cancel_backorder=True)  # No backorder: keep original demand
+        self.assertEqual(move.state, "done")
+        self.assertTrue(move.move_line_ids)
+        self.assertTrue(move.picked)
+        self.assertEqual(move.product_uom_qty, 10.0)
+        self.assertEqual(move._get_picked_quantity(), 1.0)
+        self.assertEqual(move.progress, 100.0)  # Done move => progress is always 100%
+
+    def test_move_progress_no_demanded_qty(self):
+        move = self.add_move("test_move_progress_no_demanded_qty")
+        move.product_uom_qty = 0.0
+        self.assertEqual(move.state, "draft")
+        self.assertFalse(move.move_line_ids)
+        self.assertFalse(move.picked)
+        self.assertEqual(move.product_uom_qty, 0.0)
+        self.assertEqual(move._get_picked_quantity(), 0.0)
+        self.assertEqual(move.progress, 100.0)  # No demand => progress is 100%
+
+    def test_move_progress_picked(self):
+        move = self.add_move("test_move_progress")
+        self.set_quantity(move, 3.0)
+
+        move.move_line_ids.picked = False
+        self.assertEqual(move.state, "partially_available")
+        self.assertTrue(move.move_line_ids)
+        self.assertFalse(move.picked)
+        self.assertEqual(move.product_uom_qty, 10.0)
+        self.assertEqual(move._get_picked_quantity(), 3.0)
+        self.assertEqual(move.progress, 0.0)  # Not picked => progress is 0%
+
+        move.move_line_ids.picked = True
+        self.assertEqual(move.state, "partially_available")
+        self.assertTrue(move.move_line_ids)
+        self.assertTrue(move.picked)
+        self.assertEqual(move.product_uom_qty, 10.0)
+        self.assertEqual(move._get_picked_quantity(), 3.0)
+        self.assertEqual(move.progress, 30.0)  # Picked => progress is 30%
+
+    def test_picking_progress(self):
         # No move, progress is 100%
+        self.assertFalse(self.picking.move_ids)
         self.assertEqual(self.picking.progress, 100.0)
         # Add a new move, no qty done: progress 0%
         move1 = self.add_move("Move 1")
         self.assertEqual(self.picking.progress, 0.0)
-        # Set quantity to 5.0 (half done), both move and picking are 50% done
+        # Set quantity to 5.0 (half done), but the move is not picked: 0%
         self.set_quantity(move1, 5.0)
+        self.assertEqual(self.picking.progress, 0.0)
+        # Set the move as picked: 50%
+        move1.picked = True
         self.assertEqual(self.picking.progress, 50.0)
-        self.assertEqual(move1.progress, 50.0)
         # Add a new move:
-        # move1 progress is still 50%
+        # move1 progress is 50%
         # move2 progress is 0%
         # picking progress is 25%
         move2 = self.add_move("Move 2")
         self.assertEqual(self.picking.progress, 25.0)
-        self.assertEqual(move1.progress, 50.0)
-        self.assertEqual(move2.progress, 0.0)
-        # Set quantity = 10.0 on move 2
-        # move1 progress is still 50%
-        # move2 progress is 100%
-        # picking progress is 75%
-        self.set_quantity(move2)
-        self.assertEqual(self.picking.progress, 75.0)
-        self.assertEqual(move2.progress, 100.0)
-        # Set quantity = 10.0 on move 1
+        # Set quantity = 3.0 on move 2 and set it as picked
+        # move1 progress is 50%
+        # move2 progress is 30%
+        # picking progress is 40%
+        self.set_quantity(move2, 3.0)
+        move2.picked = True
+        self.assertEqual(self.picking.progress, 40.0)
+        # Set quantity = 10.0 on both moves
         # move1 progress is 100%
-        # move2 progress is still 100%
+        # move2 progress is 100%
         # picking progress is 100%
-        self.set_quantity(move1)
+        self.set_quantity(move1 + move2, 10.0)
         self.assertEqual(self.picking.progress, 100.0)
-        self.assertEqual(move1.progress, 100.0)
-        # Set quantity = 0.0 on both move
-        # move1 progress is 0%
-        # move2 progress is still 0%
-        # picking progress is 0%
-        self.set_quantity(self.picking.move_ids, 0.0)
-        self.assertEqual(move1.progress, 0.0)
-        self.assertEqual(move2.progress, 0.0)
-        self.assertEqual(self.picking.progress, 0.0)


### PR DESCRIPTION
Avoid having progress set to 100% when moves are not yet picked
Includes a refactoring of tests for improved readability and maintainability

Supersedes #2063