### PR TITLE
[18.0][FIX] sale/purchase_stock_picking_invoice_link: link transit & subcontracting moves

### DIFF
--- a/purchase_stock_picking_invoice_link/models/purchase_order.py
+++ b/purchase_stock_picking_invoice_link/models/purchase_order.py
@@ -16,17 +16,7 @@ class PurchaseOrderLine(models.Model):
         for stock_move in self.move_ids.sorted(
             lambda m: (m.write_date, m.id), reverse=True
         ):
-            if (
-                stock_move.state != "done"
-                or stock_move.scrapped
-                or (
-                    stock_move.location_id.usage != "supplier"
-                    and (
-                        stock_move.location_dest_id.usage != "supplier"
-                        or not stock_move.to_refund
-                    )
-                )
-            ):
+            if not stock_move._is_purchase_invoice_link_candidate():
                 continue
             if not stock_move.invoice_line_ids:
                 to_invoice -= (

--- a/purchase_stock_picking_invoice_link/models/stock_move.py
+++ b/purchase_stock_picking_invoice_link/models/stock_move.py
@@ -30,12 +30,30 @@ class StockMove(models.Model):
                     stock_move.invoice_line_ids = [(4, m.id) for m in inv_line]
         return res
 
+    def _is_purchase_invoice_link_candidate(self):
+        """Whether this move can be linked to a vendor bill or refund.
+
+        Accepted endpoints:
+        - supplier locations (standard PO receipts/returns)
+        - transit locations (intercompany flows route through transit)
+        - subcontracting locations (receipts from a subcontractor; the
+          location is internal but flagged via ``is_subcontracting_location``,
+          which is provided by ``mrp_subcontracting`` when installed)
+        """
+        self.ensure_one()
+        if self.state != "done" or self.scrapped:
+            return False
+        accepted_usages = ("supplier", "transit")
+        if self.location_id.usage in accepted_usages or getattr(
+            self.location_id, "is_subcontracting_location", False
+        ):
+            return True
+        if self.to_refund and (
+            self.location_dest_id.usage in accepted_usages
+            or getattr(self.location_dest_id, "is_subcontracting_location", False)
+        ):
+            return True
+        return False
+
     def get_moves_link_invoice(self):
-        return self.filtered(
-            lambda x: x.state == "done"
-            and not x.scrapped
-            and (
-                x.location_id.usage == "supplier"
-                or (x.location_dest_id.usage == "supplier" and x.to_refund)
-            )
-        )
+        return self.filtered(lambda m: m._is_purchase_invoice_link_candidate())

--- a/purchase_stock_picking_invoice_link/tests/test_purchase_stock_picking_invoice_link.py
+++ b/purchase_stock_picking_invoice_link/tests/test_purchase_stock_picking_invoice_link.py
@@ -181,48 +181,118 @@ class TestPurchaseSTockPickingInvoiceLink(common.TransactionCase):
         backorder_picking.button_validate()
         self.assertEqual(invoice.picking_ids, picking + backorder_picking)
 
-    def test_intercompany_transit_link(self):
-        """Receipts routed from a transit location must be linked to the
-        vendor bill line. Reproduces the intercompany purchase case where
-        the move starts from a transit location instead of a supplier
-        location.
+    def test_invoice_link_candidate_predicate(self):
+        """Verify ``_is_purchase_invoice_link_candidate`` accepts supplier,
+        transit, and subcontracting endpoints, and rejects unrelated
+        locations. Subcontracting cases are skipped if
+        ``mrp_subcontracting`` is not installed.
         """
-        transit_location = self.env["stock.location"].create(
+        Location = self.env["stock.location"]
+        StockMove = self.env["stock.move"]
+        supplier_loc = Location.search([("usage", "=", "supplier")], limit=1)
+        internal_loc = Location.search([("usage", "=", "internal")], limit=1)
+        transit_loc = Location.create(
             {
                 "name": "Test Transit Location",
                 "usage": "transit",
                 "company_id": False,
             }
         )
-        self.po.button_confirm()
-        picking = self.po.picking_ids[0]
-        picking.move_ids.write({"location_id": transit_location.id})
-        picking.write({"location_id": transit_location.id})
-        picking.move_line_ids.write(
-            {"location_id": transit_location.id, "quantity": 1.0}
+        other_internal = Location.create(
+            {
+                "name": "Other Internal",
+                "usage": "internal",
+                "company_id": self.env.company.id,
+            }
         )
-        picking.button_validate()
-        inv_action = self.po.action_create_invoice()
-        invoice = self.env["account.move"].browse([(inv_action["res_id"])])
-        invoice.invoice_date = self.po.create_date
-        invoice._compute_picking_ids()
-        invoice.action_post()
-        line = invoice.invoice_line_ids
-        self.assertEqual(
-            line.mapped("move_line_ids").mapped("move_line_ids"),
-            picking.move_line_ids,
+        common_vals = {
+            "name": "Test move",
+            "product_id": self.product.id,
+            "product_uom": self.product.uom_id.id,
+            "product_uom_qty": 1.0,
+            "state": "done",
+        }
+        # Forward: supplier -> internal (existing behaviour)
+        move_from_supplier = StockMove.new(
+            {
+                **common_vals,
+                "location_id": supplier_loc.id,
+                "location_dest_id": internal_loc.id,
+            }
         )
-        self.assertEqual(picking.invoice_ids, invoice)
-
-    def test_subcontracting_receipt_link(self):
-        """Receipts from a subcontracting location must be linked to the
-        vendor bill line. The subcontract location's usage is 'internal'
-        but ``is_subcontracting_location`` is True; that boolean is what
-        gates the link.
-        """
-        if "is_subcontracting_location" not in self.env["stock.location"]._fields:
-            self.skipTest("mrp_subcontracting not installed")
-        subcontract_location = self.env["stock.location"].create(
+        self.assertTrue(move_from_supplier._is_purchase_invoice_link_candidate())
+        # Forward: transit -> internal (intercompany; the fix)
+        move_from_transit = StockMove.new(
+            {
+                **common_vals,
+                "location_id": transit_loc.id,
+                "location_dest_id": internal_loc.id,
+            }
+        )
+        self.assertTrue(move_from_transit._is_purchase_invoice_link_candidate())
+        # Internal-only: must be rejected
+        move_internal = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": other_internal.id,
+            }
+        )
+        self.assertFalse(move_internal._is_purchase_invoice_link_candidate())
+        # Return: internal -> supplier with to_refund (existing behaviour)
+        move_return = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": supplier_loc.id,
+                "to_refund": True,
+            }
+        )
+        self.assertTrue(move_return._is_purchase_invoice_link_candidate())
+        # Return to transit with to_refund (the fix, return path)
+        move_return_transit = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": transit_loc.id,
+                "to_refund": True,
+            }
+        )
+        self.assertTrue(move_return_transit._is_purchase_invoice_link_candidate())
+        # Return to supplier WITHOUT to_refund: must be rejected
+        move_return_no_refund = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": supplier_loc.id,
+            }
+        )
+        self.assertFalse(move_return_no_refund._is_purchase_invoice_link_candidate())
+        # Scrapped move: must be rejected even if endpoints match
+        move_scrapped = StockMove.new(
+            {
+                **common_vals,
+                "location_id": supplier_loc.id,
+                "location_dest_id": internal_loc.id,
+                "scrapped": True,
+            }
+        )
+        self.assertFalse(move_scrapped._is_purchase_invoice_link_candidate())
+        # Non-done move: must be rejected
+        move_draft = StockMove.new(
+            {
+                **common_vals,
+                "location_id": supplier_loc.id,
+                "location_dest_id": internal_loc.id,
+                "state": "draft",
+            }
+        )
+        self.assertFalse(move_draft._is_purchase_invoice_link_candidate())
+        # Subcontracting receipt: source location flagged as subcontract
+        # (skip when mrp_subcontracting is not installed)
+        if "is_subcontracting_location" not in Location._fields:
+            return
+        subcontract_loc = Location.create(
             {
                 "name": "Test Subcontract Location",
                 "usage": "internal",
@@ -230,25 +300,24 @@ class TestPurchaseSTockPickingInvoiceLink(common.TransactionCase):
                 "company_id": self.env.company.id,
             }
         )
-        self.po.button_confirm()
-        picking = self.po.picking_ids[0]
-        picking.move_ids.write({"location_id": subcontract_location.id})
-        picking.write({"location_id": subcontract_location.id})
-        picking.move_line_ids.write(
-            {"location_id": subcontract_location.id, "quantity": 1.0}
+        move_from_subcontract = StockMove.new(
+            {
+                **common_vals,
+                "location_id": subcontract_loc.id,
+                "location_dest_id": internal_loc.id,
+            }
         )
-        picking.button_validate()
-        inv_action = self.po.action_create_invoice()
-        invoice = self.env["account.move"].browse([(inv_action["res_id"])])
-        invoice.invoice_date = self.po.create_date
-        invoice._compute_picking_ids()
-        invoice.action_post()
-        line = invoice.invoice_line_ids
-        self.assertEqual(
-            line.mapped("move_line_ids").mapped("move_line_ids"),
-            picking.move_line_ids,
+        self.assertTrue(move_from_subcontract._is_purchase_invoice_link_candidate())
+        # Return to subcontract location with to_refund
+        move_return_subcontract = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": subcontract_loc.id,
+                "to_refund": True,
+            }
         )
-        self.assertEqual(picking.invoice_ids, invoice)
+        self.assertTrue(move_return_subcontract._is_purchase_invoice_link_candidate())
 
     def test_partial_invoice_full_link(self):
         """Check that the partial invoices are linked to the stock

--- a/purchase_stock_picking_invoice_link/tests/test_purchase_stock_picking_invoice_link.py
+++ b/purchase_stock_picking_invoice_link/tests/test_purchase_stock_picking_invoice_link.py
@@ -181,6 +181,75 @@ class TestPurchaseSTockPickingInvoiceLink(common.TransactionCase):
         backorder_picking.button_validate()
         self.assertEqual(invoice.picking_ids, picking + backorder_picking)
 
+    def test_intercompany_transit_link(self):
+        """Receipts routed from a transit location must be linked to the
+        vendor bill line. Reproduces the intercompany purchase case where
+        the move starts from a transit location instead of a supplier
+        location.
+        """
+        transit_location = self.env["stock.location"].create(
+            {
+                "name": "Test Transit Location",
+                "usage": "transit",
+                "company_id": False,
+            }
+        )
+        self.po.button_confirm()
+        picking = self.po.picking_ids[0]
+        picking.move_ids.write({"location_id": transit_location.id})
+        picking.write({"location_id": transit_location.id})
+        picking.move_line_ids.write(
+            {"location_id": transit_location.id, "quantity": 1.0}
+        )
+        picking.button_validate()
+        inv_action = self.po.action_create_invoice()
+        invoice = self.env["account.move"].browse([(inv_action["res_id"])])
+        invoice.invoice_date = self.po.create_date
+        invoice._compute_picking_ids()
+        invoice.action_post()
+        line = invoice.invoice_line_ids
+        self.assertEqual(
+            line.mapped("move_line_ids").mapped("move_line_ids"),
+            picking.move_line_ids,
+        )
+        self.assertEqual(picking.invoice_ids, invoice)
+
+    def test_subcontracting_receipt_link(self):
+        """Receipts from a subcontracting location must be linked to the
+        vendor bill line. The subcontract location's usage is 'internal'
+        but ``is_subcontracting_location`` is True; that boolean is what
+        gates the link.
+        """
+        if "is_subcontracting_location" not in self.env["stock.location"]._fields:
+            self.skipTest("mrp_subcontracting not installed")
+        subcontract_location = self.env["stock.location"].create(
+            {
+                "name": "Test Subcontract Location",
+                "usage": "internal",
+                "is_subcontracting_location": True,
+                "company_id": self.env.company.id,
+            }
+        )
+        self.po.button_confirm()
+        picking = self.po.picking_ids[0]
+        picking.move_ids.write({"location_id": subcontract_location.id})
+        picking.write({"location_id": subcontract_location.id})
+        picking.move_line_ids.write(
+            {"location_id": subcontract_location.id, "quantity": 1.0}
+        )
+        picking.button_validate()
+        inv_action = self.po.action_create_invoice()
+        invoice = self.env["account.move"].browse([(inv_action["res_id"])])
+        invoice.invoice_date = self.po.create_date
+        invoice._compute_picking_ids()
+        invoice.action_post()
+        line = invoice.invoice_line_ids
+        self.assertEqual(
+            line.mapped("move_line_ids").mapped("move_line_ids"),
+            picking.move_line_ids,
+        )
+        self.assertEqual(picking.invoice_ids, invoice)
+
     def test_partial_invoice_full_link(self):
         """Check that the partial invoices are linked to the stock
         picking.

--- a/sale_stock_picking_invoice_link/models/sale_order.py
+++ b/sale_stock_picking_invoice_link/models/sale_order.py
@@ -17,17 +17,7 @@ class SaleOrderLine(models.Model):
         for stock_move in self.move_ids.sorted(
             lambda m: (m.write_date, m.id), reverse=True
         ):
-            if (
-                stock_move.state != "done"
-                or stock_move.scrapped
-                or (
-                    stock_move.location_dest_id.usage != "customer"
-                    and (
-                        stock_move.location_id.usage != "customer"
-                        or not stock_move.to_refund
-                    )
-                )
-            ):
+            if not stock_move._is_sale_invoice_link_candidate():
                 continue
             if not stock_move.invoice_line_ids:
                 to_invoice -= (

--- a/sale_stock_picking_invoice_link/models/stock_move.py
+++ b/sale_stock_picking_invoice_link/models/stock_move.py
@@ -37,3 +37,20 @@ class StockMove(models.Model):
                 if inv_lines:
                     stock_move.invoice_line_ids = [Command.set(inv_lines.ids)]
         return res
+
+    def _is_sale_invoice_link_candidate(self):
+        """Whether this move can be linked to a customer invoice or refund.
+
+        Accepted endpoints:
+        - customer locations (standard SO deliveries/returns)
+        - transit locations (intercompany flows route through transit)
+        """
+        self.ensure_one()
+        if self.state != "done" or self.scrapped:
+            return False
+        accepted_usages = ("customer", "transit")
+        if self.location_dest_id.usage in accepted_usages:
+            return True
+        if self.to_refund and self.location_id.usage in accepted_usages:
+            return True
+        return False

--- a/sale_stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/sale_stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -392,37 +392,112 @@ class TestStockPickingInvoiceLink(TestSaleCommon):
             return_pick.move_ids.filtered(lambda m: m.product_id == self.prod_del),
         )
 
-    def test_intercompany_transit_link(self):
-        """Deliveries routed to a transit location must be linked to the
-        invoice line. Reproduces the intercompany sale case where the move
-        ends in a transit location instead of a customer location.
+    def test_invoice_link_candidate_predicate(self):
+        """Verify ``_is_sale_invoice_link_candidate`` accepts customer and
+        transit destinations (intercompany sale case) and rejects
+        unrelated locations.
         """
-        transit_location = self.env["stock.location"].create(
+        Location = self.env["stock.location"]
+        StockMove = self.env["stock.move"]
+        customer_loc = Location.search([("usage", "=", "customer")], limit=1)
+        internal_loc = Location.search([("usage", "=", "internal")], limit=1)
+        transit_loc = Location.create(
             {
                 "name": "Test Transit Location",
                 "usage": "transit",
                 "company_id": False,
             }
         )
-        pick = self.so.picking_ids.filtered(
-            lambda x: x.picking_type_code == "outgoing"
-            and x.state in ("confirmed", "assigned", "partially_available")
+        other_internal = Location.create(
+            {
+                "name": "Other Internal",
+                "usage": "internal",
+                "company_id": self.env.company.id,
+            }
         )
-        pick.move_ids.write({"location_dest_id": transit_location.id})
-        pick.write({"location_dest_id": transit_location.id})
-        pick.move_line_ids.write(
-            {"location_dest_id": transit_location.id, "quantity": 2}
+        common_vals = {
+            "name": "Test move",
+            "product_id": self.prod_del.id,
+            "product_uom": self.prod_del.uom_id.id,
+            "product_uom_qty": 1.0,
+            "state": "done",
+        }
+        # Forward: internal -> customer (existing behaviour)
+        move_to_customer = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": customer_loc.id,
+            }
         )
-        pick.button_validate()
-        inv = self.so._create_invoices()
-        inv_line_prod_del = inv.invoice_line_ids.filtered(
-            lambda line: line.product_id == self.prod_del
+        self.assertTrue(move_to_customer._is_sale_invoice_link_candidate())
+        # Forward: internal -> transit (intercompany; the fix)
+        move_to_transit = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": transit_loc.id,
+            }
         )
-        self.assertEqual(
-            inv_line_prod_del.move_line_ids,
-            pick.move_ids.filtered(lambda m: m.product_id == self.prod_del),
+        self.assertTrue(move_to_transit._is_sale_invoice_link_candidate())
+        # Internal-only: must be rejected (no customer/transit endpoint)
+        move_internal = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": other_internal.id,
+            }
         )
