### PR TITLE
[18.0][FIX] stock_dynamic_routing: push putaway

### DIFF
--- a/stock_dynamic_routing/models/stock_move.py
+++ b/stock_dynamic_routing/models/stock_move.py
@@ -524,8 +524,13 @@ class StockMove(models.Model):
         goes to the correct place. For all other moves, the destination is the
         one of the picking type to respect the locations chain.
         """
-        self.location_dest_id = routing_rule.location_src_id
+        # Do not compute putaway for the new move location dest by first
+        # setting the new location on the move line because the putaway will
+        # not consider the package
         self.move_line_ids.location_dest_id = routing_rule.location_src_id
+        self.location_dest_id = routing_rule.location_src_id
+        # Recompute putaway considering the package if any
+        self.move_line_ids._apply_putaway_strategy()
         routing_move = self._insert_routing_moves(
             routing_rule.picking_type_id,
             routing_rule.location_src_id,


### PR DESCRIPTION
Ensure the putaway is computed considering the package if any is set

I prevent `_get_putaway_strategy` to be called in https://github.com/odoo/odoo/blob/6c9ef521da8d73ea0a0ece24b00d4e3378520e51/addons/stock/models/stock_move.py#L241
and call instead https://github.com/odoo/odoo/blob/6c9ef521da8d73ea0a0ece24b00d4e3378520e51/addons/stock/models/stock_move_line.py#L254

cc @sebalix 