### PR TITLE
[FIX] purchase_stock_picking_invoice_link: avoid over-linking on partial invoicing

### DIFF
--- a/purchase_stock_picking_invoice_link/models/purchase_order.py
+++ b/purchase_stock_picking_invoice_link/models/purchase_order.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Tecnativa - Carlos Roca
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from odoo import models
-from odoo.tools import float_compare, float_is_zero
+from odoo.tools import float_compare
 
 
 class PurchaseOrderLine(models.Model):
@@ -9,10 +9,6 @@ class PurchaseOrderLine(models.Model):
 
     def get_stock_moves_link_invoice(self):
         moves_linked = self.env["stock.move"]
-        if self.product_id.purchase_method == "purchase":
-            to_invoice = self.product_qty - self.qty_invoiced
-        else:
-            to_invoice = self.qty_received - self.qty_invoiced
         for stock_move in self.move_ids.sorted(
             lambda m: (m.write_date, m.id), reverse=True
         ):
@@ -28,23 +24,34 @@ class PurchaseOrderLine(models.Model):
                 )
             ):
                 continue
-            if not stock_move.invoice_line_ids:
-                to_invoice -= (
-                    stock_move.quantity_done
-                    if not stock_move.to_refund
-                    else -stock_move.quantity_done
-                )
-                moves_linked += stock_move
-                continue
-            elif float_is_zero(
-                to_invoice, precision_rounding=self.product_uom.rounding
-            ):
-                break
-            to_invoice -= (
-                stock_move.quantity_done
-                if not stock_move.to_refund
-                else -stock_move.quantity_done
-            )
+            if stock_move.invoice_line_ids:
+                # The move is already linked to one or more invoice lines.
+                # Re-add it only if its done qty is not fully claimed by
+                # those lines (legitimate case: one picking split across
+                # several invoices of the same PO line). Otherwise skip
+                # to avoid over-linking pickings into unrelated invoices.
+                # Net the claim against credit notes so a fully-refunded
+                # move counts as unclaimed again.
+                claimed = 0.0
+                for inv_line in stock_move.invoice_line_ids:
+                    if (
+                        inv_line.purchase_line_id != self
+                        or inv_line.parent_state == "cancel"
+                    ):
+                        continue
+                    sign = 1 if inv_line.move_id.move_type == "in_invoice" else -1
+                    claimed += sign * inv_line.product_uom_id._compute_quantity(
+                        inv_line.quantity, stock_move.product_uom
+                    )
+                if (
+                    float_compare(
+                        stock_move.quantity_done - claimed,
+                        0.0,
+                        precision_rounding=stock_move.product_uom.rounding,
+                    )
+                    <= 0
+                ):
+                    continue
             moves_linked += stock_move
         return moves_linked
 

--- a/purchase_stock_picking_invoice_link/models/stock_move.py
+++ b/purchase_stock_picking_invoice_link/models/stock_move.py
@@ -2,15 +2,28 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import models
+from odoo.tools import float_compare
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
 
     def write(self, vals):
