### PR TITLE
[18.0][FIX] stock_move_source_relocate_dynamic_routing: merge moves & perf

### DIFF
--- a/stock_dynamic_routing/models/stock_move.py
+++ b/stock_dynamic_routing/models/stock_move.py
@@ -7,7 +7,7 @@ from collections import OrderedDict, defaultdict, namedtuple
 
 from psycopg2 import sql
 
-from odoo import models
+from odoo import api, models
 from odoo.tools.float_utils import float_compare
 
 _logger = logging.getLogger(__name__)
@@ -58,18 +58,16 @@ class StockMove(models.Model):
                 )
             else:
                 moves_with_routing_details[move] = self._no_routing_details()
-
-        self._apply_routing_rule_pull(moves_with_routing_details)
-        self._apply_routing_rule_push(moves_with_routing_details)
+        self._apply_routing_rule(moves_with_routing_details)
 
     def _action_assign(self, force_qty=False):
         if self.env.context.get("exclude_apply_dynamic_routing"):
-            return super()._action_assign(force_qty=force_qty)
+            super()._action_assign(force_qty=force_qty)
         else:
-            # these methods will call _action_assign in a savepoint
-            # and modify the routing if necessary
-            moves = self._split_and_apply_routing()
-            return super(StockMove, moves)._action_assign()
+            # These methods will call _action_assign in a savepoint and modify
+            # the routing if necessary. Call to super is done in the method.
+            self._split_and_apply_routing()
+        return
 
     def _split_and_apply_routing(self):
         """Apply routing rules
@@ -79,10 +77,6 @@ class StockMove(models.Model):
         * split the moves if their move lines have different source or
           destination locations and need routing
         * apply the routing rules (pull and push)
-
-        Important: if you inherit this method to skip the routing for some
-        moves, the method has to return the moves in ``self`` so they are
-        assigned.
         """
         moves_routing = self._prepare_routing_pull()
         if not moves_routing:
@@ -90,13 +84,11 @@ class StockMove(models.Model):
             # called _action_assign(), returning an empty recordset will
             # prevent the caller of the method to call _action_assign() again
             # on the same moves
-            return self.browse()
+            return
         # apply the routing
         moves_with_routing_details = self._routing_splits(moves_routing)
         moves = self.browse(move.id for move in moves_with_routing_details)
-        moves._apply_routing_rule_pull(moves_with_routing_details)
-        moves._apply_routing_rule_push(moves_with_routing_details)
-        return moves
+        moves._apply_routing_rule(moves_with_routing_details, assign=True)
 
     def _prepare_routing_pull(self):
         """Prepare pull routing rules for moves
@@ -252,7 +244,47 @@ class StockMove(models.Model):
 
         return moves_with_routing_details
 
-    def _apply_routing_rule_pull(self, routing_details):
+    def _after_apply_dynamic_routing_rule(self):
+        # Hook used by stock_move_source_relocate to also relocate confirmed
+        # moves causing them to get merged back with relocated available moves.
+        # That will prevent next moves to be split.
+        return self
+
+    def _apply_routing_rule(self, routing_details, assign=False):
+        non_relocated_moves = self.browse()
+        pull_routing_details = {}
+        push_routing_details = {}
+        for move in self:
+            move_routing_details = routing_details[move]
+            routing_rule = move_routing_details.rule
+            if not routing_rule:
+                non_relocated_moves |= move
+                continue
+            if move.picking_type_id == routing_rule.picking_type_id:
+                # no routing to apply
+                non_relocated_moves |= move
+                continue
+            if routing_rule.method == "pull":
+                pull_routing_details[move] = move_routing_details
+            if routing_rule.method == "push":
+                push_routing_details[move] = move_routing_details
+        push_moves = self._apply_routing_rule_push(push_routing_details)
+        next_moves_to_update = self._apply_routing_rule_pull(
+            pull_routing_details, assign=assign
+        )
+        moves = non_relocated_moves | push_moves
+        moves = moves._after_apply_dynamic_routing_rule()
+        if assign:
+            # assign the moves that have not been relocated.
+            # Do this before updating next moves.
+            super(StockMove, moves)._action_assign()
+        # Update the destination moves. This might trigger a new routing on the
+        # destination move.
+        next_moves_to_update._routing_pull_switch_source()
+        return
+
+    @api.model
+    def _apply_routing_rule_pull(self, routing_details, assign=False):
         """Apply pull dynamic routing
 
         When a move has a dynamic routing configured on its location and the
