### PR TITLE
[Fix] [19.0] sale_stock_partner_delivery_window: warning allways trigger

### DIFF
--- a/sale_stock_partner_delivery_window/README.rst
+++ b/sale_stock_partner_delivery_window/README.rst
@@ -32,8 +32,44 @@ Sale Stock Partner Delivery Window
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-Use the partner's "Delivery schedule preference" to compute the Sales
-Order's Expected Date, which ends up being propagated to the Delivery.
+Sale Stock Partner Delivery Window
+==================================
+
+This module extends Sales and Inventory to respect the customer’s
+delivery schedule preferences when computing delivery dates.
+
+When a Sales Order line computes its expected delivery date, the module
+checks the customer’s *Delivery schedule preference* and automatically
+adjusts the date to the next valid delivery slot.
+
+Supported delivery preferences include:
+
+- **Anytime**
+
+  Deliveries can occur at any date and time.
+
+- **Workdays only**
+
+  Deliveries are automatically postponed to the next weekday if the
+  computed date falls on a weekend.
+
+- **Configured delivery time windows**
+
+  Deliveries are restricted to specific weekdays and time ranges defined
+  on the customer record.
+
+  If the computed expected date does not match an allowed window, the
+  module selects the next available delivery slot.
+
+Additional features:
+
+- Delivery windows are evaluated in the customer’s timezone.
+- The adjusted expected date is propagated to generated delivery orders.
+- A warning is displayed on the Sales Order when the manually selected
+  commitment date does not match the customer’s delivery preferences.
+
+This ensures that promised delivery dates remain aligned with customer
+logistics constraints and preferred receiving schedules.
 
 **Table of contents**
 

--- a/sale_stock_partner_delivery_window/models/res_partner.py
+++ b/sale_stock_partner_delivery_window/models/res_partner.py
@@ -23,8 +23,8 @@ class ResPartner(models.Model):
         # Pre-compute the from_datetime, in case from_date is a `date`
         # We use the start of the day in the partner's timezone
         tz = pytz.timezone(self.tz or self.env.company.partner_id.tz or "UTC")
-        from_datetime_tz_aware = tz.localize(fields.Datetime.to_datetime(from_date))
-        from_datetime = from_datetime_tz_aware.astimezone(pytz.utc).replace(tzinfo=None)
+        from_datetime = fields.Datetime.to_datetime(from_date)
+        from_datetime_tz_aware = tz.localize(from_datetime)
         # If the delivery is anytime, simply return the from_datetime
         if self.delivery_time_preference == "anytime":
             return from_datetime

--- a/sale_stock_partner_delivery_window/readme/DESCRIPTION.md
+++ b/sale_stock_partner_delivery_window/readme/DESCRIPTION.md
@@ -1,2 +1,38 @@
-Use the partner's "Delivery schedule preference" to compute the Sales Order's
-Expected Date, which ends up being propagated to the Delivery.
+Sale Stock Partner Delivery Window
+==================================
+
+This module extends Sales and Inventory to respect the customer’s
+delivery schedule preferences when computing delivery dates.
+
+When a Sales Order line computes its expected delivery date, the module
+checks the customer’s *Delivery schedule preference* and automatically
+adjusts the date to the next valid delivery slot.
+
+Supported delivery preferences include:
+
+* **Anytime**
+  
+  Deliveries can occur at any date and time.
+
+* **Workdays only**
+  
+  Deliveries are automatically postponed to the next weekday if the
+  computed date falls on a weekend.
+
+* **Configured delivery time windows**
+  
+  Deliveries are restricted to specific weekdays and time ranges defined
+  on the customer record.
+
+  If the computed expected date does not match an allowed window, the
+  module selects the next available delivery slot.
+
+Additional features:
+
+* Delivery windows are evaluated in the customer’s timezone.
+* The adjusted expected date is propagated to generated delivery orders.
+* A warning is displayed on the Sales Order when the manually selected
+  commitment date does not match the customer’s delivery preferences.
+
+This ensures that promised delivery dates remain aligned with customer
+logistics constraints and preferred receiving schedules.

