### PR TITLE
[15.0] [FIX] CI: delete test-constraints.txt file

### DIFF
--- a/test-constraints.txt
+++ b/test-constraints.txt
@@ -1,1 +1,0 @@
-odoo-addon-partner-tz @ git+https://github.com/ecosoft-odoo/partner-contact.git@e18d353e787536e461d782ead04316b2eff292ad#egg=odoo-addon-partner-tz&subdirectory=setup/partner_tz


### PR DESCRIPTION
This PR (https://github.com/OCA/stock-logistics-workflow/pull/2050) added here the test-constraints.txt file
And this one (https://github.com/OCA/oca-ci/pull/99) changed the CI to fail if the test-constraints.txt file exists

Then, the CI always fail in the 15.0 branch of this repo, and it seems that the test-constraints.txt needs to be deleted

Supersedes #2105

I have also migrated the partner_tz module to fix this error

T-8760