### PR TITLE
[18][IMP] stock_move_line_qty_picked: Use register_hook

### DIFF
--- a/stock_move_line_qty_picked/models/stock_move.py
+++ b/stock_move_line_qty_picked/models/stock_move.py
@@ -1,8 +1,8 @@
 # Copyright 2025 Camptocamp SA
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import api, fields, models
-from odoo.tools import float_compare
 
 
 class StockMove(models.Model):
@@ -38,13 +38,26 @@ class StockMove(models.Model):
             )
         return quantity
 
-    def _action_done(self, cancel_backorder=False):
-        for move in self:
-            for line in move.move_line_ids:
-                if line.picked and float_compare(
-                    line.qty_picked,
-                    line.quantity,
-                    precision_rounding=line.product_uom_id.rounding,
-                ):
-                    line.quantity = line.qty_picked
-        return super()._action_done(cancel_backorder=cancel_backorder)
+    def _align_quantity_with_qty_picked(self):
+        self.move_line_ids._align_quantity_with_qty_picked()
+
+    def _register_hook(self):
+        super()._register_hook()
+
+        def _patched__action_done(self, cancel_backorder=False):
+            self._align_quantity_with_qty_picked()
+            return _patched__action_done.origin(self, cancel_backorder)
+
+        ModelClass = self.env.registry[self._name]
+        method = _patched__action_done
+        method.origin = ModelClass._action_done
+        ModelClass._action_done = _patched__action_done
+
+    def _unregister_hook(self):
+        # pylint: disable=missing-return, except-pass
+        super()._unregister_hook()
+        try:
+            ModelClass = self.env.registry[self._name]
+            delattr(ModelClass, "_action_done")
+        except AttributeError:
+            pass

--- a/stock_move_line_qty_picked/models/stock_move_line.py
+++ b/stock_move_line_qty_picked/models/stock_move_line.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Camptocamp SA
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import fields, models
 from odoo.tools import float_compare
@@ -57,3 +58,12 @@ class StockMoveLine(models.Model):
             values["quantity"] = qty
         self.with_context(move_line_pick_qty=True).update(values)
         return True
+
+    def _align_quantity_with_qty_picked(self):
+        for line in self:
+            if line.picked and float_compare(
+                line.qty_picked,
+                line.quantity,
+                precision_rounding=line.product_uom_id.rounding,
+            ):
+                line.quantity = line.qty_picked

--- a/stock_move_line_qty_picked/tests/test_stock_move_line_qty_picked.py
+++ b/stock_move_line_qty_picked/tests/test_stock_move_line_qty_picked.py
@@ -1,9 +1,10 @@
 # Copyright 2025 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo.tests import Form
+from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase
 
 
+@tagged("post_install", "-at_install")
 class TestStockMoveLineQtyPicked(TransactionCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Right now if this addon is installed, it aligns the qty when it is called in the stack. 
Since there are addons which are not depending on this but still overwriting `_action_done`,
we can not ensure when this `_action_done` is called in the stack. It depends on when a addon is loaded, with which dependencies. 

This change ensures, that the alignment happens before `_action_done` at all is called in the stack,
because it hooks in before with `_register_hook` and patching the method. 

The first concerns were raised here. https://github.com/OCA/stock-logistics-workflow/pull/2030#pullrequestreview-3166187551