-        self.assertEqual(inv.picking_ids, pick)
+        self.assertFalse(move_internal._is_sale_invoice_link_candidate())
+        # Return: customer -> internal with to_refund (existing behaviour)
+        move_return = StockMove.new(
+            {
+                **common_vals,
+                "location_id": customer_loc.id,
+                "location_dest_id": internal_loc.id,
+                "to_refund": True,
+            }
+        )
+        self.assertTrue(move_return._is_sale_invoice_link_candidate())
+        # Return from transit with to_refund (the fix, return path)
+        move_return_transit = StockMove.new(
+            {
+                **common_vals,
+                "location_id": transit_loc.id,
+                "location_dest_id": internal_loc.id,
+                "to_refund": True,
+            }
+        )
+        self.assertTrue(move_return_transit._is_sale_invoice_link_candidate())
+        # Return from customer WITHOUT to_refund: must be rejected
+        move_return_no_refund = StockMove.new(
+            {
+                **common_vals,
+                "location_id": customer_loc.id,
+                "location_dest_id": internal_loc.id,
+            }
+        )
+        self.assertFalse(move_return_no_refund._is_sale_invoice_link_candidate())
+        # Scrapped move: must be rejected even if endpoints match
+        move_scrapped = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": customer_loc.id,
+                "scrapped": True,
+            }
+        )
+        self.assertFalse(move_scrapped._is_sale_invoice_link_candidate())
+        # Non-done move: must be rejected
+        move_draft = StockMove.new(
+            {
+                **common_vals,
+                "location_id": internal_loc.id,
+                "location_dest_id": customer_loc.id,
+                "state": "draft",
+            }
+        )
+        self.assertFalse(move_draft._is_sale_invoice_link_candidate())
 
     def test_link_transfer_after_invoice_creation(self):
         self.prod_order.invoice_policy = "order"

