### PR TITLE
[IMP] stock_picking_batch_creation: Hide fields in picking list by default

### DIFF
--- a/stock_picking_batch_creation/views/stock_picking.xml
+++ b/stock_picking_batch_creation/views/stock_picking.xml
@@ -23,8 +23,8 @@
         <field name="inherit_id" ref="stock_picking_batch.vpicktree" />
         <field name="arch" type="xml">
             <field name="state" position="after">
-                <field name="picking_device_id" />
-                <field name="nbr_picking_lines" />
+                <field name="picking_device_id" optional="hide" />
+                <field name="nbr_picking_lines" optional="hide" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This was overloading the list view in all flows where it is not needed.