### PR TITLE
[18.0][IMP] stock_move_auto_assign_auto_release: improve performance

### DIFF
--- a/stock_move_auto_assign_auto_release/models/product_product.py
+++ b/stock_move_auto_assign_auto_release/models/product_product.py
@@ -11,8 +11,18 @@ class ProductProduct(models.Model):
     def _moves_auto_release_domain(self):
         return [
             ("product_id", "=", self.id),
-            ("is_auto_release_allowed", "=", True),
+            ("need_release", "=", True),
         ]
+
+    def _get_moves_auto_release(self):
+        moves = self.env["stock.move"].search(self._moves_auto_release_domain())
+        # NOTE 'is_auto_release_allowed' not in the domain to avoid a
+        # time consuming computation of 'release_ready' and
+        # 'ordered_available_to_promise_qty' under the hood.
+        # Filtering moves manually here limits the computation of
+        # is_auto_release_allowed' (with 'release_ready' and
+        # 'ordered_available_to_promise_qty' fields) only to relevant moves.
+        return moves.filtered("is_auto_release_allowed")
 
     def pickings_auto_release(self):
         """Job trying to auto release pickings based on product
@@ -21,7 +31,7 @@ class ProductProduct(models.Model):
         and triggers a delayed release available to promise for their pickings.
         """
         self.ensure_one()
-        moves = self.env["stock.move"].search(self._moves_auto_release_domain())
+        moves = self._get_moves_auto_release()
         pickings = moves.picking_id
         if not pickings:
             return


### PR DESCRIPTION
The search operation on `is_auto_release_allowed` (search method behind) was computing values of `release_ready` and `ordered_available_to_promise_qty` (both computed fields) on a large recordset, while we are interested only by moves linked to a given product.

This change consists of first looking for moves not yet done, then filtering them through `.filtered("is_auto_release_allowed")`, prefetching/computing the value only for these moves.

It improves the performance a lot: the underlying call to `read_group` in in `<stock.move>._get_ordered_available_to_promise_by_warehouse()` method (module `stock_available_to_promise_release`) was done too many times, from speedscope we switched from a total time of ~15s to execute these queries, to 71ms.

For instance, here are the executed queries when running the `pickings_auto_release` job on one product:

## Before
```
       queryid        |                                    query                                    | calls | total_time | mean_time  
----------------------+-----------------------------------------------------------------------------+-------+------------+-----------
  8562200540755620237 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |    18 |     827.71 |     45.98 
 -7397510249987276265 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |    12 |     802.27 |     66.86 
  6685652678514130264 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |     8 |     663.81 |     82.98 
 -2042386036926924530 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |    11 |     641.52 |     58.32 
 -7317417066892233920 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |     2 |     607.24 |    303.62 
  8481197096097106526 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |    11 |     586.92 |     53.36 
 -8191811440592170928 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |    18 |     526.29 |     29.24 
  7075618430461577918 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |     6 |     523.54 |     87.26 
  1670079897580642906 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |     2 |     508.58 |    254.29 
  7393096411707639184 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |     9 |     496.78 |     55.20 
[...]
```

## After
```
       queryid        |                                    query                                    | calls | total_time | mean_time  
----------------------+-----------------------------------------------------------------------------+-------+------------+-----------
  4754838127840822387 | SELECT "stock_move"."id" FROM "stock_move" WHERE (("stock_move"."product_id |     1 |     598.69 |    598.69 
   458237201385243853 | SELECT "stock_quant"."product_id", COUNT(*), SUM("stock_quant"."quantity")  |     1 |      39.05 |     39.05 
```

The job itself switched from an average time of 10-13s to ~150ms.