### PR TITLE
[18.0][FIX] stock_move_line_expiration_date_required: consider dropshipping

### DIFF
--- a/stock_move_line_expiration_date_required/views/stock_move_line_view.xml
+++ b/stock_move_line_expiration_date_required/views/stock_move_line_view.xml
@@ -10,7 +10,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='expiration_date']" position="attributes">
                 <attribute name="column_invisible">
-                    not parent.use_expiration_date or parent.picking_code != 'incoming'
+                    not parent.use_expiration_date or parent.picking_code not in ['incoming', 'dropship']
                 </attribute>
                 <attribute name="readonly">
                     picking_type_use_existing_lots


### PR DESCRIPTION
Dropship operations a receptions disguised as customer deliveries. In any case, we should be able to handle expiration dates as in core.

Now we can see the column:

<img width="990" height="470" alt="image" src="https://github.com/user-attachments/assets/c4d1ff28-3c12-465d-821f-e63a638bd186" />


cc @moduon MT-14398


please review @Shide @Gelojr : do you think dropshipings should have mandatory expiration date as well?