### PR TITLE
[IMP] stock_lock_lot: Add configurable locked lot reservation

### DIFF
--- a/stock_lock_lot/README.rst
+++ b/stock_lock_lot/README.rst
@@ -30,8 +30,14 @@ Stock Lock Lot
 
 This module allows you to define whether a Serial Number/lot is blocked
 or not. The default value can be set on the Product Category, in the
-field "Block new Serial Numbers/lots". Is possible to specify in a
+field "Block new Serial Numbers/lots". It's possible to specify in a
 location if locked lots are allowed to move there.
+
+Additionally, locked lots are automatically excluded from stock
+reservations, preventing them from being allocated to outgoing orders.
+This ensures that blocked inventory cannot be accidentally reserved or
+shipped. The reservation exclusion can be bypassed using the
+'force_allow_locked_lots' context when explicitly needed.
 
 **Table of contents**
 
@@ -48,8 +54,18 @@ To allow a user to block or unblock a Lot:
    Serial Numbers/Lots"
 
 To allow move locked lots to a location: #. Open the locations (menu
-"Inventory > Configuration > Warehouse Management > Locations") #. check
+"Inventory > Configuration > Warehouse Management > Locations") #. Check
 the box "Allow Locked"
+
+To configure lot behavior at product category level: #. Open the product
+categories (menu "Sales > Configuration > Product Categories") #. In the
+"Warehouse" section, you can configure:
+
+-  "Block new Serial Numbers/lots": New lots will be created as blocked
+   by default
+-  "Allow reservation of locked lots": If checked, locked lots can still
+   be reserved for orders, but cannot be moved unless the destination
+   location allows locked lots
 
 Usage
 =====
@@ -60,6 +76,36 @@ To use this module, you need to:
 2. Select one 'Lot/Serial Number' and check 'Blocked' field
 3. Now you cannot move that 'Lot/Serial Number' to any location that
    does not have the 'Allow Locked' field checked
+
+**Reservation Behavior:**
+
+By default, locked lots are automatically excluded from stock
+reservations. When creating outgoing orders (sales orders, transfers,
+etc.), the system will only reserve from unlocked lots. This prevents
+blocked inventory from being allocated to orders.
+
+However, you can configure this behavior at the product category level:
+
+-  Go to *Sales > Configuration > Product Categories*
+-  In the Warehouse section, check "Allow reservation of locked lots"
+-  When enabled, locked lots in this category can still be reserved for
+   orders, but they cannot be moved unless the destination location
+   allows locked lots
+
+This is useful when you want to:
+
+-  Reserve specific inventory for future use but prevent actual movement
+-  Hold stock for quality inspection while still planning orders
+
+To override this behavior in custom operations, use the
+'force_allow_locked_lots' context.
+
+**Example Scenarios:**
+
+-  **Quality Hold**: Lock a lot for quality inspection - it won't be
+   reserved for customer orders unless the category allows reservation
+-  **Expired Stock**: Lock expired lots to prevent them from being
+   shipped
 
 Bug Tracker
 ===========
@@ -83,15 +129,19 @@ Authors
 Contributors
 ------------
 
-- Ana Juaristi <anajuaristi@avanzosc.es>
-- Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
-- Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
-- Lionel Sausin <ls@numerigraphe.com>
-- Ainara Galdona <ainaragaldona@avanzosc.es>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Ana Juaristi <anajuaristi@avanzosc.es>
+-  Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+-  Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+-  Lionel Sausin <ls@numerigraphe.com>
+-  Ainara Galdona <ainaragaldona@avanzosc.es>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
-  - Ernesto Tejeda
+   -  Pedro M. Baeza
+   -  Ernesto Tejeda
+
+-  `Open Source Integrators <https://www.opensourceintegrators.com>`__:
+
+   -  Daniel Reis <dreis@opensourceintegrators.com>
 
 Maintainers
 -----------

--- a/stock_lock_lot/models/__init__.py
+++ b/stock_lock_lot/models/__init__.py
@@ -6,3 +6,4 @@ from . import product_category
 from . import stock_lot
 from . import stock_location
 from . import stock_move_line
+from . import stock_quant

--- a/stock_lock_lot/models/product_category.py
+++ b/stock_lock_lot/models/product_category.py
@@ -14,3 +14,11 @@ class ProductCategory(models.Model):
         "by default. This means they will not be available for use "
         "in stock moves or other operations",
     )
