### PR TITLE
[FIX] sale_stock_partner_delivery_window: compute delivery window dates in partner tz

### DIFF
--- a/sale_stock_partner_delivery_window/models/res_partner.py
+++ b/sale_stock_partner_delivery_window/models/res_partner.py
@@ -13,6 +13,18 @@ from odoo.tools.date_utils import start_of
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
+    def _to_partner_delivery_datetime(self, from_date, tz):
+        """Convert a datetime to partner local datetime.
+
+        :param from_date: date or datetime to convert.
+        :param tz: partner delivery window timezone string.
+        :return: timezone aware datetime in the partner timezone.
+        """
+        timezone = pytz.timezone(tz)
+        if isinstance(from_date, datetime):
+            return pytz.utc.localize(from_date).astimezone(timezone)
+        return timezone.localize(fields.Datetime.to_datetime(from_date))
+
     def _next_available_delivery_date(
         self, from_date: date | datetime | None = None
     ) -> datetime:
@@ -20,11 +32,12 @@ class ResPartner(models.Model):
         # If from_date is not provided, use the current datetime
         if from_date is None:  # pragma: no cover
             from_date = fields.Datetime.now()
-        # Pre-compute the from_datetime, in case from_date is a `date`
-        # We use the start of the day in the partner's timezone
-        tz = pytz.timezone(self.tz or self.env.company.partner_id.tz or "UTC")
+        # get the from_datetime, in case from_date is a `date`.
+        # datetime objects stored in odoo are naive UTC,
+        # while windows are partner local.
+        tz = self.delivery_window_tz
         from_datetime = fields.Datetime.to_datetime(from_date)
-        from_datetime_tz_aware = tz.localize(from_datetime)
+        from_datetime_tz_aware = self._to_partner_delivery_datetime(from_date, tz)
         # If the delivery is anytime, simply return the from_datetime
         if self.delivery_time_preference == "anytime":
             return from_datetime
@@ -67,11 +80,13 @@ class ResPartner(models.Model):
                             continue
                     # Otherwise, since we're looking at days ahead, simply pick the
                     # window's start time
