### PR TITLE
[18.0][FIX] stock_picking_send_by_mail: remove deprecated `view_type`

### DIFF
--- a/stock_picking_send_by_mail/models/stock_picking.py
+++ b/stock_picking_send_by_mail/models/stock_picking.py
@@ -26,7 +26,6 @@ class StockPicking(models.Model):
         return {
             "name": _("Compose Email"),
             "type": "ir.actions.act_window",
-            "view_type": "form",
             "view_mode": "form",
             "res_model": "mail.compose.message",
             "views": [(compose_form.id, "form")],


### PR DESCRIPTION
This PR removes the deprecated `view_type` attribute from the stock picking email compose action. Odoo automatically resolves view type based on `view_mode`, making `view_type` obsolete.

Keeping this field leads to warnings in Odoo logs:
> Action 'Compose Email' contains custom properties 'view_type'