+    lot_reserve_locked = fields.Boolean(
+        string="Block reservation of locked lots",
+        help="If checked, locked lots in this category will be blocked from "
+        "reservation. If unchecked, locked lots can still be reserved for "
+        "orders, but they cannot be moved unless the destination "
+        "location allows locked lots",
+        default=False,
+    )

--- a/stock_lock_lot/models/stock_lot.py
+++ b/stock_lock_lot/models/stock_lot.py
@@ -13,7 +13,16 @@ class StockLot(models.Model):
     locked = fields.Boolean(
         string="Blocked",
         tracking=True,
+        copy=False,
         help="Indicates whether this lot is blocked for use.",
+    )
+    locked_reservation = fields.Boolean(
+        string="Block reservation when locked",
+        tracking=True,
+        copy=False,
+        help="If checked, this lot will be blocked for reservation when locked. "
+        "If unchecked, this lot can be reserved even when locked. "
+        "This overrides the category setting.",
     )
     product_id = fields.Many2one(tracking=True)
 
@@ -31,29 +40,44 @@ class StockLot(models.Model):
             categ = categ.parent_id
         return _locked
 
+    def _get_product_reserve_locked(self, product):
+        """Should block reservation when locked?
+
+        @param product: browse-record for product.product
+        @return True when the category of the product
+                blocks reservation of locked lots
+        """
+        if not product or not product.categ_id:
+            return False
+        return product.categ_id.lot_reserve_locked
+
     @api.onchange("product_id")
     def _onchange_product_id(self):
         """Instruct the client to lock/unlock a lot on product change"""
         self.locked = self._get_product_locked(self.product_id)
+        self.locked_reservation = self._get_product_reserve_locked(self.product_id)
 
     @api.constrains("locked")
     def _check_lock_unlock(self):
-        if not self.user_has_groups(
-            "stock_lock_lot.group_lock_lot"
-        ) and not self.env.context.get("bypass_lock_permission_check"):
+        has_lock_group = self.user_has_groups("stock_lock_lot.group_lock_lot")
+        can_bypass_check = self.env.context.get("bypass_lock_permission_check")
+        if not (has_lock_group or can_bypass_check):
             raise exceptions.AccessError(
                 _("You are not allowed to block/unblock Serial Numbers/Lots")
             )
-        reserved_quants = self.env["stock.quant"].search(
-            [("lot_id", "in", self.ids), ("reserved_quantity", "!=", 0.0)]
-        )
-        if reserved_quants:
-            raise exceptions.ValidationError(
-                _(
-                    "You are not allowed to block/unblock, there are"
-                    " reserved quantities for these Serial Numbers/Lots"
-                )
+        # The reserved check is kept for backward compatibility
+        reserved_check = self.env.context.get("reserved_lock_permission_check")
+        if reserved_check:
+            reserved_quants = self.env["stock.quant"].search(
+                [("lot_id", "in", self.ids), ("reserved_quantity", "!=", 0.0)]
             )
+            if reserved_quants:
+                raise exceptions.ValidationError(
+                    _(
+                        "You are not allowed to block/unblock, there are"
+                        " reserved quantities for these Serial Numbers/Lots"
+                    )
+                )
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -68,6 +92,7 @@ class StockLot(models.Model):
             )
             product = self.env["product.product"].browse(product_id)
             vals["locked"] = self._get_product_locked(product)
+            vals["locked_reservation"] = self._get_product_reserve_locked(product)
         lots = super(
             StockLot, self.with_context(bypass_lock_permission_check=True)
         ).create(vals_list)
@@ -78,6 +103,7 @@ class StockLot(models.Model):
         if "product_id" in values:
             product = self.env["product.product"].browse(values["product_id"])
             values["locked"] = self._get_product_locked(product)
+            values["locked_reservation"] = self._get_product_reserve_locked(product)
         return super().write(values)
 
     def _track_subtype(self, init_values):

