### PR TITLE
[18.0][FIX] stock_partner_delivery_window: fix tz conversion

### DIFF
--- a/stock_partner_delivery_window/__manifest__.py
+++ b/stock_partner_delivery_window/__manifest__.py
@@ -5,10 +5,15 @@
     "summary": "Define preferred delivery time windows for partners",
     "version": "18.0.1.2.0",
     "category": "Inventory",
-    "author": "Camptocamp, ACSONE SA/NV, Odoo Community Association (OCA)",
+    "author": "Camptocamp, ACSONE SA/NV, BCIM, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/stock-logistics-workflow",
-    "depends": ["base_time_window", "partner_tz", "stock"],
+    "depends": [
+        "base_time_window",
+        "partner_tz",  # shows the tz field on the partner
+        "stock",
+    ],
+    "maintainers": ["jbaudoux"],
     "data": [
         "security/ir.model.access.csv",
         "views/res_partner.xml",

--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -4,11 +4,11 @@
 
 import datetime
 
+import pytz
+
 from odoo import Command, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
-
-from odoo.addons.partner_tz.tools import tz_utils
 
 WORKDAYS = list(range(5))
 
@@ -101,6 +101,9 @@ class ResPartner(models.Model):
         :return: Boolean
         """
         self.ensure_one()
+        tz = pytz.timezone(self.tz or self.env.company.partner_id.tz or "UTC")
+        if isinstance(date, datetime.datetime):
+            date = date.astimezone(pytz.utc).astimezone(tz)
         if self.delivery_time_preference == "workdays":
             if date.weekday() > 4:
                 return False
@@ -112,13 +115,7 @@ class ResPartner(models.Model):
             for w in windows:
                 start_time = w.get_time_window_start_time()
                 end_time = w.get_time_window_end_time()
-                if self.tz:
-                    utc_start = tz_utils.tz_to_utc_time(self.tz, start_time)
-                    utc_end = tz_utils.tz_to_utc_time(self.tz, end_time)
-                else:
-                    utc_start = start_time
-                    utc_end = end_time
-                if utc_start <= date.time() <= utc_end:
+                if start_time <= date.time() <= end_time:
                     return True
         return False
 

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -62,11 +62,11 @@ class StockPicking(models.Model):
         partner = self.partner_id
         if partner.delivery_time_preference == "workdays":
             message = self.env._(
-                "The %(date_name)s is %(date)s %(weekday)s, but the partner is "
+                "The %(date_name)s is %(date)s (%(tz)s), but the partner is "
                 "set to prefer deliveries on working days.",
                 date_name=self._planned_delivery_date_name,
                 date=formatted_delivery_date,
-                weekday=delivery_date.weekday(),
+                tz=self.env.context.get("tz"),
             )
         else:
             delivery_windows_strings = []

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -47,19 +47,19 @@ class TestPartnerDeliveryWindow(PartnerDeliveryWindowCommon):
             time_window_picking.partner_delivery_window_warning,
         )
 
-    @freeze_time("2020-04-02 07:59:59")  # Thursday
-    def test_with_timezone_dst(self):
+    @freeze_time("2020-04-02")
+    def test_with_timezone_dst_date_dst(self):
+        """Test while we are in DST and scheduled date also in DST"""
         # Define customer to allow shipping only between 10.00am and 4.00pm
-        # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
+        # in tz 'Europe/Brussels' (UTC+1 or UTC+2 during DST)
         self.customer_time_window.tz = "Europe/Brussels"
         self.customer_time_window.delivery_time_window_ids.write(
             {"time_window_start": 10.0, "time_window_end": 16.0}
         )
-        # Test DST
-        #
+        picking = self._create_delivery_picking(self.customer_time_window)
         # Frozen time is in UTC so 2020-04-02 07:59:59 == 2020-04-02 09:59:59
         #  in Brussels which is preferred
-        picking = self._create_delivery_picking(self.customer_time_window)
+        picking.scheduled_date = "2020-04-02 07:59:59"  # Thursday
         picking._compute_partner_delivery_window_warning()
         self.assertIn(
             "the partner is set to prefer deliveries on following time windows",
@@ -89,19 +89,106 @@ class TestPartnerDeliveryWindow(PartnerDeliveryWindowCommon):
             picking.partner_delivery_window_warning,
         )
 
-    @freeze_time("2020-03-26 08:59:59")  # Thursday
-    def test_with_timezone_no_dst(self):
+    @freeze_time("2020-03-26")
+    def test_with_timezone_no_dst_date_no_dst(self):
+        """Test while we are not in DST and scheduled date also not in DST"""
         # Define customer to allow shipping only between 10.00am and 4.00pm
-        # in tz 'Europe/Brussels' (GMT+1 or GMT+2 during DST)
+        # in tz 'Europe/Brussels' (UTC+1 or UTC+2 during DST)
         self.customer_time_window.tz = "Europe/Brussels"
         self.customer_time_window.delivery_time_window_ids.write(
             {"time_window_start": 10.0, "time_window_end": 16.0}
         )
-        # Test No-DST
-        #
+        picking = self._create_delivery_picking(self.customer_time_window)
         # Frozen time is in UTC so 2020-03-26 08:59:59 == 2020-04-02 09:59:59
         #  in Brussels which is preferred
+        picking.scheduled_date = "2020-03-26 08:59:59"  # Thursday
+        picking._compute_partner_delivery_window_warning()
+        self.assertIn(
+            "the partner is set to prefer deliveries on following time windows",
+            picking.partner_delivery_window_warning,
+        )
+        # Scheduled date is in UTC so 2020-03-26 09:00:00 == 2020-04-02 10:00:00
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-03-26 09:00:00"
+        picking._compute_partner_delivery_window_warning()
+        # No warning since we're in the timeframe
+        self.assertFalse(picking.partner_delivery_window_warning)
+        # Scheduled date is in UTC so 2020-03-26 14:59:59 == 2020-04-02 15:59:59
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-03-26 14:59:59"
+        picking._compute_partner_delivery_window_warning()
+        # No warning since we're in the timeframe
+        self.assertFalse(picking.partner_delivery_window_warning)
+        # Scheduled date is in UTC so 2020-03-26 15:00:00 == 2020-04-02 16:00:00
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-03-26 15:00:00"
+        picking._compute_partner_delivery_window_warning()
+        self.assertFalse(picking.partner_delivery_window_warning)
+        # Scheduled date is in UTC so 2020-03-26 15:00:01 == 2020-04-02 16:00:01
+        #  in Brussels which is not preferred
+        picking.scheduled_date = "2020-03-26 15:00:01"
+        picking._compute_partner_delivery_window_warning()
+        self.assertIn(
+            "the partner is set to prefer deliveries on following time windows",
+            picking.partner_delivery_window_warning,
+        )
+
+    @freeze_time("2020-03-26")
+    def test_with_timezone_no_dst_date_dst(self):
+        """Test while we are not in DST and scheduled date is in DST"""
+        # Define customer to allow shipping only between 10.00am and 4.00pm
+        # in tz 'Europe/Brussels' (UTC+1 or UTC+2 during DST)
+        self.customer_time_window.tz = "Europe/Brussels"
+        self.customer_time_window.delivery_time_window_ids.write(
+            {"time_window_start": 10.0, "time_window_end": 16.0}
+        )
         picking = self._create_delivery_picking(self.customer_time_window)
+        # Frozen time is in UTC so 2020-04-02 07:59:59 == 2020-04-02 09:59:59
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-04-02 07:59:59"  # Thursday
+        picking._compute_partner_delivery_window_warning()
+        self.assertIn(
+            "the partner is set to prefer deliveries on following time windows",
+            picking.partner_delivery_window_warning,
+        )
+        # Scheduled date is in UTC so 2020-04-02 08:00:00 == 2020-04-02 10:00:00
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-04-02 08:00:00"
+        picking._compute_partner_delivery_window_warning()
+        self.assertFalse(picking.partner_delivery_window_warning)
+        # Scheduled date is in UTC so 2020-04-02 13:59:59 == 2020-04-02 15:59:59
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-04-02 13:59:59"
+        picking._compute_partner_delivery_window_warning()
+        self.assertFalse(picking.partner_delivery_window_warning)
+        # Scheduled date is in UTC so 2020-04-02 14:00:00 == 2020-04-02 16:00:00
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-04-02 14:00:00"
+        picking._compute_partner_delivery_window_warning()
+        self.assertFalse(picking.partner_delivery_window_warning)
+        # Scheduled date is in UTC so 2020-04-02 14:00:01 == 2020-04-02 16:00:01
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-04-02 14:00:01"
+        picking._compute_partner_delivery_window_warning()
+        self.assertIn(
+            "the partner is set to prefer deliveries on following time windows",
+            picking.partner_delivery_window_warning,
+        )
+        # Now test with a scheduled that is not in DST
+
+    @freeze_time("2020-04-02")
+    def test_with_timezone_dst_date_no_dst(self):
+        """Test while we are in DST and scheduled date not in DST"""
+        # Define customer to allow shipping only between 10.00am and 4.00pm
+        # in tz 'Europe/Brussels' (UTC+1 or UTC+2 during DST)
+        self.customer_time_window.tz = "Europe/Brussels"
+        self.customer_time_window.delivery_time_window_ids.write(
+            {"time_window_start": 10.0, "time_window_end": 16.0}
+        )
+        picking = self._create_delivery_picking(self.customer_time_window)
+        # Frozen time is in UTC so 2020-03-26 08:59:59 == 2020-04-02 09:59:59
+        #  in Brussels which is preferred
+        picking.scheduled_date = "2020-03-26 08:59:59"  # Thursday
         picking._compute_partner_delivery_window_warning()
         self.assertIn(
             "the partner is set to prefer deliveries on following time windows",


### PR DESCRIPTION
* Respect daylight saving
  astimezone considers the date in the tz conversion while tz_to_utc_time only looks at the time. Today CEST is +2 but next monday CEST is +1. When the delivery date is next week, proper conversion matters based on the date.
* Add missing conversions
* Fix error message content

cc @grindtildeath @sebalix 