### PR TITLE
[16.0][FIX] stock_move_line_serial_unique: Exclude internal moves from check

### DIFF
--- a/stock_move_line_serial_unique/models/stock_move_line.py
+++ b/stock_move_line_serial_unique/models/stock_move_line.py
@@ -22,6 +22,12 @@ class StockMoveLine(models.Model):
                 and record.product_id.tracking == "serial"
                 # Check should be done only in the scenario where new serial is created.
                 and record.picking_type_id.use_create_lots
+                # Only check for moves from non-internal locations (e.g. receipts,
+                # production) to internal locations.
+                # Without this, component flushes in subcontracting receipts would
+                # incorrectly trigger the serial uniqueness check.
+                and record.location_id.usage != "internal"
+                and record.location_dest_id.usage == "internal"
             ):
                 lot_id = record.lot_id
                 if not lot_id:

--- a/stock_move_line_serial_unique/tests/test_stock_move_line_serial_unique.py
+++ b/stock_move_line_serial_unique/tests/test_stock_move_line_serial_unique.py
@@ -104,3 +104,26 @@ class TestStockQuantSerialUnique(TransactionCase):
         moveline.write({"lot_id": self.serial1.id})
         picking_out.action_confirm()
         picking_out.button_validate()
+
+    def test_internal_move_serial_with_use_create_lots(self):
+        picking_type_internal = self.env["stock.picking.type"].create(
+            {
+                "name": "Internal with Create Lots",
+                "code": "internal",
+                "sequence_code": "INT",
+                "use_create_lots": True,
+            }
+        )
+        shelf_location = self.env.ref("stock.stock_location_components")
+        picking_internal = self._create_picking(
+            self.stock_location,
+            shelf_location,
+            picking_type_internal,
+            self.owner,
+        )
+        moveline = self._create_moveline(self.product, picking_internal)
+        # Use existing serial '001' from internal location
+        # Should NOT raise ValidationError because source is internal
+        moveline.write({"lot_id": self.serial1.id})
+        picking_internal.action_confirm()
+        picking_internal.button_validate()


### PR DESCRIPTION
[FIX] stock_move_line_serial_unique: Exclude internal moves from validation

The serial number uniqueness constraint was incorrectly blocking valid internal stock moves where existing serial numbers need to be moved between internal locations.

The constraint now uses location-based logic:
- CHECK: Moves from external → internal (receipts, manufacturing)
- SKIP: Moves from internal → anywhere (consumption, internal transfers)

This prevents duplicate serial creation on receipts while allowing normal internal moves with existing serial numbers.

@qrtl QT6552