### PR TITLE
[16][FIX] stock_move_propagate_first_move

### DIFF
--- a/stock_move_propagate_first_move/README.rst
+++ b/stock_move_propagate_first_move/README.rst
@@ -70,6 +70,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Souheil Bejaoui (ACSONE SA/NV) <souheil.bejaoui@acsone.eu>
+* Adriana Saiz <adriana.saiz@factorlibre.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_move_propagate_first_move/__manifest__.py
+++ b/stock_move_propagate_first_move/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": """
         This addon propagate the picking type of the original move to all next moves
         created from procurement""",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.1.1",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",

--- a/stock_move_propagate_first_move/models/stock_move.py
+++ b/stock_move_propagate_first_move/models/stock_move.py
@@ -12,6 +12,7 @@ class StockMove(models.Model):
         string="First Move",
         readonly=True,
         help="The original move which generated this one.",
+        index="btree_not_null",
     )
     first_picking_type_id = fields.Many2one(
         comodel_name="stock.picking.type",

--- a/stock_move_propagate_first_move/readme/CONTRIBUTORS.rst
+++ b/stock_move_propagate_first_move/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Souheil Bejaoui (ACSONE SA/NV) <souheil.bejaoui@acsone.eu>
+* Adriana Saiz <adriana.saiz@factorlibre.com>

--- a/stock_move_propagate_first_move/static/description/index.html
+++ b/stock_move_propagate_first_move/static/description/index.html
@@ -416,6 +416,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-4">Contributors</a></h3>
 <ul class="simple">
 <li>Souheil Bejaoui (ACSONE SA/NV) &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
+<li>Adriana Saiz &lt;<a class="reference external" href="mailto:adriana.saiz&#64;factorlibre.com">adriana.saiz&#64;factorlibre.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Add index for first_move_id to improve performance

Without indexing first_move_id field, when trying to execute write method on a stock move, for example when we confirm a sale order. The query lasts for at least more than 7 seconds. 

This slows down the system and can even cause PostgreSQL blocks.

As we can see in this profiler, the query:

sql('SELECT "stock_move".id FROM "stock_move" WHERE ("stock_move"."first_move_id" in %s) ORDER BY "stock_move"."id" ') (SELECT "stock_move".id FROM "stock_move" WHERE ("stock_move"."first_move_id" in (25199374)) ORDER BY "stock_move"."id" )

The query is consuming more than 70% of the order confirmation time, when making a return.

<img width="1861" height="740" alt="image" src="https://github.com/user-attachments/assets/0d419d21-1c0e-46eb-848c-ba1694bb89ef" />

Whereas if we index the field first_move_id, the query lasts less than a second and all the process is finished in only 1 second

<img width="1924" height="957" alt="image" src="https://github.com/user-attachments/assets/bf5c829a-91e3-4cc1-ad58-02491830ac9e" />

