### PR TITLE
[18.0][FIX] stock_picking_group_by_partner_by_carrier: cache

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -57,6 +57,8 @@ class StockMove(models.Model):
                 moves = self.browse(m.id for m in imoves)
                 moves.picking_id._update_merged_origin()
                 moves._on_assign_picking_message_link()
+                # clear SO pickings cache to ensure action_confirm is called
+                moves.sale_line_id.order_id.invalidate_recordset(fnames=["picking_ids"])
         res = super()._assign_picking_post_process(new=new)
         return res
 


### PR DESCRIPTION
Fix SO picking_ids cache issue when procurement groups are merged. 
`action_confirm` was not called on amended pickings preventing to trigger auto orderpoints.

cc @sebalix @rousseldenis @simahawk @lmignon 