### PR TITLE
[18.0][FIX] stock_partner_delivery_window: call delivery_time_weekdays property on empty record

### DIFF
--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -73,6 +73,8 @@ class ResPartner(models.Model):
 
     @property
     def delivery_time_weekdays(self):
+        if not self:
+            return set()
         self.ensure_one()
         if self.delivery_time_preference == "anytime":
             weekdays = set(range(7))


### PR DESCRIPTION
Allows to call this property without checking at first if the partner is set, e.g.:

```python
>>> list(picking.partner_id.delivery_time_weekdays)
```

Like it's currently done in `stock_release_channel_partner_delivery_window` module: https://github.com/OCA/stock-logistics-release-channel/blob/18.0/stock_release_channel_partner_delivery_window/models/stock_picking.py#L19

