### PR TITLE
[18.0][FIX] product_customerinfo_picking: fallback to commercial partner

### DIFF
--- a/product_customerinfo_picking/models/stock_move.py
+++ b/product_customerinfo_picking/models/stock_move.py
@@ -8,6 +8,7 @@ class StockMove(models.Model):
 
     @api.depends(
         "picking_id.partner_id",
+        "picking_id.partner_id.commercial_partner_id",
         "product_id",
         "product_id.customer_ids.product_code",
         "product_id.customer_ids.product_name",
@@ -21,13 +22,24 @@ class StockMove(models.Model):
                 and move.picking_id.partner_id
                 and move.product_tmpl_id.customer_ids
             ):
+                partner = move.picking_id.partner_id
                 customer = fields.first(
                     move.product_tmpl_id.customer_ids.filtered(
-                        lambda m, mo=move: m.partner_id == mo.picking_id.partner_id
+                        lambda m, p=partner: m.partner_id == p
                     )
                 )
-                product_customer_code = customer.product_code
-                product_customer_name = customer.product_name
+                if not customer:
+                    # Fallback to commercial partner if direct match fails
+                    # (e.g. delivery address is a child contact)
+                    partner = partner.commercial_partner_id
+                    customer = fields.first(
+                        move.product_tmpl_id.customer_ids.filtered(
+                            lambda m, p=partner: m.partner_id == p
+                        )
+                    )
+                if customer:
+                    product_customer_code = customer.product_code
+                    product_customer_name = customer.product_name
             move.product_customer_code = product_customer_code
             move.product_customer_name = product_customer_name
 


### PR DESCRIPTION
When the delivery address (`picking_id.partner_id`) is a child contact of the customer, the customer product codes are stored on the `commercial_partner_id` (parent). Since the code only matched against the direct partner, it would not find the customer-specific codes.

**Fix**: After an initial direct match fails, fall back to `partner_id.commercial_partner_id` to find the customer product code/name.

Also added `picking_id.partner_id.commercial_partner_id` to `@api.depends` so the compute triggers when the commercial partner changes.

Closes #2272