### PR TITLE
[18.0][FIX] stock_picking_group_by_partner_by_carrier: Fix _create_backorder serialization

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -86,22 +86,26 @@ class StockPicking(models.Model):
             return super().action_cancel()
 
     def _create_backorder(self, backorder_moves=None):
-        backorders = self.browse()
+        grouping_disabled = {}
         for picking in self:
-            if not picking._is_grouping_disabled():
-                picking = picking.with_context(picking_no_copy_if_can_group=1)
-            picking_backorder_moves = None
-            if backorder_moves:
-                picking_backorder_moves = backorder_moves.filtered(
-                    lambda x, picking=picking: x.picking_id == picking
-                )
-            backorder = super(StockPicking, picking)._create_backorder(
-                backorder_moves=picking_backorder_moves
-            )
-            if backorder and not picking._is_grouping_disabled():
+            grouping_disabled[picking.id] = picking._is_grouping_disabled()
+        context_update = {
+            "picking_no_copy_if_can_group_dict": {
+                picking_id: not disabled
+                for picking_id, disabled in grouping_disabled.items()
+                if not disabled
+            }
+        }
+        backorders = super(
+            StockPicking, self.with_context(**context_update)
+        )._create_backorder(backorder_moves)
+        for backorder in backorders:
+            original_picking = backorder.backorder_id
+            if original_picking and not grouping_disabled.get(
+                original_picking.id, True
+            ):
                 backorder._merge_procurement_groups()
                 backorder._update_merged_origin()
-            backorders |= backorder
         return backorders
 
     def _prepare_merged_origin(self):
@@ -183,7 +187,10 @@ class StockPicking(models.Model):
         return False
 
     def copy(self, defaults=None):
-        if self.env.context.get("picking_no_copy_if_can_group") and self.move_ids:
+        if (
+            self.env.context.get("picking_no_copy_if_can_group_dict", {}).get(self.id)
+            and self.move_ids
+        ):
             # we are in the process of the creation of a backorder. If we can
             # find a suitable picking, then use it instead of copying the one
             # we are creating a backorder from


### PR DESCRIPTION
Fix issue where batch backorder creation causes incorrect detachment.

**Root Cause**: The `_create_backorder` method calls super per picking, which serializes the batch and prevents proper batch-level handling.

**Fix**: Call super once with the full recordset using a context dictionary to track per-picking grouping flags instead of per-picking serialization.

**Changes**:
- Modify `_create_backorder` to compute grouping flags upfront and call super once
- Update `copy` method to use context dict keyed by picking ID
- Apply grouping (merge\_procurement\_groups, update\_merged\_origin) to backorder results after creation