### PR TITLE
[18.0][FIX] stock_checkout_sync: Fix config view

### DIFF
--- a/stock_checkout_sync/views/stock_picking_type_views.xml
+++ b/stock_checkout_sync/views/stock_picking_type_views.xml
@@ -5,9 +5,9 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
-            <field name="default_location_dest_id" position="after">
+            <group name="locations" position="inside">
                 <field name="checkout_sync" />
-            </field>
+            </group>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
cc @mmequignon @henrybackman 

Before
<img width="932" height="153" alt="image" src="https://github.com/user-attachments/assets/db02b57e-a77f-4646-aae1-efc0fae48790" />

checkbox at the end of the dest location line