--- a/sale_stock_partner_delivery_window/static/description/index.html
+++ b/sale_stock_partner_delivery_window/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -363,9 +362,7 @@ ul.auto-toc {
 <div class="document">
 
 
-<a class="reference external image-reference" href="https://odoo-community.org/get-involved?utm_source=readme">
-<img alt="Odoo Community Association" src="https://odoo-community.org/readme-banner-image" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org/get-involved?utm_source=readme"><img alt="Odoo Community Association" src="https://odoo-community.org/readme-banner-image" /></a>
 <div class="section" id="sale-stock-partner-delivery-window">
 <h1>Sale Stock Partner Delivery Window</h1>
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -375,22 +372,42 @@ ul.auto-toc {
 !! source digest: sha256:75bb9a80a0fa2af909228102b088319b45e6d3dd055d95e797521fdfd19c0bd5
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/stock-logistics-workflow/tree/19.0/sale_stock_partner_delivery_window"><img alt="OCA/stock-logistics-workflow" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/stock-logistics-workflow-19-0/stock-logistics-workflow-19-0-sale_stock_partner_delivery_window"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/stock-logistics-workflow&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>Use the partner’s “Delivery schedule preference” to compute the Sales
-Order’s Expected Date, which ends up being propagated to the Delivery.</p>
-<p><strong>Table of contents</strong></p>
-<div class="contents local topic" id="contents">
-<ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
-</ul>
+<div class="section" id="sale-stock-partner-delivery-window-1">
+<h2>Sale Stock Partner Delivery Window</h2>
+<p>This module extends Sales and Inventory to respect the customer’s
+delivery schedule preferences when computing delivery dates.</p>
+<p>When a Sales Order line computes its expected delivery date, the module
+checks the customer’s <em>Delivery schedule preference</em> and automatically
+adjusts the date to the next valid delivery slot.</p>
+<p>Supported delivery preferences include:</p>
+<ul>
+<li><p class="first"><strong>Anytime</strong></p>
+<p>Deliveries can occur at any date and time.</p>
+</li>
+<li><p class="first"><strong>Workdays only</strong></p>
+<p>Deliveries are automatically postponed to the next weekday if the
+computed date falls on a weekend.</p>
+</li>
+<li><p class="first"><strong>Configured delivery time windows</strong></p>
+<p>Deliveries are restricted to specific weekdays and time ranges defined
+on the customer record.</p>
+<p>If the computed expected date does not match an allowed window, the
+module selects the next available delivery slot.</p>
 </li>
 </ul>
+<p>Additional features:</p>
+<ul class="simple">
+<li>Delivery windows are evaluated in the customer’s timezone.</li>
+<li>The adjusted expected date is propagated to generated delivery orders.</li>
+<li>A warning is displayed on the Sales Order when the manually selected
+commitment date does not match the customer’s delivery preferences.</li>
+</ul>
+<p>This ensures that promised delivery dates remain aligned with customer
+logistics constraints and preferred receiving schedules.</p>
+<p><strong>Table of contents</strong></p>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
+<h2>Bug Tracker</h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/stock-logistics-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -398,15 +415,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-2">Credits</a></h2>
+<h2>Credits</h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-3">Authors</a></h3>
+<h3>Authors</h3>
 <ul class="simple">
 <li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-4">Contributors</a></h3>
+<h3>Contributors</h3>
 <ul class="simple">
 <li><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a><ul>
 <li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;camptocamp.com">ivan.todorovich&#64;camptocamp.com</a>&gt;</li>
@@ -416,11 +433,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h3>
+<h3>Maintainers</h3>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_stock_partner_delivery_window/tests/test_partner_delivery_window.py
+++ b/sale_stock_partner_delivery_window/tests/test_partner_delivery_window.py
@@ -42,7 +42,7 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
     def test_expected_date_anytime_with_sale_delay(self):
         """Customer with no preferences + product sale delay.
 
-        Expected date = order date + sale_delay (2 days: Thu → Sat).
+        Expected date = order date customer_anytime+ sale_delay (2 days: Thu → Sat).
         """
         self.product.sale_delay = 2
         order = self._create_order(self.customer_anytime)
@@ -256,3 +256,128 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
         order = self._create_order(self.customer_time_window)
         with Form(order) as form, self.assertNoLogs("odoo.tests.form"):
             form.commitment_date = "2020-04-02 10:00:00"
+
+    @freeze_time("2020-04-01 10:00:00")  # Wednesday
+    def test_onchange_commitment_date_anytime_no_warning(self):
+        """Anytime delivery preference should never raise a warning."""
+        order = self._create_order(self.customer_anytime)
+
+        order.commitment_date = "2020-04-03 10:00:00"  # Friday
+        warning = order._onchange_commitment_date_delivery_window()
+
+        self.assertFalse(
+            warning,
+            "No warning should be raised for anytime delivery preference",
+        )
+
+    @freeze_time("2020-04-03 10:00:00")  # Friday
+    def test_onchange_commitment_date_workdays_warning(self):
+        """Workdays preference should warn for weekend commitment dates."""
+        order = self._create_order(self.customer_working_days)
+
+        order.commitment_date = "2020-04-04 10:00:00"  # Saturday
+        warning = order._onchange_commitment_date_delivery_window()
+
+        self.assertTrue(warning)
+        self.assertEqual(
+            warning["warning"]["title"],
+            "Customer delivery preference not met",
+        )
+        self.assertIn(
+            "next available delivery date is",
+            warning["warning"]["message"],
+        )
+
+    @freeze_time("2020-04-01 10:00:00")  # Wednesday
+    def test_onchange_commitment_date_time_window_warning(self):
+        """Time-window preference should warn for invalid delivery day.
+
+        Customer only accepts Thursday/Saturday deliveries.
+        Commitment date is Friday -> warning expected.
+        """
+        order = self._create_order(self.customer_time_window)
+
+        order.commitment_date = "2020-04-03 10:00:00"  # Friday
+        warning = order._onchange_commitment_date_delivery_window()
+
+        self.assertTrue(
+            warning,
+            "A warning should be returned for an invalid delivery day",
+        )
+
+        self.assertEqual(
+            warning["warning"]["title"],
+            "Customer delivery preference not met",
+        )
+
+        self.assertIn(
+            "next available delivery date is",
+            warning["warning"]["message"],
+        )
+
+    @freeze_time("2020-04-01 10:00:00")  # Wednesday
+    def test_onchange_commitment_date_time_window_no_warning(self):
+        """Time-window preference should not warn for valid delivery day."""
+        order = self._create_order(self.customer_time_window)
+
+        order.commitment_date = "2020-04-02 10:00:00"  # Thursday
+        warning = order._onchange_commitment_date_delivery_window()
+
+        self.assertFalse(
+            warning,
+            "No warning should be raised for a valid delivery date",
+        )
+
+    @freeze_time("2020-04-02 20:00:00")  # Thursday evening
+    def test_onchange_commitment_date_time_window_warning_outside_hours(self):
+        """Warn when commitment date is outside allowed delivery hours.
+
+        Delivery window: 14:00 -> 18:00
+        Commitment date: 20:00
+        """
+        self.customer_time_window.delivery_time_window_ids.write(
+            {
+                "time_window_start": 14.0,
+                "time_window_end": 18.0,
+            }
+        )
+
+        order = self._create_order(self.customer_time_window)
+
+        order.commitment_date = "2020-04-02 20:00:00"
+        warning = order._onchange_commitment_date_delivery_window()
+
+        self.assertTrue(
+            warning,
+            "A warning should be returned when outside delivery hours",
+        )
+
+        self.assertEqual(
+            warning["warning"]["title"],
+            "Customer delivery preference not met",
+        )
+
+        self.assertIn(
+            "next available delivery date is",
+            warning["warning"]["message"],
+        )
+
+    @freeze_time("2020-04-02 15:00:00")  # Thursday afternoon
+    def test_onchange_commitment_date_time_window_no_warning_inside_hours(self):
+        """No warning when commitment date fits allowed delivery hours."""
+        self.customer_time_window.delivery_time_window_ids.write(
+            {
+                "time_window_start": 14.0,
+                "time_window_end": 18.0,
+            }
+        )
+
+        order = self._create_order(self.customer_time_window)
+
+        order.commitment_date = "2020-04-02 15:00:00"
+        warning = order._onchange_commitment_date_delivery_window()
+
+        self.assertFalse(
+            warning,
+            "No warning should be raised inside delivery hours",
+        )


### PR DESCRIPTION
The warning trigger by the method _onchange_commitment_date_delivery_window return always a true condition because the next_date is returned as partner date tz defined. that mean we pass the commitment_date but we didn't return them if the delivery_time_preference is good. we return the datetime calculated on the timezone of the partner.

`    
    @api.onchange("commitment_date")
    def _onchange_commitment_date_delivery_window(self):
        # OVERRIDE: warn if the commitment date doesn't fit the delivery window
        if not self.commitment_date or not self.partner_id.delivery_time_preference:
            return
        next_date = self.partner_id._next_available_delivery_date(self.commitment_date)
        breakpoint()
        if self.commitment_date != next_date:
            return {
                "warning": {
                    "title": self.env._("Customer delivery preference not met"),
                    "message": self.env._(
                        "The requested date doesn't fit with the customer delivery "
                        "preference. The next available delivery date is "
                        "%(next_date)s.",
                        next_date=format_datetime(self.env, next_date),
                    ),
                }
            }
`

fixed by return the date in the orginal timezone as datetime.