### PR TITLE
[18.0][FIX] stock_move_source_relocate: action_confirm

### DIFF
--- a/stock_move_source_relocate/models/stock_move.py
+++ b/stock_move_source_relocate/models/stock_move.py
@@ -70,7 +70,7 @@ class StockMove(models.Model):
             # move on the specific relocation (for replenishment), so
             # update it's source location
             self.location_id = relocation.relocate_location_id
-            self._action_confirm(merge=True)
+            # Do not call _action_confirm on a split moves inside _action_assign
             return self
 
         missing_reserved_uom_quantity = self.product_uom_qty - qty_reserved
@@ -88,9 +88,17 @@ class StockMove(models.Model):
         move_vals_list = self._split(need)
         for move_vals in move_vals_list:
             move_vals["location_id"] = relocation.relocate_location_id.id
-        new_move = self.create(move_vals_list)
-        return new_move._action_confirm()
+            # Do not call _action_confirm on a split moves inside _action_assign
+            move_vals["state"] = "confirmed"
+            move_vals["reservation_date"] = self.reservation_date
+        return self.create(move_vals_list)
 
-    def _after_apply_source_relocate_rule(self):
-        # Hook for stock_dynamic_routing
-        return
+    def _after_apply_source_relocate_rule(self, merge=True):
+        if merge:
+            _logger.debug("Try to merge relocated moves")
+            # When the unassigned move is relocated in the same picking as the
+            # assigned move, merge back the assigned move into the relocated
+            # moves. Ensure the current move does not disappear as we are
+            # inside _action_assign
+            for moves in self.grouped("picking_id").values():
+                (moves.picking_id.move_ids - moves)._merge_moves(merge_into=moves)

--- a/stock_move_source_relocate/tests/test_source_relocate.py
+++ b/stock_move_source_relocate/tests/test_source_relocate.py
@@ -110,6 +110,9 @@ class TestSourceRelocate(SourceRelocateCommon):
 
         self.assertEqual(pick_move.state, "assigned")
         self.assertEqual(pick_move.product_uom_qty, 5)
+        replenish_move = replenish_move.search(
+            [("location_id", "=", self.loc_replenish.id), ("group_id", "=", group.id)]
+        )
         self.assertEqual(replenish_move.state, "confirmed")
         self.assertEqual(replenish_move.product_uom_qty, 15)
 

--- a/stock_move_source_relocate_dynamic_routing/models/stock_move.py
+++ b/stock_move_source_relocate_dynamic_routing/models/stock_move.py
@@ -11,19 +11,6 @@ _logger = logging.getLogger(__name__)
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    def _apply_source_relocate_rule(self, relocation, quantity, roundings):
-        relocated = super(
-            StockMove,
-            # disable application of routing in write() method of
-            # stock_dynamic_routing, we'll apply it here whatever the state of
-            # the move is
-            self.with_context(__applying_routing_rule=True),
-        )._apply_source_relocate_rule(relocation, quantity, roundings)
-        # restore the previous context without "__applying_routing_rule", otherwise
-        # it wouldn't properly apply the routing in chain in the further moves
-        relocated = relocated.with_context(**self.env.context)
-        return relocated
-
     def _after_apply_source_relocate_rule(self):
         super()._after_apply_source_relocate_rule()
         result = self._chain_apply_routing()


### PR DESCRIPTION
* When a confirmed move is split and/or source location is changed, do not call _action_confirm
* When the unassigned move is relocated in the same picking as the assigned move, merge back the assigned move into the relocated moves. Ensure the current move does not disappear as we are inside _action_assign

cc @grindtildeath @mmequignon @rousseldenis