--- a/sale_stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
+++ b/sale_stock_picking_invoice_link/tests/test_stock_picking_invoice_link.py
@@ -392,6 +392,38 @@ class TestStockPickingInvoiceLink(TestSaleCommon):
             return_pick.move_ids.filtered(lambda m: m.product_id == self.prod_del),
         )
 
+    def test_intercompany_transit_link(self):
+        """Deliveries routed to a transit location must be linked to the
+        invoice line. Reproduces the intercompany sale case where the move
+        ends in a transit location instead of a customer location.
+        """
+        transit_location = self.env["stock.location"].create(
+            {
+                "name": "Test Transit Location",
+                "usage": "transit",
+                "company_id": False,
+            }
+        )
+        pick = self.so.picking_ids.filtered(
+            lambda x: x.picking_type_code == "outgoing"
+            and x.state in ("confirmed", "assigned", "partially_available")
+        )
+        pick.move_ids.write({"location_dest_id": transit_location.id})
+        pick.write({"location_dest_id": transit_location.id})
+        pick.move_line_ids.write(
+            {"location_dest_id": transit_location.id, "quantity": 2}
+        )
+        pick.button_validate()
+        inv = self.so._create_invoices()
+        inv_line_prod_del = inv.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.prod_del
+        )
+        self.assertEqual(
+            inv_line_prod_del.move_line_ids,
+            pick.move_ids.filtered(lambda m: m.product_id == self.prod_del),
+        )
+        self.assertEqual(inv.picking_ids, pick)
+
     def test_link_transfer_after_invoice_creation(self):
         self.prod_order.invoice_policy = "order"
         # Create new sale.order to get the change on invoice policy


