### PR TITLE
[18.0][FIX] stock_picking_purchase_order: bring back smart button to link to purchase

### DIFF
--- a/stock_picking_purchase_order_link/README.rst
+++ b/stock_picking_purchase_order_link/README.rst
@@ -43,7 +43,9 @@ To use this module, you need to:
 
 1. Go to *Purchase > Products* and create one of type "Stockable".
 2. Go to *Purchase > Purchase Orders* and create one and confirm.
-3. Go to Picking > Additional Info, then navigate to the Purchase Order.
+3. Go to the picking generated clicking in shipment smartbutton.
+4. In the picking appears a new smartbutton to navigate to the purchase
+   order called *Purchase Order*.
 
 Bug Tracker
 ===========

--- a/stock_picking_purchase_order_link/__init__.py
+++ b/stock_picking_purchase_order_link/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_purchase_order_link/i18n/es.po
+++ b/stock_picking_purchase_order_link/i18n/es.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-03-27 10:26+0000\n"
 "PO-Revision-Date: 2024-03-27 10:26+0000\n"
@@ -16,8 +16,12 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#~ msgid "Purchase Order"
-#~ msgstr "Pedido de compra"
+#. module: stock_picking_purchase_order_link
+#: model_terms:ir.ui.view,arch_db:stock_picking_purchase_order_link.view_picking_form
+msgid "Purchase Order"
+msgstr "Pedido de compra"
 
-#~ msgid "Transfer"
-#~ msgstr "Albarán"
+#. module: stock_picking_purchase_order_link
+#: model:ir.model,name:stock_picking_purchase_order_link.model_stock_picking
+msgid "Transfer"
+msgstr "Albarán"

--- a/stock_picking_purchase_order_link/i18n/fr.po
+++ b/stock_picking_purchase_order_link/i18n/fr.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-03-27 10:25+0000\n"
 "PO-Revision-Date: 2024-03-27 10:25+0000\n"
@@ -16,8 +16,12 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#~ msgid "Purchase Order"
-#~ msgstr "Bon de commande"
+#. module: stock_picking_purchase_order_link
+#: model_terms:ir.ui.view,arch_db:stock_picking_purchase_order_link.view_picking_form
+msgid "Purchase Order"
+msgstr "Bon de commande"
 
-#~ msgid "Transfer"
-#~ msgstr "Transfert"
+#. module: stock_picking_purchase_order_link
+#: model:ir.model,name:stock_picking_purchase_order_link.model_stock_picking
+msgid "Transfer"
+msgstr "Transfert"

--- a/stock_picking_purchase_order_link/i18n/it.po
+++ b/stock_picking_purchase_order_link/i18n/it.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-03-27 10:24+0000\n"
 "PO-Revision-Date: 2024-03-27 10:24+0000\n"
@@ -16,8 +16,12 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#~ msgid "Purchase Order"
-#~ msgstr "Ordine di acquisto"
+#. module: stock_picking_purchase_order_link
+#: model_terms:ir.ui.view,arch_db:stock_picking_purchase_order_link.view_picking_form
+msgid "Purchase Order"
+msgstr "Ordine di acquisto"
 
-#~ msgid "Transfer"
-#~ msgstr "Trasferimento"
+#. module: stock_picking_purchase_order_link
+#: model:ir.model,name:stock_picking_purchase_order_link.model_stock_picking
+msgid "Transfer"
+msgstr "Trasferimento"

--- a/stock_picking_purchase_order_link/i18n/pt_BR.po
+++ b/stock_picking_purchase_order_link/i18n/pt_BR.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-03-27 10:23+0000\n"
 "PO-Revision-Date: 2024-03-27 10:23+0000\n"
@@ -16,8 +16,12 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#~ msgid "Purchase Order"
-#~ msgstr "Pedido Compra"
+#. module: stock_picking_purchase_order_link
+#: model_terms:ir.ui.view,arch_db:stock_picking_purchase_order_link.view_picking_form
+msgid "Purchase Order"
+msgstr "Pedido Compra"
 
-#~ msgid "Transfer"
-#~ msgstr "Transferência"
+#. module: stock_picking_purchase_order_link
+#: model:ir.model,name:stock_picking_purchase_order_link.model_stock_picking
+msgid "Transfer"
+msgstr "Transferência"

--- a/stock_picking_purchase_order_link/i18n/stock_picking_purchase_order_link.pot
+++ b/stock_picking_purchase_order_link/i18n/stock_picking_purchase_order_link.pot
@@ -1,5 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
+# 	* stock_picking_purchase_order_link
 #
 msgid ""
 msgstr ""
