### PR TITLE
[16.0] [FIX] sale_order_global_stock_route: fix nested SaleOrderLine Class in sale_order.py

### DIFF
--- a/sale_order_global_stock_route/models/sale_order.py
+++ b/sale_order_global_stock_route/models/sale_order.py
@@ -31,19 +31,20 @@ class SaleOrder(models.Model):
             lines.write({"route_id": vals["route_id"]})
         return res
 
-    class SaleOrderLine(models.Model):
-        _inherit = "sale.order.line"
 
-        @api.onchange("product_id")
-        def global_stock_route_product_id_change(self):
-            if self.order_id.route_id:
-                self.route_id = self.order_id.route_id
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
 
-        @api.model_create_multi
-        def create(self, vals_list):
-            for vals in vals_list:
-                if not vals.get("route_id", False):
-                    order = self.env["sale.order"].browse(vals["order_id"])
-                    if order.route_id:
-                        vals["route_id"] = order.route_id.id
-            return super().create(vals_list)
+    @api.onchange("product_id")
+    def global_stock_route_product_id_change(self):
+        if self.order_id.route_id:
+            self.route_id = self.order_id.route_id
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("route_id", False):
+                order = self.env["sale.order"].browse(vals["order_id"])
+                if order.route_id:
+                    vals["route_id"] = order.route_id.id
+        return super().create(vals_list)


### PR DESCRIPTION
This PR moves the `SaleOrderLine` class out of the `SaleOrder` class to make it a top-level definition. While nested classes are syntactically valid in Python and functional in Odoo, this change aligns with standard Odoo coding conventions for better readability, maintainability, and modularity. **No functional changes** are introduced.

## Changes
- Un-nested `SaleOrderLine` from within `SaleOrder`.
- Ensured consistent 4-space indentation throughout the file.

## Testing
- Verified module loads without errors in Odoo 16.
- Confirmed route inheritance and `onchange` behaviors remain intact.

This is also affecting v15,v17,v18.

@BinhexTeam