### PR TITLE
[18.0][FIX] stock_dynamic_routing: do not trigger dynamic routing when splitting moves

### DIFF
--- a/stock_dynamic_routing/models/stock_move.py
+++ b/stock_dynamic_routing/models/stock_move.py
@@ -242,7 +242,9 @@ class StockMove(models.Model):
                     new_move_vals = move._split(qty)
                 if new_move_vals:
                     new_move = self.env["stock.move"].create(new_move_vals)
-                    new_move._action_confirm(merge=False)
+                    new_move.with_context(
+                        exclude_apply_dynamic_routing=True
+                    )._action_confirm(merge=False)
                 else:
                     # If no split occurred keep the current move
                     new_move = move
@@ -437,7 +439,9 @@ class StockMove(models.Model):
                     split_move_vals = move._split(qty)
                 if split_move_vals:
                     split_move = self.create(split_move_vals)
-                    split_move._action_confirm(merge=False)
+                    split_move.with_context(
+                        exclude_apply_dynamic_routing=True
+                    )._action_confirm(merge=False)
                 if split_move != move:
                     # No split occurs if the quantity was the same.
                     # But if it did split, detach it from the move on which
@@ -559,7 +563,9 @@ class StockMove(models.Model):
         )
         if dest_moves:
             dest_moves.write({"move_orig_ids": [(3, self.id), (4, routing_move.id)]})
-        routing_move._action_confirm(merge=False)
+        routing_move.with_context(exclude_apply_dynamic_routing=True)._action_confirm(
+            merge=False
+        )
         return routing_move
 
     def _prepare_routing_move_values(self, picking_type, source, destination):


### PR DESCRIPTION
Starting from Odoo 15.0, moves are automatically assigned at confirm if their operation types are configured to do so (reservation_method == at_confirm).

This has the side effect (compared to the 14.0 version of stock_dynamic_routing) of triggering the dynamic routing automatically, even if it's not needed, and splitting moves in cascade, as not all the moves have been re-qualified yet by the dynamic routing (it'll be only at the end of the process).

For example, 30 Units have to be shipped, and only 10 are available in location A. When confirming the SO, the system will first generate a PICK_INIT+OUT transfers. Each move of the PICK_INIT will then be requalified by the dynamic routing:

1) splitting 10 Units from 30, qualifying that move as PICK_NEW, the remaining 20 Units still being a PICK_INIT
2) in a 2nd round, the 20 Units will be qualified as PICK_NEW too.

Same for PACK (if any), and OUT if the PICK move had a routing rule that could trigger `_routing_pull_switch_source()' on its next moves.

The issue from Odoo 15.0 is raised when the OUT move is split & confirmed during step 1), while step 2) didn't run yet, splitting the OUT move while it is not expected.

This fix ensures such split & confirmed moves are not assigned automatically, to not trigger the dynamic routing feature too early, like in Odoo 14.0.

NOTE: I wasn't able to reproduce the issue in a test, I'm lacking of knowledge to configure properly the routing rules/picking types.