@@ -11,3 +12,13 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: stock_picking_purchase_order_link
+#: model_terms:ir.ui.view,arch_db:stock_picking_purchase_order_link.view_picking_form
+msgid "Purchase Order"
+msgstr ""
+
+#. module: stock_picking_purchase_order_link
+#: model:ir.model,name:stock_picking_purchase_order_link.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/stock_picking_purchase_order_link/models/__init__.py
+++ b/stock_picking_purchase_order_link/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/stock_picking_purchase_order_link/models/stock_picking.py
+++ b/stock_picking_purchase_order_link/models/stock_picking.py
@@ -1,0 +1,21 @@
+# Copyright 2019 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def action_view_purchase_order(self):
+        """This function returns an action that display existing purchase order
+        of given picking.
+        """
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "purchase.purchase_form_action"
+        )
+        form = self.env.ref("purchase.purchase_order_form")
+        action["views"] = [(form.id, "form")]
+        action["res_id"] = self.purchase_id.id
+        return action

--- a/stock_picking_purchase_order_link/readme/USAGE.md
+++ b/stock_picking_purchase_order_link/readme/USAGE.md
@@ -2,4 +2,6 @@ To use this module, you need to:
 
 1.  Go to *Purchase \> Products* and create one of type "Stockable".
 2.  Go to *Purchase \> Purchase Orders* and create one and confirm.
-3.  Go to Picking > Additional Info, then navigate to the Purchase Order.
+3.  Go to the picking generated clicking in shipment smartbutton.
+4.  In the picking appears a new smartbutton to navigate to the purchase
+    order called *Purchase Order*.

--- a/stock_picking_purchase_order_link/static/description/index.html
+++ b/stock_picking_purchase_order_link/static/description/index.html
@@ -391,7 +391,9 @@ to purchase order that creates the picking.</p>
 <ol class="arabic simple">
 <li>Go to <em>Purchase &gt; Products</em> and create one of type “Stockable”.</li>
 <li>Go to <em>Purchase &gt; Purchase Orders</em> and create one and confirm.</li>
-<li>Go to Picking &gt; Additional Info, then navigate to the Purchase Order.</li>
+<li>Go to the picking generated clicking in shipment smartbutton.</li>
+<li>In the picking appears a new smartbutton to navigate to the purchase
+order called <em>Purchase Order</em>.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">

--- a/stock_picking_purchase_order_link/tests/__init__.py
+++ b/stock_picking_purchase_order_link/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_picking_purchase_order_link

--- a/stock_picking_purchase_order_link/tests/test_stock_picking_purchase_order_link.py
+++ b/stock_picking_purchase_order_link/tests/test_stock_picking_purchase_order_link.py
@@ -1,0 +1,55 @@
+# Copyright 2019 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from datetime import date
+
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestStockPickingPurchaseOrderLink(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.stock_location_obj = cls.env["stock.location"]
+        cls.stock_picking_type_obj = cls.env["stock.picking.type"]
+        cls.stock_picking_obj = cls.env["stock.picking"]
+        cls.product_product_obj = cls.env["product.product"]
+        cls.warehouse = cls.env["stock.warehouse"].create(
+            {"name": "warehouse - test", "code": "WH-TEST"}
+        )
+        cls.product = cls.product_product_obj.create(
+            {
+                "name": "product_template_obj - Test",
+                "type": "consu",
+                "standard_price": 100.00,
+            }
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Vendor - test"})
+        cls.picking_type = cls.stock_picking_type_obj.search(
+            [("warehouse_id", "=", cls.warehouse.id), ("code", "=", "incoming")]
+        )
+        purchase_order = cls.env["purchase.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "name": cls.product.name,
+                            "product_id": cls.product.id,
+                            "product_qty": 1.0,
+                            "product_uom": cls.product.uom_po_id.id,
+                            "price_unit": 10.0,
+                            "date_planned": date.today(),
+                        },
+                    )
+                ],
+            }
+        )
+        purchase_order.button_confirm()
+        cls.picking = cls.stock_picking_obj.search(
+            [("purchase_id", "=", purchase_order.id)]
+        )
+
+    def test_picking_to_purchase_order(self):
+        result = self.picking.action_view_purchase_order()
+        self.assertEqual(result["res_id"], self.picking.purchase_id.id)

--- a/stock_picking_purchase_order_link/views/stock_picking_view.xml
+++ b/stock_picking_purchase_order_link/views/stock_picking_view.xml
@@ -6,6 +6,17 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_view_purchase_order"
+                    class="oe_stat_button"
+                    type="object"
+                    icon="fa-shopping-cart"
+                    string="Purchase Order"
+                    invisible="not purchase_id"
+                    groups="stock.group_stock_user"
+                />
+            </xpath>
             <xpath expr="//field[@name='group_id']" position="after">
                 <field name="purchase_id" />
             </xpath>


### PR DESCRIPTION
As per https://github.com/OCA/stock-logistics-workflow/pull/1809#issuecomment-4250039896