### PR TITLE
[FIX] product_customerinfo_picking: support variant-level customer info

### DIFF
--- a/product_customerinfo_picking/models/stock_move.py
+++ b/product_customerinfo_picking/models/stock_move.py
@@ -6,6 +6,13 @@ from odoo import api, fields, models
 class StockMove(models.Model):
     _inherit = "stock.move"
 
+    product_customer_code = fields.Char(
+        compute="_compute_product_customer_code",
+    )
+    product_customer_name = fields.Char(
+        compute="_compute_product_customer_code",
+    )
+
     @api.depends(
         "picking_id.partner_id",
         "product_id",
@@ -19,21 +26,24 @@ class StockMove(models.Model):
             if (
                 move.picking_id
                 and move.picking_id.partner_id
-                and move.product_tmpl_id.customer_ids
+                and move.product_id.customer_ids
             ):
-                customer = fields.first(
-                    move.product_tmpl_id.customer_ids.filtered(
-                        lambda m, mo=move: m.partner_id == mo.picking_id.partner_id
-                    )
+                customer_info_ids = move.product_tmpl_id.customer_ids.filtered(
+                    lambda m, mo=move: m.partner_id == mo.picking_id.partner_id
+                    and m.product_tmpl_id == mo.product_tmpl_id
                 )
-                product_customer_code = customer.product_code
-                product_customer_name = customer.product_name
+                for customer_info_id in customer_info_ids:
+                    product_customer_code = customer_info_id.product_code
+                    product_customer_name = customer_info_id.product_name
+                    break
+                customer_ids = move.product_id.variant_customer_ids.filtered(
+                    lambda m, mo=move: m.partner_id == mo.picking_id.partner_id
+                    and m.product_id == mo.product_id
+                )
+                for customer_id in customer_ids:
+                    if customer_id.partner_id == move.picking_id.partner_id:
+                        product_customer_code = customer_id.product_code
+                        product_customer_name = customer_id.product_name
+                        break
             move.product_customer_code = product_customer_code
             move.product_customer_name = product_customer_name
-
-    product_customer_code = fields.Char(
-        compute="_compute_product_customer_code",
-    )
-    product_customer_name = fields.Char(
-        compute="_compute_product_customer_code",
-    )

--- a/product_customerinfo_picking/tests/test_product_customerinfo_picking.py
+++ b/product_customerinfo_picking/tests/test_product_customerinfo_picking.py
@@ -35,6 +35,87 @@ class TestProductCustomerinfoPicking(TransactionCase):
                 ],
             }
         )