@@ -262,49 +294,49 @@ class StockMove(models.Model):
         """
         pickings_to_check_for_emptiness = self.env["stock.picking"]
         move_ids_to_assign_per_location = defaultdict(list)
-        move_ids_to_assign_nonrelocated = []
         next_moves_to_update = self.browse()
         routing_to_apply = [
             (move, detail.rule) for move, detail in routing_details.items()
         ]
         for move, routing_rule in routing_to_apply:
-            # Add the routing rule to the context
+            # Add the routing rule to the context for stock_dynamic_routing_delivery
             move = move.with_context(__routing_rule=routing_rule)
-
-            if not routing_rule:
-                move_ids_to_assign_nonrelocated.append(move.id)
-                continue
-
-            if routing_rule.method == "push":
-                # In this case, we should not assign the move inside the
-                # pull dynamic routing. The push move must first be added before the
-                # initial move is assigned. Otherwise, when the destination
-                # location of the initial move is changed by the push rule, the
-                # putaway won't be recomputed as it is already assigned.
-                continue
-
-            if move.picking_id.picking_type_id == routing_rule.picking_type_id:
-                # already correct
-                move_ids_to_assign_nonrelocated.append(move.id)
-                continue
 
             # we expect all the lines to go to the same destination for
             # pull routing rules
             original_destination = move.location_dest_id
             current_picking_type = move.picking_id.picking_type_id
+            _logger.debug(
+                f"Rerouting {move} with pull rule of transfer {move.picking_id.name}"
+            )
 
             # Use the source location of the routing rule, if not already done
             # If a sublocation is used, it's respected.
             if not move.location_id._child_of(routing_rule.location_src_id):
+                _logger.debug(
+                    "- changed source location: "
+                    f"{routing_rule.location_src_id.display_name}"
+                )
                 move.with_context(
                     __applying_routing_rule=True
                 ).location_id = routing_rule.location_src_id
 
             # Use the picking type of the routing rule, if not already done
             if move.picking_type_id != routing_rule.picking_type_id:
+                _logger.debug(
+                    f"- changed picking type: {routing_rule.picking_type_id.name}"
+                )
                 move.picking_type_id = routing_rule.picking_type_id
 
-            if routing_rule.location_dest_id._child_of(move.location_dest_id):
+            if move.location_dest_id == routing_rule.location_dest_id:
+                next_moves_to_update |= move.move_dest_ids.filtered(
+                    lambda r: r.state == "waiting"
+                )
+            elif routing_rule.location_dest_id._child_of(move.location_dest_id):
+                _logger.debug(
+                    "- changed destination location: "
+                    f"{routing_rule.location_dest_id.display_name}"
+                )
                 # The destination of the move, is a parent of the destination
                 # of the routing, goes to the correct place, but is not precise
                 # enough: set the new destination to match the rule's one.
@@ -316,6 +348,10 @@ class StockMove(models.Model):
                     lambda r: r.state == "waiting"
                 )
             elif not move.location_dest_id._child_of(routing_rule.location_dest_id):
+                _logger.debug(
+                    "- changed destination location: "
+                    f"{routing_rule.location_dest_id.display_name}"
+                )
                 # The destination of the move is unrelated (nor identical, nor
                 # a parent or a child) to the routing destination: in this case
                 # we have to add a routing move after to reach the original destination
@@ -382,29 +418,27 @@ class StockMove(models.Model):
         # by another move, sort the moves by their source location, from the
         # most precise to the least precise. The order of the move ids within
         # one location is preserved.
-        #
-        # The non routed moves are assigned at last. This allows compatibility
-        # with the module stock_move_source_relocate and ensures we call
-        # _action_assign on the complete set of moves
-        sorted_locations = sorted(
-            move_ids_to_assign_per_location,
-            key=lambda loc: loc.parent_path,
-            reverse=True,
-        )
-        to_assign_ids = []
-        for location in sorted_locations:
-            to_assign_ids += move_ids_to_assign_per_location[location]
-        to_assign_ids += move_ids_to_assign_nonrelocated
 
-        self.browse(to_assign_ids).with_context(
-            exclude_apply_dynamic_routing=True
-        )._action_assign()
+        if assign:
+            sorted_locations = sorted(
+                move_ids_to_assign_per_location,
+                key=lambda loc: loc.parent_path,
+                reverse=True,
+            )
+            to_assign_ids = []
+            for location in sorted_locations:
+                to_assign_ids += move_ids_to_assign_per_location[location]
 
-        # Update the destination moves. This might trigger a new routing on the
-        # destination move.
-        next_moves_to_update._routing_pull_switch_source()
+            super(
+                StockMove,
+                self.browse(to_assign_ids).with_context(
+                    exclude_apply_dynamic_routing=True
+                ),
+            )._action_assign()
 
         pickings_to_check_for_emptiness._dynamic_routing_handle_empty()
+
+        return next_moves_to_update
 
     def _routing_pull_switch_source(self):
         """Switch the source location of the move in place.
