### PR TITLE
[18.0][FIX] stock_picking_origin_reference_sale: Handle client_order_ref in origin

### DIFF
--- a/stock_picking_origin_reference_sale/models/stock_picking.py
+++ b/stock_picking_origin_reference_sale/models/stock_picking.py
@@ -16,9 +16,17 @@ class StockPicking(models.Model):
         res = super()._compute_origin_reference()
         for picking in self:
             if not picking.origin_reference:
-                rel_sale = self.env[SO_MODEL_NAME].search(
-                    [("name", "=", picking.origin)], limit=1
+                so_name = (
+                    picking.origin.split(" - ")[0]
+                    if picking.origin
+                    and isinstance(picking.origin, str)
+                    and " - " in picking.origin
+                    else picking.origin
                 )
-                if rel_sale:
-                    picking.origin_reference = f"{SO_MODEL_NAME},{rel_sale.id}"
+                if so_name:
+                    rel_sale = self.env[SO_MODEL_NAME].search(
+                        [("name", "=", so_name)], limit=1
+                    )
+                    if rel_sale:
+                        picking.origin_reference = f"{SO_MODEL_NAME},{rel_sale.id}"
         return res

--- a/stock_picking_origin_reference_sale/tests/test_stock_picking_origin_reference_sale.py
+++ b/stock_picking_origin_reference_sale/tests/test_stock_picking_origin_reference_sale.py
@@ -47,3 +47,24 @@ class TestStockPickingOriginReferenceSale(
         self.assertEqual(
             picking.origin_reference, sale, "The Transfer should reference the SO."
         )
+
+    def test_02_check_correct_value_with_client_order_ref(self):
+        """
+        Check Transfer references SO when client_order_ref is set.
+
+        When client_order_ref is set, the picking origin becomes
+        'SO.name - client_order_ref', so we must extract just the SO name.
+        """
+        sale = self._create_sale(self.partner, self.product)
+        sale.client_order_ref = "CUSTOMER_REF_123"
+        sale.action_confirm()
+        self.assertTrue(sale.picking_ids)
+        self.assertEqual(
+            len(sale.picking_ids), 1, "Only one Transfer should be created."
+        )
+        picking = sale.picking_ids
+        self.assertEqual(
+            picking.origin_reference,
+            sale,
+            "Transfer should reference SO with client_order_ref.",
+        )


### PR DESCRIPTION
Fix issue #2116: Module fails to link pickings to SO when client_order_ref is set.

**Root Cause**: When `client_order_ref` is set, the picking origin field contains `SO.name - client_order_ref`, but the search was using the full origin string as the SO name.

**Fix**: Extract the SO name by splitting on ` - ` before searching, with guards for None/False/non-string origins.

**Changes**:
- Modified `_compute_origin_reference` to parse origin correctly
- Added `test_02` for client_order_ref scenario (preserving `test_01` for base case)