### PR TITLE
[18.0][FW] stock_picking_auto_create_lot: features a fixes from 16.0

### DIFF
--- a/stock_picking_auto_create_lot/README.rst
+++ b/stock_picking_auto_create_lot/README.rst
@@ -88,6 +88,8 @@ Contributors
 
   - Aung Ko Ko Lin
 
+- Eduardo de Miguel <info@moduon.team>
+
 Maintainers
 -----------
 

--- a/stock_picking_auto_create_lot/README.rst
+++ b/stock_picking_auto_create_lot/README.rst
@@ -46,6 +46,30 @@ To configure this module, you need to:
 3. Go to a *Inventory > Master Data > Products*.
 4. Set 'auto create lot' option for the products you need.
 
+It's possible to configure by code a way to force the setting of the
+auto lot when printing the detailed operation labels. To do so, pass the
+context key ``force_auto_lot`` to the report. This is a simple example
+with a server action, but it can be done with overriding methods as
+well:
+
+.. code:: xml
+
+        <record id="action_print_detailed_operation" model="ir.actions.server">
+             <field name="name">Print detailed operations</field>
+             <field name="model_id" ref="stock.model_stock_move_line" />
+             <field
+                   name="binding_model_id"
+                   ref="stock.model_stock_move_line"
+             />
+             <field name="binding_view_types">list</field>
+             <field name="state">code</field>
+             <field name="code">
+        if records:
+             report = env["ir.actions.report"].sudo()._get_report("my_custom_module.my_custom_report_xml_id")
+             action = report.with_context(force_auto_lot=True).report_action(records.ids)
+             </field>
+        </record>
+
 Usage
 =====
 

--- a/stock_picking_auto_create_lot/__manifest__.py
+++ b/stock_picking_auto_create_lot/__manifest__.py
@@ -12,6 +12,10 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["stock"],
-    "data": ["views/product_views.xml", "views/stock_picking_type_views.xml"],
+    "data": [
+        "views/product_views.xml",
+        "views/product_category_views.xml",
+        "views/stock_picking_type_views.xml",
+    ],
     "maintainers": ["sergio-teruel"],
 }

--- a/stock_picking_auto_create_lot/models/__init__.py
+++ b/stock_picking_auto_create_lot/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import ir_actions_report
 from . import product
 from . import product_category
 from . import stock_picking

--- a/stock_picking_auto_create_lot/models/__init__.py
+++ b/stock_picking_auto_create_lot/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import product
+from . import product_category
 from . import stock_picking
 from . import stock_picking_type
 from . import stock_move

--- a/stock_picking_auto_create_lot/models/ir_actions_report.py
+++ b/stock_picking_auto_create_lot/models/ir_actions_report.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Moduon Team
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class IrActionReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def report_action(self, docids, data=None, config=True):
+        # Catch a context to force lot creation on print so it can be used in different
+        # scenarios without the need of defining glue modules.
+        if self.env.context.get("force_auto_lot") and self.model == "stock.move.line":
+            move_lines = (
+                self.env["stock.move.line"]
+                .browse(docids)
+                .filtered(
+                    lambda x: (
+                        not x.lot_id
+                        and not x.lot_name
+                        and x.product_id.tracking != "none"
+                        and (
+                            x.product_id.auto_create_lot
+                            or x.product_id.categ_id.auto_create_lot
+                        )
+                    )
+                )
+            )
+            if move_lines:
+                for line in move_lines:
+                    line.lot_name = line._get_lot_sequence()
+                move_lines.with_context(
+                    bypass_reservation_update=True
+                )._create_and_assign_production_lot()
+        return super().report_action(docids, data, config)

--- a/stock_picking_auto_create_lot/models/product_category.py
+++ b/stock_picking_auto_create_lot/models/product_category.py
@@ -1,0 +1,9 @@
+# Copyright 2025 Moduon Team
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ProductCategory(models.Model):
+    _inherit = "product.category"
+
+    auto_create_lot = fields.Boolean()

