### PR TITLE
[FIX] stock_no_negative false positive

### DIFF
--- a/stock_no_negative/models/stock_quant.py
+++ b/stock_no_negative/models/stock_quant.py
@@ -31,12 +31,22 @@ class StockQuant(models.Model):
             )
             disallowed_by_location = not quant.location_id.allow_negative_stock
             if (
-                float_compare(quant.quantity, 0, precision_digits=p) == -1
-                and quant.product_id.is_storable
+                quant.product_id.is_storable
                 and quant.location_id.usage in ["internal", "transit"]
                 and disallowed_by_product
                 and disallowed_by_location
             ):
+                gathered_quants = self.with_context(quants_cache=None)._gather(
+                    self.product_id,
+                    self.location_id,
+                    lot_id=self.lot_id,
+                    package_id=self.package_id,
+                    owner_id=self.owner_id,
+                    strict=True,
+                )
+                quantity = sum(q.quantity for q in gathered_quants)
+                if float_compare(quantity, 0, precision_digits=p) >= 0:
+                    return
                 msg_add = ""
                 if quant.lot_id:
                     msg_add = _(" lot %(name)s", name=quant.lot_id.display_name)

--- a/stock_no_negative/tests/test_stock_no_negative.py
+++ b/stock_no_negative/tests/test_stock_no_negative.py
@@ -36,7 +36,7 @@ class TestStockNoNegative(TransactionCase):
         )
         return product_ctg
 
-    def _create_product(self, name):
+    def _create_product(self, name="test product"):
         product = self.product_model.create(
             {
                 "name": name,
@@ -211,3 +211,83 @@ class TestStockNoNegative(TransactionCase):
             ]
         )
         self.assertEqual(quant.quantity, -100)
+
+    def test_constrain_allow_negative_quant_if_gathered_qty_positive(self):
+        """in case of concurrent access, it is legal to create a negative quant
+        if the overall quantity remains positive"""
+        product = self._create_product()
+        Quant = self.env["stock.quant"].with_context(test_stock_no_negative=True)
+        Quant.create(
+            [
+                {
+                    "product_id": product.id,
+                    "location_id": self.location_id.id,
+                    "quantity": 5,
+                }
+            ]
+        )
+        # this is legal
+        Quant.create(
+            [
+                {
+                    "product_id": product.id,
+                    "location_id": self.location_id.id,
+                    "quantity": -3,
+                }
+            ]
+        )
+        quants = Quant._gather(product, self.location_id)
+        self.assertEqual(sum(quants.mapped("quantity")), 2)
+
+    def test_constrain_forbids_negative_quant_if_gathered_qty_negative(self):
+        """in case of concurrent access, it is forbidden to create a negative quant
+        if the overall quantity gets negative"""
+        product = self._create_product()
+        Quant = self.env["stock.quant"].with_context(test_stock_no_negative=True)
+        Quant.create(
+            [
+                {
+                    "product_id": product.id,
+                    "location_id": self.location_id.id,
+                    "quantity": 5,
+                }
+            ]
+        )
+        # this will trigger the constrain because the overall quantity becomes -1
+        with self.assertRaises(UserError):
+            Quant.create(
+                [
+                    {
+                        "product_id": product.id,
+                        "location_id": self.location_id.id,
+                        "quantity": -6,
+                    }
+                ]
+            )
+
+    def test_constrain_forbids_changing_quantity_if_gathered_qty_negative(self):
+        """it is forbidden to change the quantity of a quant
+        if the overall quantity gets negative"""
+        product = self._create_product()
+        Quant = self.env["stock.quant"].with_context(test_stock_no_negative=True)
+        quant1 = Quant.create(
+            [
+                {
+                    "product_id": product.id,
+                    "location_id": self.location_id.id,
+                    "quantity": 5,
+                }
+            ]
+        )
+        Quant.create(
+            [
+                {
+                    "product_id": product.id,
+                    "location_id": self.location_id.id,
+                    "quantity": -3,
+                }
+            ]
+        )
+        # this will trigger the constrain because the overall quantity becomes -1
+        with self.assertRaises(UserError):
+            quant1.quantity = 2


### PR DESCRIPTION
Because of concurrency, it is possible that a negative quant is created because the main quant is locked and Odoo will avoid waiting in that case, and create additional quants for the product in the location.

This fix updates the way the constraint is computed by gathering the quants and checking the overall quantity.