### PR TITLE
[14.0][IMP] stock_owner_restriction: Various Backports from 18.0

### DIFF
--- a/stock_owner_restriction/models/product.py
+++ b/stock_owner_restriction/models/product.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Carlos Dauden - Tecnativa
 # Copyright 2020 Sergio Teruel - Tecnativa
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import models
+from odoo import api, models
 
 
 class ProductProduct(models.Model):
@@ -34,3 +34,11 @@ class ProductProduct(models.Model):
         return super(ProductProduct, new_self)._search_qty_available_new(
             operator, value, lot_id=lot_id, owner_id=owner_id, package_id=package_id
         )
+
+    @api.depends_context("force_restricted_owner_id")
+    def _compute_quantities(self):
+        # Add force_restricted_owner_id to depends_context to compute qty when this
+        # key change.
+        # For example, in a report you want to print all stock available from a product
+        # and stock available from one owner.
+        return super()._compute_quantities()

--- a/stock_owner_restriction/models/stock_move.py
+++ b/stock_owner_restriction/models/stock_move.py
@@ -16,7 +16,8 @@ class StockMove(models.Model):
         those moves.
         """
         return self.filtered(
-            lambda m: m.picking_type_id.owner_restriction == "standard_behavior"
+            lambda m: not m.picking_type_id
+            or m.picking_type_id.owner_restriction == "standard_behavior"
         )
 
     def _get_owner_for_assign(self):

--- a/stock_owner_restriction/models/stock_move.py
+++ b/stock_owner_restriction/models/stock_move.py
@@ -9,19 +9,38 @@ from odoo import models
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    def _action_assign(self):
-        # Split moves by picking type owner behavior restriction to process
-        # moves depending of their owners
-        moves = self.filtered(
+    def _get_moves_to_assign_with_standard_behavior(self):
+        """This method is expected to be extended as necessary. e.g. you may not want to
+        handle subcontracting receipts (whose picking type is normal incoming receipt
+        unless configured otherwise) with standard behavior, and you can filter out
+        those moves.
+        """
+        return self.filtered(
             lambda m: m.picking_type_id.owner_restriction == "standard_behavior"
         )
+
+    def _get_owner_for_assign(self):
+        """This method is expected to be extended as necessary. e.g. different logic
+        needs to be applied for moves in manufacturing orders.
+        """
+        self.ensure_one()
+        partner = self.move_dest_ids.picking_id.owner_id
+        if not partner:
+            partner = self.picking_id.owner_id or self.picking_id.partner_id
+        return partner
+
+    def _action_assign(self, force_qty=False):
+        # Split moves by picking type owner behavior restriction to process
+        # moves depending of their owners
+        moves = self._get_moves_to_assign_with_standard_behavior()
         super(StockMove, moves)._action_assign()
         dict_key = defaultdict(lambda: self.env["stock.move"])
         for move in self - moves:
             if move.picking_type_id.owner_restriction == "unassigned_owner":
                 dict_key[False] |= move
             else:
-                dict_key[move.picking_id.owner_id or move.picking_id.partner_id] |= move
+                partner = move._get_owner_for_assign()
+                dict_key[partner] |= move
         for owner_id, moves_to_assign in dict_key.items():
             super(
                 StockMove,

--- a/stock_owner_restriction/models/stock_move.py
+++ b/stock_owner_restriction/models/stock_move.py
@@ -4,6 +4,7 @@
 from collections import defaultdict
 
 from odoo import models
+from odoo.tools import groupby
 
 
 class StockMove(models.Model):
@@ -47,22 +48,26 @@ class StockMove(models.Model):
                 StockMove,
                 moves_to_assign.with_context(force_restricted_owner_id=owner_id),
             )._action_assign()
-            if (
-                owner_id
-                and moves_to_assign.picking_type_id.owner_restriction
-                == "partner_or_unassigned"
-                and sum(
-                    [
-                        move.reserved_availability - move.product_uom_qty
-                        for move in moves_to_assign
-                    ]
-                )
-                < 0
-            ):
-                super(
-                    StockMove,
-                    moves_to_assign.with_context(force_restricted_owner_id=False),
-                )._action_assign()
+            if not owner_id:
+                continue
+            moves_by_type = groupby(moves_to_assign, lambda move: move.picking_type_id)
+            for picking_type, moves_of_type in moves_by_type:
+                if picking_type.owner_restriction != "partner_or_unassigned":
+                    continue
+                moves_of_type = self.browse().union(*moves_of_type)
+                if (
+                    sum(
+                        [
+                            move.reserved_availability - move.product_uom_qty
+                            for move in moves_of_type
+                        ]
+                    )
+                    < 0
+                ):
+                    super(
+                        StockMove,
+                        moves_of_type.with_context(force_restricted_owner_id=False),
+                    )._action_assign()
 
     def _update_reserved_quantity(
         self,

--- a/stock_owner_restriction/models/stock_quant.py
+++ b/stock_owner_restriction/models/stock_quant.py
@@ -22,7 +22,9 @@ class StockQuant(models.Model):
             location_id,
             lot_id=lot_id,
             package_id=package_id,
-            owner_id=owner_id,
+            # Prevent a negative quant from being created with owner instead of reducing
+            # the original quant when a return is made by assigning owner
+            owner_id=owner_id if location_id.usage != "customer" else None,
             strict=strict,
         )
         restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)

--- a/stock_owner_restriction/models/stock_quant.py
+++ b/stock_owner_restriction/models/stock_quant.py
@@ -8,6 +8,14 @@ from odoo.osv import expression
 class StockQuant(models.Model):
     _inherit = "stock.quant"
 
+    @api.model
+    def _get_restriction_owner_id(self, location_id, owner_id):
+        """Hook to allow modify the owner of quants to gather.
+        By default prevent a negative quant from being created with owner instead of
+        reducing the original quant when a return is made by assigning owner.
+        """
+        return owner_id if location_id.usage != "customer" else None
+
     def _gather(
         self,
         product_id,
@@ -22,9 +30,7 @@ class StockQuant(models.Model):
             location_id,
             lot_id=lot_id,
             package_id=package_id,
-            # Prevent a negative quant from being created with owner instead of reducing
-            # the original quant when a return is made by assigning owner
-            owner_id=owner_id if location_id.usage != "customer" else None,
+            owner_id=self._get_restriction_owner_id(location_id, owner_id),
             strict=strict,
         )
         restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)

--- a/stock_owner_restriction/tests/test_stock_owner_restriction.py
+++ b/stock_owner_restriction/tests/test_stock_owner_restriction.py
@@ -67,9 +67,14 @@ class TestStockOwnerRestriction(SavepointCase):
         )
 
     def test_product_qty_available(self):
-        # Quants with owner assigned are not available
-        self.assertEqual(self.product.qty_available, 500.00)
-        self.product.invalidate_cache()
+        # No need invalidate the cache, force_restricted_owner_id key is added to
+        # context depends of product qty_available
+        self.assertEqual(
+            self.product.with_context(
+                force_restricted_owner_id=self.owner.id
+            ).qty_available,
+            500.00,
+        )
         self.assertEqual(
             self.product.with_context(skip_restricted_owner=True).qty_available, 1000.00
         )

--- a/stock_owner_restriction/tests/test_stock_owner_restriction.py
+++ b/stock_owner_restriction/tests/test_stock_owner_restriction.py
@@ -8,7 +8,16 @@ class TestStockOwnerRestriction(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        # Remove this variable in v16 and put instead:
+        # from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+        DISABLED_MAIL_CONTEXT = {
+            "tracking_disable": True,
+            "mail_create_nolog": True,
+            "mail_create_nosubscribe": True,
+            "mail_notrack": True,
+            "no_reset_password": True,
+        }
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         # models
         cls.picking_model = cls.env["stock.picking"]
         cls.move_model = cls.env["stock.move"]


### PR DESCRIPTION
This PR adds multiple backports and one fix, which can be forward ported to the newest version. 

Backported Commits:

- https://github.com/OCA/stock-logistics-workflow/commit/a6c30c1a338bf5b94b2408d2b3319bde205c458f (Only refactoring of stock.move)
- https://github.com/OCA/stock-logistics-workflow/commit/086f896baf008042050d69e697ee12cc3aa77b77
- https://github.com/OCA/stock-logistics-workflow/commit/4e20260c4b3e19d884d77bb1c844b4068ee856dd
- https://github.com/OCA/stock-logistics-workflow/commit/5a8c3c377f89923988058eedaad70372af5ea2b0
- https://github.com/OCA/stock-logistics-workflow/commit/34943fc4a714b196c8502a718f8ab4b449352b86
- https://github.com/OCA/stock-logistics-workflow/commit/c4a7435ab825aea74bbad8ab133ecf7675387340

The fix includes the grouping of moves by picking type of the same owner. 