### PR TITLE
[18.0][FIX] stock_picking_batch_creation: Imp first picking slection

### DIFF
--- a/stock_picking_batch_creation/tests/test_batch_creation_splitting.py
+++ b/stock_picking_batch_creation/tests/test_batch_creation_splitting.py
@@ -1,0 +1,90 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from .common import ClusterPickingCommonFeatures
+
+
+class TestBatchCreationSplitting(ClusterPickingCommonFeatures):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_batch_creation_one_pick_move_over_the_limit(self):
+        """Test splitting a picking when the first move exceed the weight limit."""
+        self.pick2.action_cancel()
+        self.pick3.action_cancel()
+        # Keep the picking 1 with one line and product 1
+        move = self.pick1.move_ids
+        # And the weight of the move can not be accepted by the device
+        max_weight = 9
+        move_weight = move.product_id.weight * move.product_qty
+        self.assertTrue(move_weight > max_weight)
+        self.make_picking_batch.write(
+            {
+                "maximum_number_of_preparation_lines": 2,
+                "split_picking_exceeding_limits": True,
+            }
+        )
+        device = self._create_device(
+            "Device-A",
+            min_volume=0,
+            max_volume=0,
+            max_weight=max_weight,
+            nbr_bins=6,
+            sequence=1,
+        )
+        self.make_picking_batch.stock_device_type_ids = device
+        batch = self.make_picking_batch._create_batch()
+        # There is no batch because the only picking could not be split
+        self.assertFalse(batch)
+
+    def test_batch_creation_move_over_the_limit_take_2nd_picking(self):
+        """Test splitting a picking when the first move exceed the weight limit."""
+        self.pick3.action_cancel()
+        # Keep the picking 1 with one line and product 1
+        move = self.pick1.move_ids
+        # And the weight of the move can not be accepted by the device
+        max_weight = 9
+        move_weight = move.product_id.weight * move.product_qty
+        self.assertTrue(move_weight > max_weight)
+        # Get the picking to fit the limit
+        self.pick2.move_ids.product_id.weight = 0.2
+        # Force recomputation after changing the product weight
+        self.pick2.move_ids._cal_move_weight()
+        self.make_picking_batch.write(
+            {
+                "maximum_number_of_preparation_lines": 2,
+                "split_picking_exceeding_limits": True,
+            }
+        )
+        device = self._create_device(
+            "Device-A",
+            min_volume=0,
+            max_volume=0,
+            max_weight=max_weight,
+            nbr_bins=6,
+            sequence=1,
+        )
+        self.make_picking_batch.stock_device_type_ids = device
+        batch = self.make_picking_batch._create_batch()
+        self.assertTrue(batch, "We should have a batch")
+        self.assertTrue(self.pick2 in batch.picking_ids)
+        self.assertTrue(batch.picking_ids, "We should have a picking in the batch")
+
+    def test_batch_creation_splitting_by_number_of_lines(self):
+        """Test splitting a picking when the number of lines exceed the limit."""
+        self.pick1.action_cancel()
+        self.pick2.action_cancel()
+        # Keep the picking 3
+        self._add_product_to_picking(self.pick3, self.p3)
+        self._add_product_to_picking(self.pick3, self.p4)
+        # And now it has 4 lines
+        self.make_picking_batch.write({"maximum_number_of_preparation_lines": 2})
+        self.make_picking_batch.write({"split_picking_exceeding_limits": True})
+        device = self._create_device("Test", 0.0, 0.0, 0.0, 20, 1)
+        self.make_picking_batch.stock_device_type_ids = device
+        batch = self.make_picking_batch._create_batch()
+        self.assertFalse(self.pick3 in batch.picking_ids)
+        self.assertTrue(batch, "We should have a batch")
+        self.assertTrue(batch.picking_ids, "We should have a picking in the batch")
+        self.assertEqual(len(batch.picking_ids.move_line_ids), 2)

--- a/stock_picking_batch_creation/wizards/make_picking_batch.py
+++ b/stock_picking_batch_creation/wizards/make_picking_batch.py
@@ -1,6 +1,7 @@
 # Copyright 2021 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
 import math
 import threading
 from collections import defaultdict
@@ -14,6 +15,8 @@ from ..exceptions import (
     PickingCandidateNumberLineExceedError,
     PickingSplitNotPossibleError,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 class MakePickingBatch(models.TransientModel):
@@ -316,23 +319,32 @@ class MakePickingBatch(models.TransientModel):
             for device in self.stock_device_type_ids:
                 device_domains.append(self._get_picking_domain_for_device(device))
             domain = AND([domain, OR(device_domains)])
-        picking = self._execute_search_pickings(domain, limit=1)
-        if not picking and not no_limit and raise_if_not_found:
-            self._raise_create_batch_not_possible()
+            picking = self._execute_search_pickings(domain, limit=1)
+            if not picking and raise_if_not_found:
+                self._raise_create_batch_not_possible()
+            return picking
+        pickings = self._execute_search_pickings(domain)
         # at this stage we have the first picking to add to the batch but it could
         # exceed the limits of the available devices. In this case we split the
         # picking and return the picking to add to the batch. The split is done only
         # if the split_picking_exceeding_limits is set to True.
-        if (
-            picking
-            and self.split_picking_exceeding_limits
-            and self._is_picking_exceeding_limits(picking)
-        ):
-            split_picking = self._split_first_picking_for_limit(picking)
-            if not split_picking and raise_if_not_found:
-                raise PickingSplitNotPossibleError(picking)
-            picking = split_picking
-        return picking
+        selected_picking = self.env["stock.picking"]
+        for picking in pickings:
+            if self._is_picking_exceeding_limits(picking):
+                split_picking = self._split_first_picking_for_limit(picking)
+                if not split_picking:
+                    if raise_if_not_found:
+                        raise PickingSplitNotPossibleError(picking)
+                    _logger.warning(
+                        f"The picking {picking.name} could not be split "
+                        "for batch creation."
+                    )
+                    continue
+                selected_picking = split_picking
+            else:
+                selected_picking = picking
+            break
+        return selected_picking
 
     def _get_additional_picking(self):
         """Get the next picking to add to the batch."""


### PR DESCRIPTION
When trying to create a batch picking only with the first availale transfer, there could be some occurence where that picking does not fit the dimension of the device and can not be split.

This can happen when all moves from the transfer are oversize compare to the dimension of the device.

After this change, the module will use the next transfer to create a batch until it is successfull.