### PR TITLE
[14.0][FIX] stock_return_request - fix report model

### DIFF
--- a/stock_return_request/report/stock_return_report.xml
+++ b/stock_return_request/report/stock_return_report.xml
@@ -128,7 +128,7 @@
 
     <record id="action_report_stock_return_request" model="ir.actions.report">
         <field name="name">Stock Return Request Report</field>
-        <field name="model">report.stock.card.report</field>
+        <field name="model">stock.return.request</field>
         <field name="report_type">qweb-pdf</field>
         <field
             name="report_name"


### PR DESCRIPTION
An incorrect model is referenced, which belongs to another addon that is not listed as a dependency (nor is it necessary)