### PR TITLE
[18.0][FIX] stock_picking_group_by_partner_by_carrier: cache issue

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -57,8 +57,13 @@ class StockMove(models.Model):
                 moves = self.browse(m.id for m in imoves)
                 moves.picking_id._update_merged_origin()
                 moves._on_assign_picking_message_link()
-                # clear SO pickings cache to ensure action_confirm is called
-                moves.sale_line_id.order_id.invalidate_recordset(fnames=["picking_ids"])
+        # Ensure sale.order.picking_ids is properly read to ensure
+        # action_confirm is called.
+        # The m2m relation from stock.picking to sale.order is changed to a
+        # stored computed field with depends but the reverse relation is not
+        # defined as computed, so we need to flush the stored computed field so
+        # that any read from sale.order will fetch the right value.
+        self.picking_id.flush_recordset(["sale_ids"])
         res = super()._assign_picking_post_process(new=new)
         return res
 


### PR DESCRIPTION
Fix SO picking_ids cache issue when procurement groups are merged. action_confirm was not called preventing to trigger auto orderpoints.

@lmignon @rousseldenis @sebalix I found the real issue. Here is a better fix

The m2m relation between sale.order and stock.picking was changed to computed on the picking side. So reading from the SO won't trigger the recompute. To workaround this, I force a flush of the computed field when the value is modified to ensure the read from the SO will collect the right data from DB.