### PR TITLE
[18.0][FIX] stock_picking_batch_creation: Fix unsupported operand

### DIFF
--- a/stock_picking_batch_creation/wizards/make_picking_batch.py
+++ b/stock_picking_batch_creation/wizards/make_picking_batch.py
@@ -493,7 +493,8 @@ class MakePickingBatch(models.TransientModel):
         :param picking: picking to add to the batch
         """
         self._selected_picking_ids.append(picking.id)
-        self._remaining_weight -= picking.weight
+        if self._remaining_weight is not None:
+            self._remaining_weight -= picking.weight
         self._remaining_nbr_picking_lines -= picking.nbr_picking_lines
         nbr_bins = self._get_nbr_bins_for_picking(picking)
         self._remaining_nbr_bins -= nbr_bins


### PR DESCRIPTION
In case device has no attribute max_weight set, _init_counters function will set self._remaining_weight as None, so we need to consider this possibility before decreasing it when adding picking.