### PR TITLE
[FIX] stock_partner_delivery_window: check delivery windows with env timezone handling

### DIFF
--- a/stock_partner_delivery_window/models/res_partner.py
+++ b/stock_partner_delivery_window/models/res_partner.py
@@ -84,6 +84,12 @@ class ResPartner(models.Model):
             )
         return weekdays
 
+    @property
+    def delivery_window_tz(self):
+        """Return the timezone used to interpret partner delivery windows."""
+        self.ensure_one()
+        return self.tz or self.env.company.partner_id.tz or "UTC"
+
     def _is_in_delivery_window(self, date):
         """
         Checks if provided date is in a delivery window for actual partner
@@ -92,9 +98,9 @@ class ResPartner(models.Model):
         :return: Boolean
         """
         self.ensure_one()
-        tz = pytz.timezone(self.tz or self.env.company.partner_id.tz or "UTC")
+        timezone = pytz.timezone(self.delivery_window_tz)
         if isinstance(date, datetime.datetime):
-            date = date.astimezone(pytz.utc).astimezone(tz)
+            date = pytz.utc.localize(date).astimezone(timezone)
         if self.delivery_time_preference == "workdays":
             if date.weekday() > 4:
                 return False

--- a/stock_partner_delivery_window/models/stock_picking.py
+++ b/stock_partner_delivery_window/models/stock_picking.py
@@ -56,32 +56,31 @@ class StockPicking(models.Model):
 
     def _scheduled_date_no_delivery_window_match_msg(self):
         delivery_date = self._planned_delivery_date()
+        partner = self.partner_id
+        tz = partner.delivery_window_tz
         if isinstance(delivery_date, datetime.datetime):
-            formatted_delivery_date = format_datetime(self.env, delivery_date)
+            formatted_delivery_date = format_datetime(self.env, delivery_date, tz=tz)
         else:
             formatted_delivery_date = format_date(self.env, delivery_date)
-        partner = self.partner_id
         if partner.delivery_time_preference == "workdays":
             message = self.env._(
                 "The %(date_name)s is %(date)s (%(tz)s), but the partner is "
                 "set to prefer deliveries on working days.",
                 date_name=self._planned_delivery_date_name,
                 date=formatted_delivery_date,
-                tz=self.env.context.get("tz"),
+                tz=tz,
             )
         else:
             delivery_windows_strings = []
             if partner:
                 for w in partner._get_delivery_windows().get(partner):
-                    delivery_windows_strings.append(
-                        f"  * {w.display_name} ({partner.tz})"
-                    )
+                    delivery_windows_strings.append(f"  * {w.display_name} ({tz})")
             message = self.env._(
                 "The %(date_name)s is %(date)s (%(tz)s), but the partner is "
                 "set to prefer deliveries on following time windows:\n%(window)s",
                 date_name=self._planned_delivery_date_name,
                 date=formatted_delivery_date,
-                tz=self.env.context.get("tz"),
+                tz=tz,
                 window="\n".join(delivery_windows_strings),
             )
         return message

--- a/stock_partner_delivery_window/tests/test_delivery_window.py
+++ b/stock_partner_delivery_window/tests/test_delivery_window.py
@@ -6,6 +6,8 @@ from unittest import mock
 
 from freezegun import freeze_time
 
+from odoo import Command
+
 from .common import PartnerDeliveryWindowCommon
 
 
@@ -263,3 +265,44 @@ class TestPartnerDeliveryWindow(PartnerDeliveryWindowCommon):
         self.assertTrue(self.customer_time_window._is_in_delivery_window(date))
         date = datetime.datetime.fromisoformat("2020-04-04 17:00:00")
         self.assertFalse(self.customer_time_window._is_in_delivery_window(date))
+
+    def test_partner_tz_is_in_delivery_window(self):
+        """Test UTC datetimes are checked against partner-local windows."""
+        self.customer_time_window.tz = "Europe/Zurich"
+        self.customer_time_window.delivery_time_window_ids.write(
+            {
+                "time_window_start": 10.0,
+                "time_window_end": 18.0,
+                "time_window_weekday_ids": [
+                    Command.set(
+                        [self.env.ref("base_time_window.time_weekday_friday").id]
+                    )
+                ],
+            }
+        )
+
+        date = datetime.datetime.fromisoformat("2026-05-29 07:59:59")
+        self.assertFalse(self.customer_time_window._is_in_delivery_window(date))
+        date = datetime.datetime.fromisoformat("2026-05-29 08:00:00")
+        self.assertTrue(self.customer_time_window._is_in_delivery_window(date))
+
+    def test_company_tz_is_delivery_window_fallback(self):
+        """Test company timezone is used when partner has no timezone."""
+        self.env.company.partner_id.tz = "Europe/Zurich"
+        self.customer_time_window.tz = False
+        self.customer_time_window.delivery_time_window_ids.write(
+            {
+                "time_window_start": 10.0,
+                "time_window_end": 18.0,
+                "time_window_weekday_ids": [
+                    Command.set(
+                        [self.env.ref("base_time_window.time_weekday_friday").id]
+                    )
+                ],
+            }
+        )
+
+        date = datetime.datetime.fromisoformat("2026-05-29 07:59:59")
+        self.assertFalse(self.customer_time_window._is_in_delivery_window(date))
+        date = datetime.datetime.fromisoformat("2026-05-29 08:00:00")
+        self.assertTrue(self.customer_time_window._is_in_delivery_window(date))


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Stock picking delivery window checks can evaluate scheduled dates incorrectly when the partner delivery window is configured in a timezone different from UTC.

The module also still used manual context timezone access in warning messages, while Odoo 19.0 recommends using `self.env.tz`.

**Current behavior before PR:**

A picking scheduled date stored as an Odoo naive UTC datetime could be checked as if it were already expressed in the partner timezone.

This could make the delivery window warning appear or disappear incorrectly around window boundaries.

Warning messages also used `self.env.context.get("tz")` instead of the Odoo 19.0 `self.env.tz` timezone reference.

**Desired behavior after PR is merged:**

Picking scheduled dates are converted from Odoo naive UTC to the partner delivery window timezone before checking whether they fit the delivery window.

Warning messages use `self.env.tz` for the current environment timezone reference.

This aligns the module with Odoo 19.0 timezone handling while preserving partner local delivery window semantics.

**Steps to validate expected behavior**

1. Open a test customer.
2. Set `Timezone` to `Europe/Zurich`.
3. Set `Delivery time schedule preference` to `Fixed time windows`.
4. Add one delivery time window:
   - Weekday: `Friday`
   - From: `10:00`
   - To: `18:00`

5. Create or open an outgoing delivery picking for this customer.
6. Set `Scheduled Date` to Friday `09:59` customer local time.
   - Expected: delivery-window warning is shown.

7. Set `Scheduled Date` to Friday `10:00` customer local time.
   - Expected: no delivery-window warning.

8. Set `Scheduled Date` to Friday `18:00` customer local time.
   - Expected: no delivery-window warning.

9. Set `Scheduled Date` to Friday `18:01` customer local time.
   - Expected: delivery-window warning is shown.

10. Set `Scheduled Date` to Thursday `10:00` customer local time.
    - Expected: delivery-window warning is shown.