### PR TITLE
[14.0][FIX] stock_return_request - fix to allow return of serial numbers

### DIFF
--- a/stock_return_request/models/stock_return_request.py
+++ b/stock_return_request/models/stock_return_request.py
@@ -266,7 +266,7 @@ class StockReturnRequest(models.Model):
                     return_move = done_moves[move]
                     return_move.product_uom_qty += qty
                 done_moves.setdefault(move, self.env["stock.move"])
-                done_moves[move] += return_move
+                done_moves[move] |= return_move
                 return_move._action_confirm()
                 # We need to be deterministic with lots to avoid autoassign
                 # thus we create manually the line


### PR DESCRIPTION
To avoid an _expected singleton_ in the case where we are returning serial numbers sent in the same `stock.move`