-        """Method used to associate the stock.move with the created account.move.line
-        when the invoicing method of the product is 'purchase' and the invoice is done
-        before receiving the products.
+        """Associate the stock.move with the related account.move.line when the
+        invoicing method of the product is 'purchase' and a matching invoice
+        line still has quantity not covered by previously linked moves.
+
+        Each move is linked at most to one invoice line (the oldest one whose
+        pending quantity is still positive). This avoids over-linking the same
+        move to multiple partial invoices of the same purchase order line,
+        while preserving the legitimate accumulation case where a single
+        invoice with the ordered quantity receives goods through several
+        pickings. Cancelled invoices are excluded from the search so an
+        abandoned draft does not absorb the newly done move.
+
+        The hook only fires when ``state`` appears in ``vals``. The core
+        ``_action_done`` flow writes ``{'state': 'done', 'date': ...}`` to
+        the validated moves; this method relies on that contract.
         """
         res = super().write(vals)
         if vals.get("state", "") == "done":
@@ -20,14 +33,30 @@ class StockMove(models.Model):
                 and sm.product_id.purchase_method == "purchase"
             ):
                 inv_type = stock_move.to_refund and "in_refund" or "in_invoice"
-                inv_line = self.env["account.move.line"].search(
+                inv_lines = self.env["account.move.line"].search(
                     [
                         ("purchase_line_id", "=", stock_move.purchase_line_id.id),
                         ("move_id.move_type", "=", inv_type),
-                    ]
+                        ("move_id.state", "not in", ("cancel",)),
+                    ],
+                    order="id",
                 )
-                if inv_line:
-                    stock_move.invoice_line_ids = [(4, m.id) for m in inv_line]
+                candidate = inv_lines.filtered(
+                    lambda line: stock_move not in line.move_line_ids
+                    and float_compare(
+                        sum(
+                            sm.product_uom._compute_quantity(
+                                sm.product_uom_qty, line.product_uom_id
+                            )
+                            for sm in line.move_line_ids
+                        ),
+                        line.quantity,
+                        precision_rounding=line.product_uom_id.rounding,
+                    )
+                    < 0
+                )[:1]
+                if candidate:
+                    stock_move.invoice_line_ids = [(4, candidate.id)]
         return res
 
     def get_moves_link_invoice(self):

--- a/purchase_stock_picking_invoice_link/tests/test_purchase_stock_picking_invoice_link.py
+++ b/purchase_stock_picking_invoice_link/tests/test_purchase_stock_picking_invoice_link.py
@@ -212,3 +212,266 @@ class TestPurchaseSTockPickingInvoiceLink(common.TransactionCase):
         inv_action = self.po.action_create_invoice()
         inv2 = self.env["account.move"].browse([(inv_action["res_id"])])
         self.assertEqual(inv2.picking_ids, picking)
+
+    def test_partial_invoice_separate_pickings(self):
+        """Each partial invoice from a different picking links only to its
+        corresponding picking moves.
+        """
+        self.product.purchase_method = "purchase"
+        self.po.order_line.product_qty = 4.0
+        self.po.button_confirm()
+        po_line = self.po.order_line
+        # First picking: partial 2 of 4, leaves a backorder
+        picking_1 = self.po.picking_ids[0]
+        picking_1.move_line_ids.qty_done = 2.0
+        picking_1._action_done()
+        self.env["stock.backorder.confirmation"].create(
+            {"pick_ids": [(4, picking_1.id)]}
+        ).process()
+        # First invoice for the 2 received
+        inv_action = self.po.action_create_invoice()
+        invoice_1 = self.env["account.move"].browse(inv_action["res_id"])
+        inv_form = Form(invoice_1)
+        inv_form.invoice_date = fields.Date.today()
+        with inv_form.invoice_line_ids.edit(0) as line_form:
+            line_form.quantity = 2
+        invoice_1 = inv_form.save()
+        invoice_1.action_post()
+        # Second picking (backorder): 2 of 2
+        picking_2 = self.po.picking_ids.filtered(lambda p: p.state != "done")
+        picking_2.move_line_ids.qty_done = 2.0
+        picking_2.button_validate()
+        # Second invoice for the remaining 2
+        inv_action = self.po.action_create_invoice()
+        invoice_2 = self.env["account.move"].browse(inv_action["res_id"])
+        invoice_2.invoice_date = fields.Date.today()
+        invoice_2.action_post()
+        # Each invoice must link only to its corresponding picking. Filter
+        # by purchase_line_id so downstream modules adding ancillary lines
+        # (e.g. purchase_invoice_new_picking_line) do not break the asserts.
+        inv1_line = invoice_1.invoice_line_ids.filtered(
+            lambda line: line.purchase_line_id == po_line
+        )
+        inv2_line = invoice_2.invoice_line_ids.filtered(
+            lambda line: line.purchase_line_id == po_line
+        )
+        self.assertEqual(invoice_1.picking_ids, picking_1)
+        self.assertEqual(invoice_2.picking_ids, picking_2)
+        self.assertEqual(inv1_line.move_line_ids, picking_1.move_ids)
+        self.assertEqual(inv2_line.move_line_ids, picking_2.move_ids)
+
+    def test_claimed_skips_cancelled_invoice_lines(self):
+        """Coverage: invoice lines whose parent move is cancelled must not
+        count toward the move's claimed qty, so the move is re-linkable
+        on the next invoice.
+        """
+        self.po.button_confirm()
+        po_line = self.po.order_line
+        picking = self.po.picking_ids[0]
+        move = picking.move_ids
+        picking.move_line_ids.qty_done = 1.0
+        picking.button_validate()
+        inv1 = self.env["account.move"].browse(
+            self.po.action_create_invoice()["res_id"]
+        )
+        inv1.invoice_date = fields.Date.today()
+        inv1.action_post()
+        inv1.button_cancel()
+        inv2 = self.env["account.move"].browse(
+            self.po.action_create_invoice()["res_id"]
+        )
+        # The only invoice line tied to the move is the cancelled one;
+        # claimed should be 0 and the move should be re-linked to inv2.
+        inv2_line = inv2.invoice_line_ids.filtered(
+            lambda line: line.purchase_line_id == po_line
+        )
+        self.assertEqual(inv2_line.move_line_ids, move)
+
+    def test_claimed_subtracts_credit_notes(self):
+        """Coverage: a credit note linked to the same move subtracts from
+        the claimed qty, so a fully-refunded move is treated as
+        unclaimed again on the next invoice.
+        """
+        self.po.button_confirm()
+        # Capture the PO line and stock.move before validation so we keep
+        # singleton references even if other modules (e.g.
+        # purchase_invoice_new_picking_line) add extra order lines later.
+        po_line = self.po.order_line
+        picking = self.po.picking_ids[0]
+        move = picking.move_ids
+        picking.move_line_ids.qty_done = 1.0
+        picking.button_validate()
+        inv1 = self.env["account.move"].browse(
+            self.po.action_create_invoice()["res_id"]
+        )
+        inv1.invoice_date = fields.Date.today()
+        inv1.action_post()
+        # Manually create a credit note that points to the same PO line
+        # and the same stock.move so the in_refund branch of the
+        # claimed computation fires.
+        refund = self.env["account.move"].create(
+            {
+                "move_type": "in_refund",
+                "partner_id": self.supplier.id,
+                "journal_id": inv1.journal_id.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": 15.0,
+                            "purchase_line_id": po_line.id,
+                            "move_line_ids": [(6, 0, move.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+        refund.action_post()
+        # qty_invoiced is now 0 net (inv1 +1, refund -1) so the next
+        # invoice will be re-created and must include the move via the
+        # in_refund subtraction path.
+        inv2 = self.env["account.move"].browse(
+            self.po.action_create_invoice()["res_id"]
+        )
+        inv2_line = inv2.invoice_line_ids.filtered(
+            lambda line: line.purchase_line_id == po_line
+        )
+        self.assertEqual(inv2_line.move_line_ids, move)
+
+    def test_sequential_drafts_to_refund_moves(self):
+        """Reproduce a scenario where receipt moves are flagged
+        to_refund=True (e.g. by a connector). With several pickings of the
+        same PO line invoiced as separate drafts before any is posted,
+        each draft must only link to its own picking moves: the sign flip
+        in get_stock_moves_link_invoice's to_invoice computation for
+        to_refund moves used to pull every previously linked move into the
+        new draft.
+        """
+        self.product.purchase_method = "receive"
+        self.po.order_line.product_qty = 12.0
+        self.po.button_confirm()
+        po_line = self.po.order_line
+        pickings = []
+        invoices = []
+        for qty in (3.0, 2.0, 5.0, 2.0):
+            picking = self.po.picking_ids.filtered(lambda p: p.state != "done")[:1]
+            picking.move_line_ids.qty_done = qty
+            picking.move_ids.to_refund = True
+            picking._action_done()
+            if self.po.picking_ids.filtered(lambda p: p.state != "done"):
+                self.env["stock.backorder.confirmation"].create(
+                    {"pick_ids": [(4, picking.id)]}
+                ).process()
+            pickings.append(picking)
+            inv_action = self.po.action_create_invoice()
+            invoice = self.env["account.move"].browse(inv_action["res_id"])
+            invoice.invoice_date = fields.Date.today()
+            invoices.append(invoice)
+        for picking, invoice in zip(pickings, invoices):
+            inv_line = invoice.invoice_line_ids.filtered(
+                lambda line: line.purchase_line_id == po_line
+            )
+            self.assertEqual(
+                inv_line.move_line_ids,
+                picking.move_ids,
+                f"Draft {invoice.id} should only link to picking {picking.id} "
+                f"moves, got {inv_line.move_line_ids.ids}",
+            )
+
+    def test_write_skips_cancelled_invoice_in_search(self):
+        """When a posted invoice is cancelled before a backorder is
+        validated, ``write()`` on the backorder move must not pick the
+        cancelled invoice's line as candidate. The line's ``quantity``
+        is still uncovered by its ``move_line_ids`` so without the
+        ``move_id.state`` domain filter the new move would be linked to
+        an abandoned draft.
+        """
+        self.product.purchase_method = "purchase"
+        self.po.order_line.product_qty = 4.0
+        self.po.button_confirm()
+        po_line = self.po.order_line
+        picking_1 = self.po.picking_ids[0]
+        picking_1.move_line_ids.qty_done = 2.0
+        picking_1._action_done()
+        self.env["stock.backorder.confirmation"].create(
+            {"pick_ids": [(4, picking_1.id)]}
+        ).process()
+        inv1 = self.env["account.move"].browse(
+            self.po.action_create_invoice()["res_id"]
+        )
+        inv_form = Form(inv1)
+        inv_form.invoice_date = fields.Date.today()
+        with inv_form.invoice_line_ids.edit(0) as line_form:
+            line_form.quantity = 2
+        inv1 = inv_form.save()
+        inv1.action_post()
+        inv1.button_cancel()
+        # Validate the backorder after inv1 is cancelled. write() must
+        # exclude inv1's line via the move_id.state domain filter.
+        picking_2 = self.po.picking_ids.filtered(lambda p: p.state != "done")
+        picking_2.move_line_ids.qty_done = 2.0
+        picking_2.button_validate()
+        inv1_line = inv1.invoice_line_ids.filtered(
+            lambda line: line.purchase_line_id == po_line
+        )
+        self.assertEqual(inv1_line.move_line_ids, picking_1.move_ids)
+
+    def test_write_handles_alternative_uom(self):
+        """Backorder linked to a single invoice when the PO line uses a
+        UoM different from the product reference UoM (e.g. dozens for a
+        product measured in units). The cobertura check in write() must
+        normalise via ``_compute_quantity`` so the cumulated qty is
+        compared in the invoice line UoM. Without conversion the filter
+        would mix magnitudes and either miss or duplicate the link.
+        """
+        uom_dozen = self.env.ref("uom.product_uom_dozen")
+        self.product.purchase_method = "purchase"
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.supplier.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 2.0,
+                            "product_uom": uom_dozen.id,
+                            "price_unit": 15.0,
+                            "name": self.product.name,
+                            "date_planned": fields.Datetime.now(),
+                        },
+                    )
+                ],
+            }
+        )
+        po.button_confirm()
+        po_line = po.order_line
+        # Note: _prepare_stock_moves pivots the move to the product
+        # reference UoM (Unit) so qty_done is set in units: 12 = 1 dozen.
+        picking_1 = po.picking_ids[0]
+        picking_1.move_line_ids.qty_done = 12.0
+        picking_1._action_done()
+        self.env["stock.backorder.confirmation"].create(
+            {"pick_ids": [(4, picking_1.id)]}
+        ).process()
+        # Invoice for the full ordered qty (2 dozens) covers both
+        # pickings; the backorder's write() must extend the link via
+        # the cobertura comparison after _compute_quantity conversion
+        # of move qty (units) into invoice line UoM (dozens).
+        inv = self.env["account.move"].browse(po.action_create_invoice()["res_id"])
+        inv.invoice_date = fields.Date.today()
+        inv.action_post()
+        picking_2 = po.picking_ids.filtered(lambda p: p.state != "done")
+        picking_2.move_line_ids.qty_done = 12.0
+        picking_2.button_validate()
+        inv_line = inv.invoice_line_ids.filtered(
+            lambda line: line.purchase_line_id == po_line
+        )
+        self.assertEqual(
+            inv_line.move_line_ids, picking_1.move_ids | picking_2.move_ids
+        )


### PR DESCRIPTION
Two complementary leaks let a single stock.move end up linked to several invoice lines of the same purchase order line, so each draft invoice ended up displaying pickings that did not belong to it:

- stock.move.write({state: done}) (fires for products with control policy "On ordered quantities") used to push the move into every matching invoice line. It now targets at most one line whose pending quantity is still positive — sum of previously linked moves' qty below line.quantity, with UoM rounding tolerance.

- purchase.order.line.get_stock_moves_link_invoice() (runs for both control policies, on every invoice creation) used to fall through and re-add any move whose to_invoice budget was not yet exhausted, even when that move was already fully claimed by an earlier invoice line. It now nets the qty already claimed by non-cancelled invoice lines (in_invoice add, in_refund subtract) and skips moves whose done qty is fully covered, preserving the legitimate split-into- multiple-invoices case where a single picking is invoiced piecewise.

Two new tests reproduce both shapes
(test_partial_invoice_separate_pickings and
test_sequential_drafts_to_refund_moves); existing tests covering the legitimate accumulation cases keep passing.