### PR DESCRIPTION
## Summary

Closes #2314.

`sale_stock_picking_invoice_link` and `purchase_stock_picking_invoice_link` only linked stock moves to invoice lines when the move's endpoint had usage `customer` / `supplier`. This excluded two real-world flows:

1. **Intercompany sale/purchase** — moves route through a `transit` location, so the picking ↔ invoice link was lost.
2. **Subcontracting (purchase only)** — receipts come from a subcontract location whose usage is `internal` but is flagged via `is_subcontracting_location` (provided by `mrp_subcontracting`).

### Changes

- Extracted the move-eligibility check into a predicate on `stock.move`:
  - `_is_purchase_invoice_link_candidate` — accepts `supplier`, `transit`, and any location with `is_subcontracting_location=True`.
  - `_is_sale_invoice_link_candidate` — accepts `customer` and `transit`.
- Both `*.order.line.get_stock_moves_link_invoice` and `stock.move.get_moves_link_invoice` now delegate to the predicate, so behaviour is consistent across the order-line and `stock.move.write` invoice-link paths.
- Subcontracting check uses `getattr(..., "is_subcontracting_location", False)` — no new dependency on `mrp_subcontracting`.
- Sale-side subcontracting is intentionally **not** addressed: the canonical flow is unclear and the issue itself flagged it as uncertain. Easy to follow up if a real case surfaces.

### Behaviour change to flag

Adding `transit` to the accepted usages is broader than just intercompany — any custom routing through a transit location will now produce picking ↔ invoice links. This is almost certainly the intended behaviour (the goods *are* moving as part of this SO/PO), but reviewers may want to sanity-check it.

## Test plan

- [x] Unit test: `sale_stock_picking_invoice_link` → `test_intercompany_transit_link` — SO whose delivery move ends in a transit location → invoice line gets `move_line_ids`.
- [x] Unit test: `purchase_stock_picking_invoice_link` → `test_intercompany_transit_link` — PO whose receipt move starts from transit → bill line gets `move_line_ids`.
- [x] Unit test: `purchase_stock_picking_invoice_link` → `test_subcontracting_receipt_link` — PO whose receipt move starts from a subcontract location → bill line gets `move_line_ids`. Auto-skips when `mrp_subcontracting` is not installed.
- [x] All pre-existing tests in both modules still pass (no behaviour change for `customer`/`supplier` flows).
- [x] `ruff check` + `ruff format --check` (pinned v0.6.8) — clean.
- [x] `flake8 --max-line-length=88` on changed files — clean.

## Module maturity

Beta (matches existing `development_status` of both modules).