### PR TITLE
[18.0][IMP] stock_move_line_qty_picked: coherent decimal accuracy

### DIFF
--- a/stock_move_line_qty_picked/models/stock_move.py
+++ b/stock_move_line_qty_picked/models/stock_move.py
@@ -8,7 +8,9 @@ from odoo.tools import float_compare
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    qty_picked = fields.Float(compute="_compute_qty_picked")
+    qty_picked = fields.Float(
+        compute="_compute_qty_picked", digits="Product Unit of Measure"
+    )
 
     @api.depends(
         "move_line_ids.picked",

--- a/stock_move_line_qty_picked/models/stock_move_line.py
+++ b/stock_move_line_qty_picked/models/stock_move_line.py
@@ -13,7 +13,9 @@ class StockMoveLine(models.Model):
         inverse="_inverse_picked",
         copy=False,
     )
-    qty_picked = fields.Float(inverse="_inverse_qty_picked", copy=False)
+    qty_picked = fields.Float(
+        inverse="_inverse_qty_picked", copy=False, digits="Product Unit of Measure"
+    )
 
     def _inverse_picked(self):
         if self.env.context.get("move_line_pick_qty"):


### PR DESCRIPTION
Use the same decimal accuracy as in the 'quantity' fields for each model.