--- a/stock_lock_lot/models/stock_lot.py
+++ b/stock_lock_lot/models/stock_lot.py
@@ -55,24 +55,23 @@ class StockLot(models.Model):
                 )
             )
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         """Force the locking/unlocking, ignoring the value of 'locked'."""
-        product = self.env["product.product"].browse(
-            vals.get(
+        for vals in vals_list:
+            product_id = vals.get(
                 "product_id",
                 # Web quick-create provide in context
                 self.env.context.get(
                     "product_id", self.env.context.get("default_product_id", False)
                 ),
             )
-        )
-        vals["locked"] = self._get_product_locked(product)
-        lot = super(
+            product = self.env["product.product"].browse(product_id)
+            vals["locked"] = self._get_product_locked(product)
+        lots = super(
             StockLot, self.with_context(bypass_lock_permission_check=True)
-        ).create(vals)
-
-        return self.browse(lot.id)  # for cleaning context
+        ).create(vals_list)
+        return lots
 
     def write(self, values):
         """ "Lock the lot if changing the product and locking is required"""

--- a/stock_lock_lot/models/stock_quant.py
+++ b/stock_lock_lot/models/stock_quant.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Open Source Integrators (http://www.opensourceintegrators.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+from odoo.osv import expression
+
+
+class StockQuant(models.Model):
+    _inherit = "stock.quant"
+
+    def _get_gather_domain(
+        self,
+        product_id,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
+        domain = super()._get_gather_domain(
+            product_id, location_id, lot_id, package_id, owner_id, strict
+        )
+        # Extend StockQuant to exclude locked lots from reservation domain
+        # Block locked lots unless they have reserve_locked=False
+        if not self.env.context.get("force_allow_locked_lots"):
+            filter_domain = [
+                "|",
+                "|",
+                ("lot_id", "=", False),
+                ("lot_id.locked", "=", False),
+                ("lot_id.locked_reservation", "=", False),
+            ]
+            domain = expression.AND([domain, filter_domain])
+        return domain

--- a/stock_lock_lot/readme/CONFIGURE.md
+++ b/stock_lock_lot/readme/CONFIGURE.md
@@ -5,6 +5,12 @@ To allow a user to block or unblock a Lot:
 2.  In the "Warehouse" section, check the box "Allow to block/unblock
     Serial Numbers/Lots"
 
-To allow move locked lots to a location: \#. Open the locations (menu
-"Inventory \> Configuration \> Warehouse Management \> Locations") \#.
-check the box "Allow Locked"
+To allow move locked lots to a location:
+#. Open the locations (menu "Inventory \> Configuration \> Warehouse Management \> Locations")
+#. Check the box "Allow Locked"
+
+To configure lot behavior at product category level:
+#. Open the product categories (menu "Sales \> Configuration \> Product Categories")
+#. In the "Warehouse" section, you can configure:
+   - "Block new Serial Numbers/lots": New lots will be created as blocked by default
+   - "Allow reservation of locked lots": If checked, locked lots can still be reserved for orders, but cannot be moved unless the destination location allows locked lots

--- a/stock_lock_lot/readme/CONTRIBUTORS.md
+++ b/stock_lock_lot/readme/CONTRIBUTORS.md
@@ -6,3 +6,5 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Pedro M. Baeza
   - Ernesto Tejeda
+- [Open Source Integrators](https://www.opensourceintegrators.com):
+  - Daniel Reis \<<dreis@opensourceintegrators.com>>

--- a/stock_lock_lot/readme/DESCRIPTION.md
+++ b/stock_lock_lot/readme/DESCRIPTION.md
@@ -1,4 +1,10 @@
 This module allows you to define whether a Serial Number/lot is blocked
 or not. The default value can be set on the Product Category, in the
-field "Block new Serial Numbers/lots". Is possible to specify in a
+field "Block new Serial Numbers/lots". It's possible to specify in a
 location if locked lots are allowed to move there.
+
+Additionally, locked lots are automatically excluded from stock reservations,
+preventing them from being allocated to outgoing orders. This ensures that
+blocked inventory cannot be accidentally reserved or shipped. The reservation
+exclusion can be bypassed using the 'force_allow_locked_lots' context when
+explicitly needed.

--- a/stock_lock_lot/readme/USAGE.md
+++ b/stock_lock_lot/readme/USAGE.md
@@ -4,3 +4,29 @@ To use this module, you need to:
 2.  Select one 'Lot/Serial Number' and check 'Blocked' field
 3.  Now you cannot move that 'Lot/Serial Number' to any location that
     does not have the 'Allow Locked' field checked
+
+**Reservation Behavior:**
+
+By default, locked lots are automatically excluded from stock reservations.
+When creating outgoing orders (sales orders, transfers, etc.), the system
+will only reserve from unlocked lots. This prevents blocked inventory from 
+being allocated to orders.
+
+However, you can configure this behavior at the product category level:
+
+- Go to *Sales \> Configuration \> Product Categories*
+- In the Warehouse section, check "Allow reservation of locked lots"
+- When enabled, locked lots in this category can still be reserved for orders,
+  but they cannot be moved unless the destination location allows locked lots
+
+This is useful when you want to:
+- Reserve specific inventory for future use but prevent actual movement
+- Hold stock for quality inspection while still planning orders
+
+To override this behavior in custom operations, use the 'force_allow_locked_lots' context.
+
+**Example Scenarios:**
+
+- **Quality Hold**: Lock a lot for quality inspection - it won't be reserved
+  for customer orders unless the category allows reservation
+- **Expired Stock**: Lock expired lots to prevent them from being shipped

--- a/stock_lock_lot/static/description/index.html
+++ b/stock_lock_lot/static/description/index.html
@@ -372,8 +372,13 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/stock-logistics-workflow/tree/17.0/stock_lock_lot"><img alt="OCA/stock-logistics-workflow" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/stock-logistics-workflow-17-0/stock-logistics-workflow-17-0-stock_lock_lot"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/stock-logistics-workflow&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module allows you to define whether a Serial Number/lot is blocked
 or not. The default value can be set on the Product Category, in the
-field “Block new Serial Numbers/lots”. Is possible to specify in a
+field “Block new Serial Numbers/lots”. It’s possible to specify in a
 location if locked lots are allowed to move there.</p>
+<p>Additionally, locked lots are automatically excluded from stock
+reservations, preventing them from being allocated to outgoing orders.
+This ensures that blocked inventory cannot be accidentally reserved or
+shipped. The reservation exclusion can be bypassed using the
+‘force_allow_locked_lots’ context when explicitly needed.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -397,8 +402,18 @@ location if locked lots are allowed to move there.</p>
 Serial Numbers/Lots”</li>
 </ol>
 <p>To allow move locked lots to a location: #. Open the locations (menu
-“Inventory &gt; Configuration &gt; Warehouse Management &gt; Locations”) #. check
+“Inventory &gt; Configuration &gt; Warehouse Management &gt; Locations”) #. Check
 the box “Allow Locked”</p>
+<p>To configure lot behavior at product category level: #. Open the product
+categories (menu “Sales &gt; Configuration &gt; Product Categories”) #. In the
+“Warehouse” section, you can configure:</p>
+<ul class="simple">
+<li>“Block new Serial Numbers/lots”: New lots will be created as blocked
+by default</li>
+<li>“Allow reservation of locked lots”: If checked, locked lots can still
+be reserved for orders, but cannot be moved unless the destination
+location allows locked lots</li>
+</ul>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
@@ -409,6 +424,33 @@ the box “Allow Locked”</p>
 <li>Now you cannot move that ‘Lot/Serial Number’ to any location that
 does not have the ‘Allow Locked’ field checked</li>
 </ol>
+<p><strong>Reservation Behavior:</strong></p>
+<p>By default, locked lots are automatically excluded from stock
+reservations. When creating outgoing orders (sales orders, transfers,
+etc.), the system will only reserve from unlocked lots. This prevents
+blocked inventory from being allocated to orders.</p>
+<p>However, you can configure this behavior at the product category level:</p>
+<ul class="simple">
+<li>Go to <em>Sales &gt; Configuration &gt; Product Categories</em></li>
+<li>In the Warehouse section, check “Allow reservation of locked lots”</li>
+<li>When enabled, locked lots in this category can still be reserved for
+orders, but they cannot be moved unless the destination location
+allows locked lots</li>
+</ul>
+<p>This is useful when you want to:</p>
+<ul class="simple">
+<li>Reserve specific inventory for future use but prevent actual movement</li>
+<li>Hold stock for quality inspection while still planning orders</li>
+</ul>
+<p>To override this behavior in custom operations, use the
+‘force_allow_locked_lots’ context.</p>
+<p><strong>Example Scenarios:</strong></p>
+<ul class="simple">
+<li><strong>Quality Hold</strong>: Lock a lot for quality inspection - it won’t be
+reserved for customer orders unless the category allows reservation</li>
+<li><strong>Expired Stock</strong>: Lock expired lots to prevent them from being
+shipped</li>
+</ul>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
@@ -438,6 +480,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza</li>
 <li>Ernesto Tejeda</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.opensourceintegrators.com">Open Source Integrators</a>:<ul>
+<li>Daniel Reis &lt;<a class="reference external" href="mailto:dreis&#64;opensourceintegrators.com">dreis&#64;opensourceintegrators.com</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/stock_lock_lot/tests/test_stock_lock_lot.py
+++ b/stock_lock_lot/tests/test_stock_lock_lot.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2025 Open Source Integrators (http://www.opensourceintegrators.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import exceptions
@@ -13,15 +14,28 @@ class TestStockLockLot(common.TransactionCase):
             {"name": "Test category", "lot_default_locked": True}
         )
         cls.product = cls.env["product.product"].create(
-            {"name": "Test product", "categ_id": cls.category.id}
+            {"name": "Test product", "categ_id": cls.category.id, "type": "product"}
         )
+        cls.warehouse = cls.env["stock.warehouse"].search([], limit=1)
+        cls.location = cls.warehouse.lot_stock_id
 
-    def _get_lot_default_vals(self):
+    def _get_lot_default_vals(self, name="Test lot", locked=False):
         return {
-            "name": "Test lot",
+            "name": name,
             "product_id": self.product.id,
             "company_id": self.env.user.company_id.id,
+            "locked": locked,
         }
+
+    def _get_lot_quant(self, lot):
+        """Get the quant for a specific lot."""
+        return self.env["stock.quant"].search(
+            [
+                ("product_id", "=", self.product.id),
+                ("location_id", "=", self.location.id),
+                ("lot_id", "=", lot.id),
+            ]
+        )
 
     def test_new_lot_unlocked(self):
         self.category.lot_default_locked = False
@@ -43,3 +57,196 @@ class TestStockLockLot(common.TransactionCase):
         lot = self.env["stock.lot"].create(self._get_lot_default_vals())
         with self.assertRaises(exceptions.AccessError):
             lot.locked = False
+
+    def test_locked_lot_excluded_from_reservation(self):
+        """Test that locked lots are excluded from reservation."""
+        # Create two lots - one locked, one unlocked
+        locked_lot = self.env["stock.lot"].create(
+            self._get_lot_default_vals(name="Locked Lot", locked=True)
+        )
+        unlocked_lot = self.env["stock.lot"].create(
+            self._get_lot_default_vals(name="Unlocked Lot", locked=False)
+        )
+
+        # Create quants for both lots (_update_available_quantity returns tuple)
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.location, 10, lot_id=locked_lot
+        )
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.location, 10, lot_id=unlocked_lot
+        )
+
+        # Get the quant objects using helper function
+        locked_quant = self._get_lot_quant(locked_lot)
+        unlocked_quant = self._get_lot_quant(unlocked_lot)
+
+        # Check initial availability - both should have 10 available
+        self.assertEqual(locked_quant.available_quantity, 10.0)
+        self.assertEqual(unlocked_quant.available_quantity, 10.0)
+
+        # Try to create a stock move that would need to reserve inventory
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test move",
+                "product_id": self.product.id,
+                "product_uom_qty": 5.0,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.location.id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+            }
+        )
+
+        # Confirm the move to trigger reservation
+        move._action_confirm()
+        move._action_assign()
+
+        # Refresh quants to get updated quantities
+        locked_quant.invalidate_recordset()
+        unlocked_quant.invalidate_recordset()
+
+        # Only the unlocked lot should have been reserved
+        self.assertEqual(
+            locked_quant.reserved_quantity, 0.0, "Locked lot should not be reserved"
+        )
+        self.assertEqual(
+            locked_quant.available_quantity,
+            10.0,
+            "Locked lot should still be available",
+        )
+        self.assertEqual(
+            unlocked_quant.reserved_quantity, 5.0, "Unlocked lot should be reserved"
+        )
+        self.assertEqual(
+            unlocked_quant.available_quantity,
+            5.0,
+            "Unlocked lot should have reduced availability",
+        )
+
+    def test_locked_lot_included_in_reservation_when_allowed(self):
+        """Test that locked lots can be reserved when category allows it."""
+        # Update category to allow reservation of locked lots
+        self.category.lot_reserve_locked = False
+
+        # Create two lots - one locked, one unlocked
+        locked_lot = self.env["stock.lot"].create(
+            self._get_lot_default_vals(name="Locked Lot", locked=True)
+        )
+        unlocked_lot = self.env["stock.lot"].create(
+            self._get_lot_default_vals(name="Unlocked Lot", locked=False)
+        )
+
+        # Create quants for both lots (_update_available_quantity returns tuple)
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.location, 10, lot_id=locked_lot
+        )
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.location, 10, lot_id=unlocked_lot
+        )
+
+        # Get the quant objects using helper function
+        locked_quant = self._get_lot_quant(locked_lot)
+        unlocked_quant = self._get_lot_quant(unlocked_lot)
+
+        # Check initial availability - both should have 10 available
+        self.assertEqual(locked_quant.available_quantity, 10.0)
+        self.assertEqual(unlocked_quant.available_quantity, 10.0)
+
+        # Try to create a stock move that would need to reserve inventory
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test move",
+                "product_id": self.product.id,
+                "product_uom_qty": 15.0,  # Need more than unlocked lot has
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.location.id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+            }
+        )
+
+        # Confirm the move to trigger reservation
+        move._action_confirm()
+        move._action_assign()
+
+        # Refresh quants to get updated quantities
+        locked_quant.invalidate_recordset()
+        unlocked_quant.invalidate_recordset()
+
+        # Both lots should have been reserved since category allows it
+        self.assertEqual(
+            locked_quant.reserved_quantity,
+            5.0,
+            "Locked lot should be reserved when allowed",
+        )
+        self.assertEqual(
+            locked_quant.available_quantity,
+            5.0,
+            "Locked lot should have reduced availability",
+        )
+        self.assertEqual(
+            unlocked_quant.reserved_quantity, 10.0, "Unlocked lot should be reserved"
+        )
+        self.assertEqual(
+            unlocked_quant.available_quantity,
+            0.0,
+            "Unlocked lot should have no availability left",
+        )
+
+    def test_lot_level_reserve_locked_override(self):
+        """Test that lot-level reserve_locked overrides category setting."""
+        # Category does NOT allow reservation of locked lots
+        self.category.lot_reserve_locked = False
+
+        # Create a locked lot with lot-level override to allow reservation
+        locked_lot = self.env["stock.lot"].create(
+            self._get_lot_default_vals(name="Locked Lot", locked=True)
+        )
+        locked_lot.locked_reservation = False
+
+        # Create an unlocked lot for comparison
+        unlocked_lot = self.env["stock.lot"].create(
+            self._get_lot_default_vals(name="Unlocked Lot", locked=False)
+        )
+
+        # Create quants for both lots
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.location, 10, lot_id=locked_lot
+        )
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.location, 10, lot_id=unlocked_lot
+        )
+
+        # Get the quant objects using helper function
+        locked_quant = self._get_lot_quant(locked_lot)
+        unlocked_quant = self._get_lot_quant(unlocked_lot)
+
+        # Try to create a stock move that would need to reserve inventory
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test move",
+                "product_id": self.product.id,
+                "product_uom_qty": 5.0,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.location.id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+            }
+        )
+
+        # Confirm the move to trigger reservation
+        move._action_confirm()
+        move._action_assign()
+
+        # Refresh quants to get updated quantities
+        locked_quant.invalidate_recordset()
+        unlocked_quant.invalidate_recordset()
+
+        # The locked lot should be reserved due to lot-level override
+        self.assertEqual(
+            locked_quant.reserved_quantity,
+            5.0,
+            "Locked lot should be reserved with lot-level override",
+        )
+        self.assertEqual(
+            locked_quant.available_quantity,
+            5.0,
+            "Locked lot should have reduced availability",
+        )