+        # Product with two variants for variant-specific customerinfo tests
+        cls.attr = cls.env["product.attribute"].create({"name": "Size"})
+        cls.val_s = cls.env["product.attribute.value"].create(
+            {"attribute_id": cls.attr.id, "name": "S"}
+        )
+        cls.val_m = cls.env["product.attribute.value"].create(
+            {"attribute_id": cls.attr.id, "name": "M"}
+        )
+        cls.variant_tmpl = cls.env["product.template"].create(
+            {
+                "name": "Test Variant T-Shirt",
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": cls.attr.id,
+                            "value_ids": [(6, 0, [cls.val_s.id, cls.val_m.id])],
+                        },
+                    )
+                ],
+            }
+        )
+        cls.variant_s = cls.variant_tmpl.product_variant_ids.filtered(
+            lambda p: cls.val_s
+            in p.product_template_attribute_value_ids.product_attribute_value_id
+        )
+        cls.variant_m = cls.variant_tmpl.product_variant_ids.filtered(
+            lambda p: cls.val_m
+            in p.product_template_attribute_value_ids.product_attribute_value_id
+        )
+        # Template-level customerinfo (applies to all variants as fallback)
+        cls.variant_tmpl.write(
+            {
+                "customer_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "partner_id": cls.agrolait.id,
+                            "product_code": "TMPL_AGROLAIT",
+                            "product_name": "T-Shirt (Template)",
+                        },
+                    )
+                ]
+            }
+        )
+        # Variant-specific customerinfo (only for variant_s + agrolait)
+        cls.env["product.customerinfo"].create(
+            {
+                "product_tmpl_id": cls.variant_tmpl.id,
+                "product_id": cls.variant_s.id,
+                "partner_id": cls.agrolait.id,
+                "product_code": "VAR_S_AGROLAIT",
+                "product_name": "T-Shirt S (Variant)",
+            }
+        )
+
+    def _create_delivery(self, partner, product):
+        return self.env["stock.picking"].create(
+            {
+                "partner_id": partner.id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "location_id": self.src_location.id,
+                "location_dest_id": self.dest_location.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.partner_ref,
+                            "product_id": product.id,
+                            "product_uom": product.uom_id.id,
+                            "product_uom_qty": 1.0,
+                            "location_id": self.src_location.id,
+                            "location_dest_id": self.dest_location.id,
+                        },
+                    )
+                ],
+            }
+        )
 
     def test_product_customerinfo_picking(self):
         delivery_picking = self.env["stock.picking"].new(
@@ -103,3 +184,30 @@ class TestProductCustomerinfoPicking(TransactionCase):
         move = delivery_picking.move_ids[0]
         move._compute_product_customer_code()
         self.assertEqual(move.product_customer_code, "test_gemini")
+
+    def test_variant_fallback_to_template(self):
+        """variant_m has no variant-specific entry → template-level code is used."""
+        picking = self._create_delivery(self.agrolait, self.variant_m)
+        move = picking.move_ids[0]
+        move._compute_product_customer_code()
+        self.assertEqual(move.product_customer_code, "TMPL_AGROLAIT")
+        self.assertEqual(move.product_customer_name, "T-Shirt (Template)")
+
+    def test_variant_specific_overrides_template(self):
+        """
+        variant_s has a variant-specific entry
+        → it overrides the template-level code.
+        """
+        picking = self._create_delivery(self.agrolait, self.variant_s)
+        move = picking.move_ids[0]
+        move._compute_product_customer_code()
+        self.assertEqual(move.product_customer_code, "VAR_S_AGROLAIT")
+        self.assertEqual(move.product_customer_name, "T-Shirt S (Variant)")
+
+    def test_variant_no_customerinfo_for_other_partner(self):
+        """No customerinfo for gemini on variant product → code and name stay empty."""
+        picking = self._create_delivery(self.gemini, self.variant_s)
+        move = picking.move_ids[0]
+        move._compute_product_customer_code()
+        self.assertFalse(move.product_customer_code)
+        self.assertFalse(move.product_customer_name)


### PR DESCRIPTION
## Problem

The `_compute_product_customer_code` method on `stock.move` only looked up
customer info at the **product template** level (`product_tmpl_id.customer_ids`).
It ignored `product.customerinfo` records linked to a specific **product variant**
(`variant_customer_ids`), so the customer reference/name was never filled for
variant-specific entries.

Additionally, the guard condition checked `product_tmpl_id.customer_ids` while
the `@api.depends` tracked `product_id.customer_ids`, causing a mismatch.

## Fix

- Guard condition: check `product_id.customer_ids` (consistent with `@api.depends`)
- Template-level lookup: add `product_tmpl_id` filter to avoid cross-template matches
- Variant-level lookup: after the template-level result, look up
  `variant_customer_ids` filtered by partner **and** product variant; if found,
  override the template-level values so variant-specific info takes precedence

## Test scenario

1. Create a product with variants (e.g. colour A, colour B)
2. Add a customer reference on the template level and a different one on a
   specific variant
3. Create a delivery order for that variant
4. Verify the stock move shows the **variant-level** customer reference,
   not the template-level one

🤖 Generated with [Claude Code](https://claude.com/claude-code)