### PR TITLE
[18.0][FIX] stock_picking_origin_reference_sale: set origin_reference from Sales Order ignoring customer reference

### DIFF
--- a/stock_picking_origin_reference_sale/models/stock_picking.py
+++ b/stock_picking_origin_reference_sale/models/stock_picking.py
@@ -11,13 +11,19 @@ class StockPicking(models.Model):
     def _selection_origin_reference(self):
         return super()._selection_origin_reference() + [(SO_MODEL_NAME, "Sales Order")]
 
+    def convert_origin(self, origin):
+        if not origin:
+            return ""
+        return origin.split("-")[0].strip()
+
     @api.depends(lambda x: x._get_depends_compute_origin_reference())
     def _compute_origin_reference(self):
         res = super()._compute_origin_reference()
         for picking in self:
             if not picking.origin_reference:
+                origin = self.convert_origin(picking.origin)
                 rel_sale = self.env[SO_MODEL_NAME].search(
-                    [("name", "=", picking.origin)], limit=1
+                    [("name", "=", origin)], limit=1
                 )
                 if rel_sale:
                     picking.origin_reference = f"{SO_MODEL_NAME},{rel_sale.id}"


### PR DESCRIPTION
**Description of the issue:**
When a Sales Order has a Customer Reference (`client_order_ref`), the Delivery Order `origin` field includes both the SO name and the customer reference (e.g., "SO00029 - ABC123"). 
This prevents the Delivery Order from having a clickable link to the originating Sales Order.

**Current behavior:**
- Delivery Order `origin` = "SO00029 - ABC123" (plain text)
- No clickable link to the SO in the transfer.

**Expected behavior:**
- The Delivery Order should maintain a clickable link to the Sales Order via the `origin_reference` field.
- The `origin` field can still show the descriptive text including the customer reference.

**Solution implemented:**
- Added a `convert_origin` method to extract only the SO name from `origin`.
- Updated `_compute_origin_reference` to search for the SO using the extracted name and set `origin_reference`.
- Ensures that Delivery Orders now correctly link back to the originating Sales Order without modifying the descriptive `origin`.

**Affected versions:**  
- Odoo 18.0

**Example:**  
- `origin` = "SO00029 - ABC123"  
- `origin_reference` = "sale.order,42" (clickable link to SO)

**Impact**

Restores expected behavior of the Delivery Orders by ensuring the Source Document link (origin_reference) correctly points to the originating Sales Order, even when a Customer Reference is present.

Fixes issue [#2116](https://github.com/OCA/stock-logistics-workflow/issues/2116)