--- a/stock_lock_lot/views/product_category_view.xml
+++ b/stock_lock_lot/views/product_category_view.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <group name="first">
                 <field name="lot_default_locked" />
+                <field name="lot_reserve_locked" />
             </group>
         </field>
     </record>

--- a/stock_lock_lot/views/stock_lot_view.xml
+++ b/stock_lock_lot/views/stock_lot_view.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="ref" position="after">
                 <field name="locked" />
+                <field name="locked_reservation" invisible="not locked" />
             </field>
         </field>
     </record>
@@ -17,6 +18,7 @@
         <field name="arch" type="xml">
             <field name="create_date" position="after">
                 <field name="locked" />
+                <field name="locked_reservation" optional="hide" />
             </field>
         </field>
     </record>
@@ -27,10 +29,16 @@
         <field name="arch" type="xml">
             <group position="before">
                 <field name="locked" />
+                <field name="locked_reservation" />
                 <filter
                     string="Locked"
                     name="locked_filter"
                     domain="[('locked', '=', True)]"
+                />
+                <filter
+                    string="Allow Reservation When Locked"
+                    name="reserve_locked_filter"
+                    domain="[('locked_reservation', '=', False)]"
                 />
             </group>
             <filter name="group_by_product" position="before">


### PR DESCRIPTION
- [FIX] stock_lock_lot: support for create multi
- [IMP] stock_lock_lot: Add configurable locked lot reservation

Configurable reservation of locked lots was implemented here, but the conclusion was that this is a bad idea - you don't want locked lots to be reserved.
Still, I leave it here since the work was done and someone might find it useful.