### PR TITLE
[18.0][FIX] stock_picking_batch_creation: splitting

### DIFF
--- a/stock_picking_batch_creation/tests/test_batch_creation_splitting.py
+++ b/stock_picking_batch_creation/tests/test_batch_creation_splitting.py
@@ -1,4 +1,5 @@
 # Copyright 2025 Camptocamp SA
+# Copyright 2026 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from .common import ClusterPickingCommonFeatures
@@ -10,7 +11,7 @@ class TestBatchCreationSplitting(ClusterPickingCommonFeatures):
         super().setUpClass()
 
     def test_batch_creation_one_pick_move_over_the_limit(self):
-        """Test splitting a picking when the first move exceed the weight limit."""
+        """Test splitting a picking when the first move exceeds a limit."""
         self.pick2.action_cancel()
         self.pick3.action_cancel()
         # Keep the picking 1 with one line and product 1
@@ -35,11 +36,10 @@ class TestBatchCreationSplitting(ClusterPickingCommonFeatures):
         )
         self.make_picking_batch.stock_device_type_ids = device
         batch = self.make_picking_batch._create_batch()
-        # There is no batch because the only picking could not be split
-        self.assertFalse(batch)
+        self.assertTrue(batch, "There should always be a batch")
 
     def test_batch_creation_move_over_the_limit_take_2nd_picking(self):
-        """Test splitting a picking when the first move exceed the weight limit."""
+        """Splitting is disabled, the first picking exceeding a limit is excluded."""
         self.pick3.action_cancel()
         # Keep the picking 1 with one line and product 1
         move = self.pick1.move_ids
@@ -54,7 +54,7 @@ class TestBatchCreationSplitting(ClusterPickingCommonFeatures):
         self.make_picking_batch.write(
             {
                 "maximum_number_of_preparation_lines": 2,
-                "split_picking_exceeding_limits": True,
+                "split_picking_exceeding_limits": False,
             }
         )
         device = self._create_device(

--- a/stock_picking_batch_creation/wizards/make_picking_batch.py
+++ b/stock_picking_batch_creation/wizards/make_picking_batch.py
@@ -14,7 +14,6 @@ from ..exceptions import (
     NoPickingCandidateError,
     NoSuitableDeviceError,
     PickingCandidateNumberLineExceedError,
-    PickingSplitNotPossibleError,
 )
 
 _logger = logging.getLogger(__name__)
@@ -337,14 +336,10 @@ class MakePickingBatch(models.TransientModel):
             if self._is_picking_exceeding_limits(picking):
                 split_picking = self._split_first_picking_for_limit(picking)
                 if not split_picking:
-                    if raise_if_not_found:
-                        raise PickingSplitNotPossibleError(picking)
-                    _logger.debug(
-                        f"The picking {picking.name} could not be split "
-                        "for batch creation."
-                    )
-                    continue
-                selected_picking = split_picking
+                    # If the picking has only one move, it won't be split
+                    selected_picking = picking
+                else:
+                    selected_picking = split_picking
             else:
                 selected_picking = picking
             break
@@ -444,9 +439,11 @@ class MakePickingBatch(models.TransientModel):
             return self.env["stock.picking.batch"].browse()
         device = self._compute_device_to_use(first_picking)
         if not device:
-            if raise_if_not_possible:
-                raise NoSuitableDeviceError(pickings=first_picking)
-            return self.env["stock.picking.batch"].browse()
+            # A picking has been elected. If no device is suitable, use the
+            # last device. This can happen when the picking still exceeds the
+            # limits. Then the best device to use is the last done (that should
+            # be the biggest one).
+            device = self._get_sorted_devices()[-1]
         self._init_counters(first_picking, device)
         self._apply_limits()
         vals = self._create_batch_values()


### PR DESCRIPTION
1/ When splitting is enabled, an over limit picking can be elected as first picking. In that case, the last device should be used.
When this occurred, no batch could ever be created as the first picking to process was elected but no suitable device was returned.

2/ An over limit picking must be excluded only when splitting is disabled.
If the splitting is enabled, the over limit picking will be split and elected

3/  When a trying to split a picking with a single move, there will be no split order as there is only one move. In this case, the picking must be used.


cc @TDu @mmequignon @lmignon @phschmidt 