@@ -456,6 +490,7 @@ class StockMove(models.Model):
             lambda r: r.state == "waiting"
         )._chain_apply_routing()
 
+    @api.model
     def _apply_routing_rule_push(self, routing_details):
         """Apply push dynamic routing
 
@@ -465,19 +500,13 @@ class StockMove(models.Model):
         the routing ones and creates a new chained move after it.
         """
         pickings_to_check_for_emptiness = self.env["stock.picking"]
-        for move in self:
-            move_routing_details = routing_details[move]
+        push_moves = self.browse()
+        for move, move_routing_details in routing_details.items():
             routing_rule = move_routing_details.rule
-            # Add the routing details to the context
+            push_moves |= move
+            # Add the routing rule to the context for stock_dynamic_routing_delivery
             move = move.with_context(__routing_rule=routing_rule)
-            # At this point, we should not have lines with different source
-            # locations, they have been split by _routing_splits()
-            if not routing_rule.method == "push":
-                continue
-            if move.picking_id.picking_type_id == routing_rule.picking_type_id:
-                # the routing rule has already been applied and re-classified
-                # the move in the picking type
-                continue
+
             if move.location_dest_id == routing_rule.location_src_id:
                 # the routing rule has already been applied and added a new
                 # routing move after this one
@@ -502,6 +531,7 @@ class StockMove(models.Model):
                 )
 
         pickings_to_check_for_emptiness._dynamic_routing_handle_empty()