--- a/stock_picking_auto_create_lot/models/stock_move.py
+++ b/stock_picking_auto_create_lot/models/stock_move.py
@@ -16,7 +16,8 @@ class StockMove(models.Model):
     def _compute_display_assign_serial(self):
         super()._compute_display_assign_serial()
         moves_not_display = self.filtered(
-            lambda m: m.picking_type_id.auto_create_lot and m.product_id.auto_create_lot
+            lambda m: m.picking_type_id.auto_create_lot
+            and (m.product_id.auto_create_lot or m.product_id.categ_id.auto_create_lot)
         )
         for move in moves_not_display:
             move.display_assign_serial = False
@@ -30,7 +31,10 @@ class StockMove(models.Model):
                 continue
             if (
                 move.product_id.tracking == "none"
-                or not move.product_id.auto_create_lot
+                or not (
+                    move.product_id.auto_create_lot
+                    or move.product_id.categ_id.auto_create_lot
+                )
                 or not move.picking_type_id.auto_create_lot
             ):
                 continue

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -17,7 +17,10 @@ class StockPicking(models.Model):
                 not x.lot_id
                 and not x.lot_name
                 and x.product_id.tracking != "none"
-                and x.product_id.auto_create_lot
+                and (
+                    x.product_id.auto_create_lot
+                    or x.product_id.categ_id.auto_create_lot
+                )
             )
         )
         for line in lines:

--- a/stock_picking_auto_create_lot/readme/CONFIGURE.md
+++ b/stock_picking_auto_create_lot/readme/CONFIGURE.md
@@ -4,3 +4,26 @@ To configure this module, you need to:
 2.  Set 'auto create lot' option for this operation type.
 3.  Go to a *Inventory \> Master Data \> Products*.
 4.  Set 'auto create lot' option for the products you need.