-                    return (
-                        datetime.combine(next_date, start_time)
-                        .astimezone(pytz.utc)
-                        .replace(tzinfo=None)
+                    next_datetime = next_date.replace(
+                        hour=start_time.hour,
+                        minute=start_time.minute,
+                        second=start_time.second,
+                        microsecond=start_time.microsecond,
                     )
+                    return next_datetime.astimezone(pytz.utc).replace(tzinfo=None)
         else:  # pragma: no cover
             raise ValueError(
                 self.env._(

--- a/sale_stock_partner_delivery_window/tests/test_partner_delivery_window.py
+++ b/sale_stock_partner_delivery_window/tests/test_partner_delivery_window.py
@@ -25,6 +25,20 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
             }
         )
 
+    def _set_friday_zurich_window(self):
+        self.customer_time_window.tz = "Europe/Zurich"
+        self.customer_time_window.delivery_time_window_ids.write(
+            {
+                "time_window_start": 10.0,
+                "time_window_end": 18.0,
+                "time_window_weekday_ids": [
+                    Command.set(
+                        self.env.ref("base_time_window.time_weekday_friday").ids
+                    )
+                ],
+            }
+        )
+
     @freeze_time("2020-04-02 10:00:00")  # Thursday
     def test_expected_date_anytime(self):
         """Customer with no delivery preferences.
@@ -380,4 +394,69 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
         self.assertFalse(
             warning,
             "No warning should be raised inside delivery hours",
+        )
+
+    def test_next_available_delivery_date_keeps_valid_utc_datetime(self):
+        """Test a valid UTC datetime is not shifted by partner timezone."""
+        self._set_friday_zurich_window()
+
+        next_date = self.customer_time_window._next_available_delivery_date(
+            fields.Datetime.to_datetime("2026-05-29 08:00:00")
+        )
+
+        self.assertEqual(
+            fields.Datetime.to_string(next_date),
+            "2026-05-29 08:00:00",
+        )
+
+    def test_next_available_delivery_date_returns_window_start_in_utc(self):
+        """Test the next available window start is returned."""
+        self._set_friday_zurich_window()
+
+        next_date = self.customer_time_window._next_available_delivery_date(
+            fields.Datetime.to_datetime("2026-05-28 06:00:00")
+        )
+
+        self.assertEqual(
+            fields.Datetime.to_string(next_date),
+            "2026-05-29 10:00:00",
+        )
+
+    def test_next_available_delivery_date_uses_company_tz_fallback(self):
+        """Test company timezone is used when partner has no timezone."""
+        self._set_friday_zurich_window()
+        self.env.company.partner_id.tz = "Europe/Zurich"
+        self.customer_time_window.tz = False
+
+        next_date = self.customer_time_window._next_available_delivery_date(
+            fields.Datetime.to_datetime("2026-05-28 06:00:00")
+        )
+
+        self.assertEqual(
+            fields.Datetime.to_string(next_date),
+            "2026-05-29 10:00:00",
+        )
+
+    def test_onchange_commitment_date_no_warning_inside_partner_window(self):
+        """Test no warning is shown for a UTC datetime inside the partner window."""
+        self._set_friday_zurich_window()
+        order = self._create_order(self.customer_time_window)
+
+        order.commitment_date = "2026-05-29 08:00:00"
+        warning = order._onchange_commitment_date_delivery_window()
+
+        self.assertFalse(warning)
+
+    def test_onchange_commitment_date_warning_displays_correct_next_time(self):
+        """Test warning displays the next available date."""
+        self._set_friday_zurich_window()
+        order = self._create_order(self.customer_time_window)
+
+        order.commitment_date = "2026-05-28 06:00:00"
+        warning = order._onchange_commitment_date_delivery_window()
+
+        self.assertTrue(warning)
+        self.assertIn(
+            "05/29/2026 10:00:00 AM",
+            warning["warning"]["message"],
         )


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When a sale order delivery date is checked against the customer delivery time windows, the next available delivery date can be computed with an incorrect timezone.

Odoo datetime fields are stored as naive UTC datetimes, but `_next_available_delivery_date` was treating the incoming `commitment_date` as if it was already expressed in the partner timezone.

**Current behavior before PR:**

If a customer has delivery windows in a non-UTC timezone, the sale order warning may suggest an incorrect next available delivery time.

Example:
- Partner timezone: Europe/Zurich
- Delivery window: Friday 10:00-18:00
- Requested delivery date is outside the window
- Suggested next available date may be shifted because the UTC datetime is interpreted as partner local time.

**Desired behavior after PR is merged:**

The sale order delivery date is converted from Odoo naive UTC to the partner delivery window timezone before checking the customer delivery preference.

When the next available delivery window is found, it is converted back to Odoo naive UTC before being returned and formatted by Odoo.

This keeps:
- delivery window checks correct in the customer/partner timezone;
- stored datetimes consistent with Odoo UTC conventions;
- warning display handled by Odoo’s normal formatting logic.

**Steps to validate expected behavior**

1. Open a test customer.
  - Set `Timezone` to `Europe/Zurich`.
  - Set `Delivery time schedule preference` to `Fixed time windows`.
  - Add one delivery time window:
   - Weekday: `Friday`
   - From: `10:00`
   - To: `18:00`

2. Create a quotation for this customer.

3. Set `Delivery Date` to Friday `10:00` customer local time.
   - Expected: no “Customer delivery preference not met” warning.

4. Set `Delivery Date` to Thursday `10:00` customer local time.
   - Expected: warning is shown.
   - Suggested next available delivery date should be Friday `10:00` customer/user-visible time.

5. Set `Delivery Date` to Friday `09:59` customer local time.
   - Expected: warning is shown.
   - Suggested next available delivery date should be Friday `10:00`.

6. Set `Delivery Date` to Friday `18:01` customer local time.
   - Expected: warning is shown.
   - Suggested next available delivery date should be the next valid Friday at `10:00`.

7. Confirm the quotation.
   - Expected: delivery picking is created.
   - Its scheduled date should remain consistent with the sale delivery date logic.
   - The picking warning should match the stock check rules from `stock_partner_delivery_window`.