+        return push_moves
 
     def _routing_push_switch_picking_type(self, routing_rule):
         """Switch the picking type of the move in place
@@ -549,6 +579,10 @@ class StockMove(models.Model):
     def _insert_routing_moves(self, picking_type, location, destination):
         """Create a chained move for a routing rule"""
         self.ensure_one()
+        _logger.debug(
+            f"- changed with inserted move from {location.display_name} to "
+            f"{destination.display_name}"
+        )
         dest_moves = self.move_dest_ids
         # Insert move between the source and destination for the new
         # operation

--- a/stock_dynamic_routing/tests/test_routing_push.py
+++ b/stock_dynamic_routing/tests/test_routing_push.py
@@ -435,7 +435,7 @@ class TestRoutingPush(BaseCommon):
         moves = self.env["stock.move"].browse(
             move.id for move in moves_with_routing_details
         )
-        moves._apply_routing_rule_push(moves_with_routing_details)
+        moves._apply_routing_rule(moves_with_routing_details)
         moves._action_assign()
 
         # At this point, we should have this

--- a/stock_move_source_relocate_dynamic_routing/models/stock_move.py
+++ b/stock_move_source_relocate_dynamic_routing/models/stock_move.py
@@ -11,8 +11,14 @@ _logger = logging.getLogger(__name__)
 class StockMove(models.Model):
     _inherit = "stock.move"
 
-    def _after_apply_source_relocate_rule(self):
-        super()._after_apply_source_relocate_rule()
-        result = self._chain_apply_routing()
-        _logger.debug("Dynamic routing applied on relocated moves %s", self.ids)
-        return result
+    def _after_apply_dynamic_routing_rule(self):
+        self._apply_source_relocate()
+        return self.with_context(exclude_apply_source_relocate=True)
+
+    def _after_apply_source_relocate_rule(self, merge=True):
+        # Apply dynamic routing on relocated move to potentially route it in
+        # another picking
+        _logger.debug(f"Apply dynamic routing on relocated moves {self}")
+        self._chain_apply_routing()
+        super()._after_apply_source_relocate_rule(merge=merge)
+        return

--- a/stock_move_source_relocate_dynamic_routing/models/stock_move.py
+++ b/stock_move_source_relocate_dynamic_routing/models/stock_move.py
@@ -12,7 +12,7 @@ class StockMove(models.Model):
     _inherit = "stock.move"
 
     def _after_apply_dynamic_routing_rule(self):
-        self._apply_source_relocate()
+        self.with_context(bypass_log_message=True)._apply_source_relocate()
         return self.with_context(exclude_apply_source_relocate=True)
 
     def _after_apply_source_relocate_rule(self, merge=True):

--- a/stock_move_source_relocate_dynamic_routing/tests/test_dynamic_destination.py
+++ b/stock_move_source_relocate_dynamic_routing/tests/test_dynamic_destination.py
@@ -10,8 +10,8 @@ class TestRoutingAndSourceRelocate(TestRoutingPullCommon):
         When a pick move is partially available and the destination is
         re-routed, it is split in 2 moves, one assigned on the re-routed
         destination location and one not assigned relocated and then re-routed
-        to that same destination location. As both pick moves are going to the
-        same destination location, ensure the ship move is not split.
+        to that same destination location. As both pick moves have the same source
+        location, they get merged. Also ensure the ship move is not split.
 
         This test is similar to test_change_dest_move_source_split in
         stock_dynamic_routing/tests/test_routing_pull except that no move_d is created
@@ -70,44 +70,30 @@ class TestRoutingAndSourceRelocate(TestRoutingPullCommon):
         self._update_product_qty_in_location(self.location_hb_1_2, move_a.product_id, 6)
         pick_picking.action_assign()
 
-        move_c = (
-            self.env["stock.picking"]
-            .search([("picking_type_id", "=", self.pick_type_routing_op.id)])
-            .move_ids
-        ) - move_a
         self.assertRecordValues(
-            move_a | move_b | move_c,
+            move_a | move_b,
             [
                 {
-                    "product_qty": 4,
+                    "product_qty": 10,
                     "move_orig_ids": [],
                     "move_dest_ids": move_b.ids,
-                    "state": "confirmed",
+                    "state": "partially_available",
                     "location_id": self.location_hb.id,
                     "location_dest_id": area1.id,
                 },
                 {
                     "product_qty": 10,
-                    "move_orig_ids": (move_c | move_a).ids,
+                    "move_orig_ids": move_a.ids,
                     "move_dest_ids": [],
                     "state": "waiting",
                     "location_id": area1.id,
                     "location_dest_id": self.customer_loc.id,
-                },
-                {
-                    "product_qty": 6,
-                    "move_orig_ids": [],
-                    "move_dest_ids": move_b.ids,
-                    "state": "assigned",
-                    "location_id": self.location_hb.id,
-                    "location_dest_id": area1.id,
                 },
             ],
         )
 
         self.assertEqual(move_a.picking_id.picking_type_id, self.pick_type_routing_op)
         self.assertEqual(move_b.picking_id.picking_type_id, pick_type_routing_delivery)
-        self.assertEqual(move_c.picking_id.picking_type_id, self.pick_type_routing_op)
 
     def test_prepickship_with_routing_and_relocate(self):
         """Check that if a pick move is waiting another move, the ship move is not split


### PR DESCRIPTION
## stock_dynamic_routing: _action_assign
    
Do not call _action_assign inside _action_assign but use super().
Add hook for relocate before updating next moves.


## stock_move_source_relocate_dynamic_routing:

Use new hooks to ensure relocate is called just after the dynamic routing on the picking and before the dynamic routing on the next moves.  This allows moves to be merged back and prevents chained moves to be split.

Depends on:
* https://github.com/OCA/stock-logistics-workflow/pull/2291

Relates also to:
* https://github.com/OCA/stock-logistics-workflow/pull/2290
* https://github.com/OCA/stock-logistics-workflow/pull/2296

Other related perf improvements:
* https://github.com/OCA/stock-logistics-workflow/pull/2298 
* https://github.com/OCA/stock-logistics-reservation/pull/52

cc @grindtildeath @mmequignon @rousseldenis