### PR TITLE
[FIX] sale_stock_restocking_fee_invoicing: fix context retrieval

### DIFF
--- a/sale_stock_restocking_fee_invoicing/wizards/stock_return_picking.py
+++ b/sale_stock_restocking_fee_invoicing/wizards/stock_return_picking.py
@@ -24,7 +24,9 @@ class StockReturnPicking(models.TransientModel):
             or "is_customer_return" in fields
         ):
             return res
-        picking = self.env["stock.picking"].browse(self.env.context["active_id"])
+        picking = self.env["stock.picking"].browse(self.env.context.get("active_id"))
+        if not picking:
+            return res
         charge_restocking_fee = picking.partner_id.charge_restocking_fee
         if "is_customer_return" in fields:
             res["is_customer_return"] = picking.picking_kind == "customer_out"


### PR DESCRIPTION
fix context retrieval for "active_id" in StockReturnPicking to prevent errors when no picking is found or "active_id" not inside context