### PR TITLE
[18.0][IMP] stock_dynamic_routing: remove logged message

### DIFF
--- a/stock_dynamic_routing/models/__init__.py
+++ b/stock_dynamic_routing/models/__init__.py
@@ -1,5 +1,6 @@
 from . import stock_location
 from . import stock_move
+from . import stock_move_line
 from . import stock_picking
 from . import stock_routing
 from . import stock_routing_rule

--- a/stock_dynamic_routing/models/stock_move.py
+++ b/stock_dynamic_routing/models/stock_move.py
@@ -239,7 +239,9 @@ class StockMove(models.Model):
                     )
                     == 1
                 ):
-                    new_move_vals = move._split(qty)
+                    new_move_vals = move.with_context(bypass_log_message=True)._split(
+                        qty
+                    )
                 if new_move_vals:
                     new_move = self.env["stock.move"].create(new_move_vals)
                     new_move._action_confirm(merge=False)

--- a/stock_dynamic_routing/models/stock_move_line.py
+++ b/stock_dynamic_routing/models/stock_move_line.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def _log_message(self, record, move, template, vals):
+        if self.env.context.get("bypass_log_message"):
+            return
+        super()._log_message(record, move, template, vals)
+        return


### PR DESCRIPTION
Do not log that the initial demand has been updated when the move is split. The demand is still the same, it's just split in 2 moves.

This also increases the performance as logging that message is quite slow.

cc @grindtildeath @mmequignon @rousseldenis