### PR TITLE
[18.0][FIX] stock_picking_tier_validation: Fix singleton error in batch transfer validation

### DIFF
--- a/stock_picking_tier_validation/models/stock_picking.py
+++ b/stock_picking_tier_validation/models/stock_picking.py
@@ -19,7 +19,7 @@ class StockPicking(models.Model):
                 # try to validate operation
                 reviews = rec.request_validation()
                 rec._validate_tier(reviews)
-                if self.validation_status != "validated":
+                if rec.validation_status != "validated":
                     raise ValidationError(
                         _(
                             "This action needs to be validated for at least "


### PR DESCRIPTION
Fix singleton error when validating batch transfers with tier validation enabled.

**Root Cause**: Using `self.validation_status` instead of `rec.validation_status` inside a loop iterating over individual records causes a ValueError when multiple pickings are validated together.

**Fix**: Change `self.validation_status` to `rec.validation_status` in the `button_validate` method.

**Before**:
```python
if self.validation_status != "validated":
```

**After**:
```python
if rec.validation_status != "validated":
```