### PR TITLE
[18.0][IMP] stock_partner_delivery_window: check date

### DIFF
--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -2,6 +2,8 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
+import datetime
+
 from odoo import Command, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
@@ -91,20 +93,22 @@ class ResPartner(models.Model):
             )
         return weekdays
 
-    def is_in_delivery_window(self, date_time):
+    def is_in_delivery_window(self, date):
         """
-        Checks if provided date_time is in a delivery window for actual partner
+        Checks if provided date is in a delivery window for actual partner
 
-        :param date_time: Datetime object
+        :param date: Datetime or Date object
         :return: Boolean
         """
         self.ensure_one()
         if self.delivery_time_preference == "workdays":
-            if date_time.weekday() > 4:
+            if date.weekday() > 4:
                 return False
             return True
-        windows = self.get_delivery_windows(date_time.weekday()).get(self.id)
+        windows = self.get_delivery_windows(date.weekday()).get(self.id)
         if windows:
+            if not isinstance(date, datetime.datetime):
+                return True
             for w in windows:
                 start_time = w.get_time_window_start_time()
                 end_time = w.get_time_window_end_time()
@@ -114,7 +118,7 @@ class ResPartner(models.Model):
                 else:
                     utc_start = start_time
                     utc_end = end_time
-                if utc_start <= date_time.time() <= utc_end:
+                if utc_start <= date.time() <= utc_end:
                     return True
         return False
 

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Camptocamp
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import datetime
+
 from freezegun import freeze_time
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -197,3 +199,23 @@ class TestPartnerDeliveryWindow(BaseCommon):
 
     def test_weekdays_time_window(self):
         self.assertEqual(self.customer_time_window.delivery_time_weekdays, {3, 5})
+
+    def test_is_in_delivery_window(self):
+        # window for Thu and Sat
+        self.customer_time_window.delivery_time_window_ids.write(
+            {"time_window_start": 10.0, "time_window_end": 16.0}
+        )
+        # Friday
+        date = datetime.date.fromisoformat("2020-04-03")
+        self.assertFalse(self.customer_time_window.is_in_delivery_window(date))
+        # Saturday
+        date = datetime.date.fromisoformat("2020-04-04")
+        self.assertTrue(self.customer_time_window.is_in_delivery_window(date))
+        date = datetime.datetime.fromisoformat("2020-04-04 09:00:00")
+        self.assertFalse(self.customer_time_window.is_in_delivery_window(date))
+        date = datetime.datetime.fromisoformat("2020-04-04 10:00:00")
+        self.assertTrue(self.customer_time_window.is_in_delivery_window(date))
+        date = datetime.datetime.fromisoformat("2020-04-04 16:00:00")
+        self.assertTrue(self.customer_time_window.is_in_delivery_window(date))
+        date = datetime.datetime.fromisoformat("2020-04-04 17:00:00")
+        self.assertFalse(self.customer_time_window.is_in_delivery_window(date))


### PR DESCRIPTION
Allow to check if a date is in window. Now works with date and datetime. This allows to check a delivery date without time.

cc @grindtildeath @sebalix @mmequignon 