### PR TITLE
[18.0][FIX] stock_picking_batch_invoice_frequency: use wrapper method

### DIFF
--- a/stock_picking_batch_invoice_frequency/models/stock_picking.py
+++ b/stock_picking_batch_invoice_frequency/models/stock_picking.py
@@ -8,8 +8,8 @@ from odoo import models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    def _action_done(self):
-        res = super()._action_done()
+    def button_validate(self):
+        res = super().button_validate()
         if self.env.context.get("invoice_batch", False):
             sales = self.mapped("sale_id").filtered(
                 lambda so: so.invoice_status == "to invoice"


### PR DESCRIPTION
fw of: https://github.com/OCA/stock-logistics-workflow/pull/2357

Pickings are validated from the batch with the button_validate method.

We want to avoid that other modules using the inner method _action_done are called after the invoices are done, which should be the very last thing to do.

cc @moduon MT-14940

please review @EmilioPascual @Shide 