### PR TITLE
[16.0][FIX] sale_stock_restocking_fee_invoicing: prevent KeyError on active_id

### DIFF
--- a/sale_stock_restocking_fee_invoicing/wizards/stock_return_picking.py
+++ b/sale_stock_restocking_fee_invoicing/wizards/stock_return_picking.py
@@ -24,6 +24,8 @@ class StockReturnPicking(models.TransientModel):
             or "is_customer_return" in fields
         ):
             return res
+        if "active_id" not in self.env.context:
+            return res
         picking = self.env["stock.picking"].browse(self.env.context["active_id"])
         charge_restocking_fee = picking.partner_id.charge_restocking_fee
         if "is_customer_return" in fields:


### PR DESCRIPTION
Ensure the 'active_id' key exists in the context before accessing it. When running unit tests from dependent modules, the context may not contain 'active_id', leading to a KeyError. This fix adds a safe check to handle these cases gracefully.