### PR TITLE
[18.0][FIX] stock_move_source_relocate: Merge back split moves

### DIFF
--- a/stock_move_source_relocate/models/stock_move.py
+++ b/stock_move_source_relocate/models/stock_move.py
@@ -70,6 +70,7 @@ class StockMove(models.Model):
             # move on the specific relocation (for replenishment), so
             # update it's source location
             self.location_id = relocation.relocate_location_id
+            self._action_confirm(merge=True)
             return self
 
         missing_reserved_uom_quantity = self.product_uom_qty - qty_reserved
@@ -84,10 +85,11 @@ class StockMove(models.Model):
         # A part of the quantity could be reserved in the original
         # location, so keep this part in the move and split the rest
         # in a new move, where will take the goods in the relocation
-        new_move = self.create(self._split(need))
-        new_move._action_confirm(merge=False)
-        new_move.location_id = relocation.relocate_location_id
-        self._action_assign()
+        move_vals_list = self._split(need)
+        for move_vals in move_vals_list:
+            move_vals["location_id"] = relocation.relocate_location_id.id
+        new_move = self.create(move_vals_list)
+        new_move._action_confirm()
         return new_move
 
     def _after_apply_source_relocate_rule(self):

--- a/stock_move_source_relocate/models/stock_move.py
+++ b/stock_move_source_relocate/models/stock_move.py
@@ -89,8 +89,7 @@ class StockMove(models.Model):
         for move_vals in move_vals_list:
             move_vals["location_id"] = relocation.relocate_location_id.id
         new_move = self.create(move_vals_list)
-        new_move._action_confirm()
-        return new_move
+        return new_move._action_confirm()
 
     def _after_apply_source_relocate_rule(self):
         # Hook for stock_dynamic_routing

--- a/stock_move_source_relocate/tests/common.py
+++ b/stock_move_source_relocate/tests/common.py
@@ -38,7 +38,7 @@ class SourceRelocateCommon(common.TransactionCase):
             {"name": "Product2", "type": "consu", "is_storable": True}
         )
 
-    def _create_single_move(self, product, picking_type):
+    def _create_single_move(self, product, picking_type, custom_vals=None):
         move_vals = {
             "name": product.name,
             "picking_type_id": picking_type.id,
@@ -47,10 +47,13 @@ class SourceRelocateCommon(common.TransactionCase):
             "product_uom": product.uom_id.id,
             "location_id": picking_type.default_location_src_id.id,
             "location_dest_id": picking_type.default_location_dest_id.id,
-            "state": "confirmed",
             "procure_method": "make_to_stock",
         }
-        return self.env["stock.move"].create(move_vals)
+        if custom_vals:
+            move_vals.update(custom_vals)
+        move = self.env["stock.move"].create(move_vals)
+        move._action_confirm()
+        return move
 
     def _create_relocate_rule(self, location, relocation, picking_type, domain=None):
         self.env["stock.source.relocate"].create(

--- a/stock_move_source_relocate/tests/test_source_relocate.py
+++ b/stock_move_source_relocate/tests/test_source_relocate.py
@@ -52,9 +52,7 @@ class TestSourceRelocate(SourceRelocateCommon):
         )
         self._update_qty_in_location(self.loc_shelf_1, self.product, 3)
         move = self._create_single_move(self.product, self.wh.pick_type_id)
-        move._assign_picking()
-        move._action_assign()
-
+        # Move is split after partial assignation
         self.assertRecordValues(
             move,
             [
@@ -78,6 +76,42 @@ class TestSourceRelocate(SourceRelocateCommon):
                 }
             ],
         )
+        # Remove stock must remove the reservation and merge back the moves together
+        inventory_quant = (
+            self.env["stock.quant"].sudo()._gather(self.product, self.loc_shelf_1)
+        )
+        inventory_quant.inventory_quantity = 0
+        inventory_quant.action_apply_inventory()
+        self.assertEqual(len((move | new_move).exists()), 1)
+
+    def test_relocate_partial_merge_new_move(self):
+        self._create_relocate_rule(
+            self.wh.lot_stock_id, self.loc_replenish, self.wh.pick_type_id
+        )
+        self._update_qty_in_location(self.loc_shelf_1, self.product, 5)
+        group = self.env["procurement.group"].create({"name": "Test merge"})
+
+        replenish_move = self._create_single_move(
+            self.product,
+            self.wh.pick_type_id,
+            custom_vals={
+                "location_id": self.loc_replenish.id,
+                "group_id": group.id,
+            },
+        )
+        pick_move = self._create_single_move(
+            self.product,
+            self.wh.pick_type_id,
+            custom_vals={
+                "group_id": group.id,
+                "picking_id": replenish_move.picking_id.id,
+            },
+        )
+
+        self.assertEqual(pick_move.state, "assigned")
+        self.assertEqual(pick_move.product_uom_qty, 5)
+        self.assertEqual(replenish_move.state, "confirmed")
+        self.assertEqual(replenish_move.product_uom_qty, 15)
 
     def test_relocate_ignore_available(self):
         self._create_relocate_rule(

--- a/stock_move_source_relocate_dynamic_routing/tests/test_dynamic_destination.py
+++ b/stock_move_source_relocate_dynamic_routing/tests/test_dynamic_destination.py
@@ -74,7 +74,7 @@ class TestRoutingAndSourceRelocate(TestRoutingPullCommon):
             self.env["stock.picking"]
             .search([("picking_type_id", "=", self.pick_type_routing_op.id)])
             .move_ids
-        )[0]
+        ) - move_a
         self.assertRecordValues(
             move_a | move_b | move_c,
             [
@@ -214,7 +214,7 @@ class TestRoutingAndSourceRelocate(TestRoutingPullCommon):
             self.env["stock.picking"]
             .search([("picking_type_id", "=", self.pick_type_routing_op.id)])
             .move_ids
-        )[0]
+        ) - move_a
         self.assertRecordValues(
             move_a | move_b | move_c | move_d,
             [


### PR DESCRIPTION
In case a move was split by the relocation rule, and the move that was reserved gets unreserved we were ending up with two different moves, on the same location (relocated) although it does not make sense to keep both move split, as we want to merge back the moves together.