### PR TITLE
[14.0][FIX]stock_move_line_auto_fill: skip auto-fill when move line a…

### DIFF
--- a/stock_move_line_auto_fill/models/stock_picking.py
+++ b/stock_move_line_auto_fill/models/stock_picking.py
@@ -59,4 +59,6 @@ class StockPicking(models.Model):
             )
         )
         for op in operations_to_auto_fill:
-            op.qty_done = op.product_uom_qty
+            already_done = sum(op.move_id._get_move_lines().mapped("qty_done"))
+            if not already_done:
+                op.qty_done = op.product_uom_qty

--- a/stock_move_line_auto_fill/tests/test_stock_picking_auto_fill.py
+++ b/stock_move_line_auto_fill/tests/test_stock_picking_auto_fill.py
@@ -485,3 +485,62 @@ class TestStockPicking(common.TransactionCase):
         returned_picking = self._picking_return(returned_picking, 500.00)
 
         self.assertEqual(product.qty_available, 500)
+
+    def test_auto_fill_skip_if_other_line_has_qty_done_no_show_reserved(self):
+        self.product_9.tracking = "none"
+        self.picking_type_in.show_reserved = False
+        move = self.move_model.create(
+            {
+                "product_id": self.product_9.id,
+                "picking_id": self.picking.id,
+                "name": self.product_9.display_name,
+                "picking_type_id": self.picking_type_in.id,
+                "product_uom_qty": 10.0,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.picking_type_in.default_location_dest_id.id,
+                "product_uom": self.product_9.uom_id.id,
+            }
+        )
+        self.picking.action_confirm()
+        self.assertEqual(self.picking.state, "assigned")
+        self.assertEqual(len(self.picking.move_line_ids), 1)
+        move.quantity_done = 3.0
+        self.picking.action_pack_operation_auto_fill()
+        self.assertEqual(len(self.picking.move_line_ids), 2)
+        self.assertEqual(self.picking.move_line_ids[0].qty_done, 0.0)
+        self.assertEqual(self.picking.move_line_ids[1].qty_done, 3.0)
+        self.picking.action_assign()
+        self.assertEqual(len(self.picking.move_line_ids), 1)
+        self.assertEqual(self.picking.move_line_ids.qty_done, 3.0)
+
+    def test_auto_fill_skip_if_other_line_has_qty_done_show_reserved(self):
+        self.product_9.tracking = "none"
+        self.picking_type_in.show_reserved = True
+        picking = self.picking_model.with_context(
+            default_picking_type_id=self.picking_type_in.id
+        ).create(
+            {
+                "partner_id": self.supplier.id,
+                "picking_type_id": self.picking_type_in.id,
+                "location_id": self.supplier_location.id,
+            }
+        )
+        move = self.move_model.create(
+            {
+                "product_id": self.product_9.id,
+                "picking_id": picking.id,
+                "name": self.product_9.display_name,
+                "picking_type_id": self.picking_type_in.id,
+                "product_uom_qty": 10.0,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.picking_type_in.default_location_dest_id.id,
+                "product_uom": self.product_9.uom_id.id,
+            }
+        )
+        picking.action_confirm()
+        self.assertEqual(picking.state, "assigned")
+        self.assertEqual(len(picking.move_line_ids), 1)
+        move.quantity_done = 3.0
+        picking.action_pack_operation_auto_fill()
+        self.assertEqual(len(picking.move_line_ids), 1)
+        self.assertEqual(picking.move_line_ids.qty_done, 3.0)


### PR DESCRIPTION
…lready has qty_done

Auto-fill cumulates qty_done when a quantity is manually set and show_reserved is disabled, creating duplicate move lines.

This PR fix auto-fill ignoring existing qty_done on move lines when show_reserved is disabled.

Add tests to cover skip behavior for both show_reserved True and False cases.