### PR TITLE
[18.0][FIX] stock_picking_batch_creation: fix stock device order

### DIFF
--- a/stock_picking_batch_creation/tests/test_get_device_to_use.py
+++ b/stock_picking_batch_creation/tests/test_get_device_to_use.py
@@ -213,3 +213,67 @@ class TestGetDeviceToUse(ClusterPickingCommonFeatures):
         self.assertEqual(first_picking, self.pick1)
         device = make_picking_batch._compute_device_to_use(first_picking)
         self.assertEqual(device, self.device1)
+
+    def test_device_used_for_first_picking_splitting_00(self):
+        """Check the last device is used for splitting the first picking.
+
+        Default order is :: device3, device2, device1.
+        The last device (device1) can not manage the only picking.
+        So the picking will be split.
+
+        """
+        # Keep only one picking and a heavy one
+        self.pick1.action_cancel()
+        self.pick2.action_cancel()
+        product_big_1 = self._create_product("Unittest P1 voluminous", 10, 100, 1, 1)
+        self._set_quantity_in_stock(self.stock_location, product_big_1)
+        self._add_product_to_picking(self.pick3, product_big_1)
+        make_picking_batch = self.make_picking_batch.create(
+            {
+                "user_id": self.env.user.id,
+                "picking_type_ids": [(4, self.picking_type_1.id)],
+                "split_picking_exceeding_limits": True,
+                # Add the device not in their default sort order
+                "stock_device_type_ids": [
+                    (4, self.device1.id),
+                    (4, self.device2.id),
+                    (4, self.device3.id),
+                ],
+            }
+        )
+        first_picking = make_picking_batch._get_first_picking()
+        # A split picking has been created
+        self.assertTrue(first_picking != self.pick3)
+
+    def test_device_used_for_first_picking_splitting_01(self):
+        """Check the last device is used for splitting the first picking.
+
+        The last device (device2) can manage the only picking.
+        So picking will not be split.
+
+        """
+        # Keep only one picking and a heavy one.
+        self.pick1.action_cancel()
+        self.pick2.action_cancel()
+        product_big_1 = self._create_product("Unittest P1 voluminous", 10, 100, 1, 1)
+        self._set_quantity_in_stock(self.stock_location, product_big_1)
+        self._add_product_to_picking(self.pick3, product_big_1)
+        # Set the device order
+        self.device1.sequence = 10
+        self.device3.sequence = 20
+        self.device2.sequence = 30
+        make_picking_batch = self.make_picking_batch.create(
+            {
+                "user_id": self.env.user.id,
+                "picking_type_ids": [(4, self.picking_type_1.id)],
+                "split_picking_exceeding_limits": True,
+                # Add the device not in their default sort order
+                "stock_device_type_ids": [
+                    (4, self.device1.id),
+                    (4, self.device2.id),
+                    (4, self.device3.id),
+                ],
+            }
+        )
+        first_picking = make_picking_batch._get_first_picking()
+        self.assertEqual(first_picking, self.pick3)

--- a/stock_picking_batch_creation/wizards/make_picking_batch.py
+++ b/stock_picking_batch_creation/wizards/make_picking_batch.py
@@ -266,7 +266,7 @@ class MakePickingBatch(models.TransientModel):
         )
 
     def _split_first_picking_for_limit(self, picking):
-        last_device = self.stock_device_type_ids[-1]
+        last_device = self._get_sorted_devices()[-1]
         if last_device.split_mode == "dimension":
             return (
                 self.env["stock.split.picking"]
@@ -294,7 +294,7 @@ class MakePickingBatch(models.TransientModel):
         ):
             return True
         # Then, check the device limits
-        last_device = self.stock_device_type_ids[-1]
+        last_device = self._get_sorted_devices()[-1]
         if last_device.split_mode == "dimension":
             if last_device.max_volume and picking.volume > last_device.max_volume:
                 return True
@@ -375,10 +375,17 @@ class MakePickingBatch(models.TransientModel):
         return remaining_volume
 
     def _compute_device_to_use(self, picking):
-        for device in self.stock_device_type_ids.sorted("sequence"):
+        for device in self._get_sorted_devices():
             if picking.filtered_domain(self._get_picking_domain_for_device(device)):
                 return device
         return self.env["stock.device.type"]
+
+    def _get_sorted_devices(self):
+        """Return the devices sorted in their default order.
+
+        Because it will not be done by default with the Many2many
+        """
+        return self.stock_device_type_ids.sorted()
 
     def _volume_condition_for_device_choice(
         self, min_volume, picking_volume, max_volume


### PR DESCRIPTION
Before this change when searching for a device to use for the batch, the order of the devices was not guaranteed although important. And it could cause some batch split not happening.

Now the possible devices will be sorted by their default order, which is by sequence and name.