+
+
+It's possible to configure by code a way to force the setting of the auto lot when
+printing the detailed operation labels. To do so, pass the context key `force_auto_lot`
+to the report. This is a simple example with a server action, but it can be done with
+overriding methods as well:
+
+```xml
+     <record id="action_print_detailed_operation" model="ir.actions.server">
+          <field name="name">Print detailed operations</field>
+          <field name="model_id" ref="stock.model_stock_move_line" />
+          <field
+                name="binding_model_id"
+                ref="stock.model_stock_move_line"
+          />
+          <field name="binding_view_types">list</field>
+          <field name="state">code</field>
+          <field name="code">
+     if records:
+          report = env["ir.actions.report"].sudo()._get_report("my_custom_module.my_custom_report_xml_id")
+          action = report.with_context(force_auto_lot=True).report_action(records.ids)
+          </field>
+     </record>

--- a/stock_picking_auto_create_lot/readme/CONTRIBUTORS.md
+++ b/stock_picking_auto_create_lot/readme/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - Valentin Vinagre \<<valentin.vinagre@sygel.es>\>
 - [Quartile](https://www.quartile.co):
   - Aung Ko Ko Lin
+- Eduardo de Miguel \<<info@moduon.team>\>

--- a/stock_picking_auto_create_lot/static/description/index.html
+++ b/stock_picking_auto_create_lot/static/description/index.html
@@ -395,6 +395,28 @@ create lots for incoming pickings.</p>
 <li>Go to a <em>Inventory &gt; Master Data &gt; Products</em>.</li>
 <li>Set ‘auto create lot’ option for the products you need.</li>
 </ol>
+<p>It’s possible to configure by code a way to force the setting of the
+auto lot when printing the detailed operation labels. To do so, pass the
+context key <tt class="docutils literal">force_auto_lot</tt> to the report. This is a simple example
+with a server action, but it can be done with overriding methods as
+well:</p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;record</span><span class="w"> </span><span class="na">id=</span><span class="s">&quot;action_print_detailed_operation&quot;</span><span class="w"> </span><span class="na">model=</span><span class="s">&quot;ir.actions.server&quot;</span><span class="nt">&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;name&quot;</span><span class="nt">&gt;</span>Print<span class="w"> </span>detailed<span class="w"> </span>operations<span class="nt">&lt;/field&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;model_id&quot;</span><span class="w"> </span><span class="na">ref=</span><span class="s">&quot;stock.model_stock_move_line&quot;</span><span class="w"> </span><span class="nt">/&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w">
+           </span><span class="na">name=</span><span class="s">&quot;binding_model_id&quot;</span><span class="w">
+           </span><span class="na">ref=</span><span class="s">&quot;stock.model_stock_move_line&quot;</span><span class="w">
+     </span><span class="nt">/&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;binding_view_types&quot;</span><span class="nt">&gt;</span>list<span class="nt">&lt;/field&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;state&quot;</span><span class="nt">&gt;</span>code<span class="nt">&lt;/field&gt;</span><span class="w">
+     </span><span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;code&quot;</span><span class="nt">&gt;</span><span class="w">
+</span>if<span class="w"> </span>records:<span class="w">
+     </span>report<span class="w"> </span>=<span class="w"> </span>env[&quot;ir.actions.report&quot;].sudo()._get_report(&quot;my_custom_module.my_custom_report_xml_id&quot;)<span class="w">
+     </span>action<span class="w"> </span>=<span class="w"> </span>report.with_context(force_auto_lot=True).report_action(records.ids)<span class="w">
+     </span><span class="nt">&lt;/field&gt;</span><span class="w">
+</span><span class="nt">&lt;/record&gt;</span>
+</pre>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>

--- a/stock_picking_auto_create_lot/static/description/index.html
+++ b/stock_picking_auto_create_lot/static/description/index.html
@@ -436,6 +436,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Aung Ko Ko Lin</li>
 </ul>
 </li>
+<li>Eduardo de Miguel &lt;<a class="reference external" href="mailto:info&#64;moduon.team">info&#64;moduon.team</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_picking_auto_create_lot/tests/common.py
+++ b/stock_picking_auto_create_lot/tests/common.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # Copyright 2020 ACSONE SA/NV
+# Copyright 2025 Moduon Team
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 
@@ -20,6 +21,9 @@ class CommonStockPickingAutoCreateLot:
         cls.picking_type_in = cls.env.ref("stock.picking_type_in")
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
         cls.supplier = cls.env["res.partner"].create({"name": "Supplier - test"})
+        cls.auto_lot_category = cls.env["product.category"].create(
+            {"name": "Test Auto Lot Category", "auto_create_lot": True}
+        )
 
     @classmethod
     def _create_product(cls, tracking="lot", auto=True):

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # Copyright 2020 ACSONE SA/NV
+# Copyright 2025 Moduon Team
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.exceptions import UserError
 from odoo.tests import TransactionCase
@@ -13,14 +14,19 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
         super().setUpClass()
         # Create 3 products with lot/serial and auto_create True/False
         cls.product = cls._create_product()
-        cls.product_serial = cls._create_product(tracking="serial")
+        cls.product_serial = cls._create_product(tracking="serial", auto=True)
         cls.product_serial_not_auto = cls._create_product(tracking="serial", auto=False)
+        cls.product_serial_categ_auto = cls._create_product(
+            tracking="serial", auto=False
+        )
+        cls.product_serial_categ_auto.categ_id = cls.auto_lot_category
         cls.picking_type_in.auto_create_lot = True
 
         cls._create_picking()
         cls._create_move(product=cls.product, qty=2.0)
         cls._create_move(product=cls.product_serial, qty=3.0)
         cls._create_move(product=cls.product_serial_not_auto, qty=4.0)
+        cls._create_move(product=cls.product_serial_categ_auto, qty=5.0)
 
     def test_manual_lot(self):
         self.picking.action_assign()
@@ -29,7 +35,10 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             lambda m: m.product_id == self.product_serial
         )
         self.assertFalse(move.display_assign_serial)
-
+        move = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_serial_categ_auto
+        )
+        self.assertFalse(move.display_assign_serial)
         move = self.picking.move_ids.filtered(
             lambda m: m.product_id == self.product_serial_not_auto
         )
@@ -45,6 +54,10 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             [("product_id", "=", self.product_serial.id)]
         )
         self.assertEqual(len(lot), 3)
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product_serial_categ_auto.id)]
+        )
+        self.assertEqual(len(lot), 5)
 
     def test_auto_create_lot(self):
         self.picking.action_assign()
@@ -53,7 +66,10 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             lambda m: m.product_id == self.product_serial
         )
         self.assertFalse(move.display_assign_serial)
-
+        move = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_serial_categ_auto
+        )
+        self.assertFalse(move.display_assign_serial)
         move = self.picking.move_ids.filtered(
             lambda m: m.product_id == self.product_serial_not_auto
         )
@@ -70,6 +86,10 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             [("product_id", "=", self.product_serial.id)]
         )
         self.assertEqual(len(lot), 3)
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product_serial_categ_auto.id)]
+        )
+        self.assertEqual(len(lot), 5)
 
     def test_auto_create_transfer_lot(self):
         self.picking.action_assign()
@@ -102,11 +122,23 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
             [("product_id", "=", self.product_serial.id)]
         )
         self.assertEqual(len(lot), 3)
+        lot = self.env["stock.lot"].search(
+            [("product_id", "=", self.product_serial_categ_auto.id)]
+        )
+        self.assertEqual(len(lot), 5)
 
         # Check if lots are unique per move and per product if managed
         # per serial
         move_lines_serial = self.picking.move_line_ids.filtered(
             lambda m: m.product_id.tracking == "serial" and m.product_id.auto_create_lot
+        )
+        serials = []
+        for move in move_lines_serial:
+            serials.append(move.lot_id.name)
+        self.assertUniqueIn(serials)
+        move_lines_serial = self.picking.move_line_ids.filtered(
+            lambda m: m.product_id.tracking == "serial"
+            and m.product_id.categ_id.auto_create_lot
         )
         serials = []
         for move in move_lines_serial:
@@ -129,7 +161,7 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
 
         moves = pickings.mapped("move_ids").filtered(
             lambda m: m.product_id == self.product_serial
-            and m.product_id.auto_create_lot
+            and (m.product_id.auto_create_lot or m.product_id.categ_id.auto_create_lot)
         )
         for line in moves.mapped("move_line_ids"):
             self.assertFalse(line.lot_name)

--- a/stock_picking_auto_create_lot/views/product_category_views.xml
+++ b/stock_picking_auto_create_lot/views/product_category_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Moduon Team
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_category_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.category.auto.lot.form</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="stock.product_category_form_view_inherit" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='logistics']" position="inside">
+                <field name="auto_create_lot" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_picking_auto_create_lot/views/product_views.xml
+++ b/stock_picking_auto_create_lot/views/product_views.xml
@@ -3,7 +3,7 @@
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="view_template_property_form" model="ir.ui.view">
-        <field name="name">Product template Secondary Unit</field>
+        <field name="name">product.template.stock.property.form.auto.lot.inherit</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">


### PR DESCRIPTION
(Same as in https://github.com/OCA/stock-logistics-workflow/pull/2182 but for 18.0)

Includes:

- [x] [[IMP] stock_picking_auto_create_lot: Auto Lot from Product Categories · OCA/stock-logistics-workflow@4ce51b9](https://github.com/OCA/stock-logistics-workflow/commit/4ce51b9f8f6133a6feaf631e2776bce5c705ddd8)
- [x] [[IMP] stock_picking_auto_create_lot: lot on print · OCA/stock-logistics-workflow@7365a49](https://github.com/OCA/stock-logistics-workflow/commit/7365a49b31b7a091c5b933e16451de0cc1063e52)

Not including due to incompatible approaches or need for more in depth forward port:

- https://github.com/OCA/stock-logistics-workflow/commit/7b1127d3b4b90ffbb5b0528dd78b068db52c34db @Shide : how do you want to deal with this one?

cc @moduon

MT-12761