### PR TITLE
[19.0][FIX] sale_stock_partner_delivery_window: keep partner tz for future window dates

### DIFF
--- a/sale_stock_partner_delivery_window/models/res_partner.py
+++ b/sale_stock_partner_delivery_window/models/res_partner.py
@@ -7,7 +7,6 @@ import pytz
 
 from odoo import fields, models
 from odoo.exceptions import UserError
-from odoo.tools.date_utils import start_of
 
 
 class ResPartner(models.Model):
@@ -28,65 +27,107 @@ class ResPartner(models.Model):
     def _next_available_delivery_date(
         self, from_date: date | datetime | None = None
     ) -> datetime:
-        """Compute the next available delivery date"""
-        # If from_date is not provided, use the current datetime
+        """Compute the next available delivery datetime in Odoo UTC format.
+
+        Partner delivery preferences are expressed in the partner delivery
+        timezone, while Odoo datetime fields are stored as naive UTC datetimes.
+        This method therefore accepts either:
+
+        * a naive UTC ``datetime`` coming from Odoo, such as a sale order
+          ``commitment_date`` or a sale line expected date;
+        * a ``date`` value, which is interpreted as a date in the partner
+          delivery timezone;
+        * no value, in which case the current Odoo UTC datetime is used.
+
+        The returned value is always a naive UTC ``datetime`` suitable for Odoo
+        datetime fields.
+
+        Concrete examples:
+
+        * ``anytime``: ``2026-06-11 11:00:00`` UTC is already valid, so it is
+          returned unchanged.
+        * ``workdays``: a Saturday input is moved forward to Monday while
+          keeping the original UTC time.
+        * ``time_windows``: with partner timezone ``Europe/Zurich`` and a
+          Wednesday ``09:00-17:00`` window, Wednesday ``09:00`` local in June is
+          returned as ``07:00:00`` UTC. If Thursday ``13:00`` local
+          is requested for a Wednesday only partner,
+          the method returns the next Wednesday window start.
+        """
+        # If no anchor date is provided, use the current Odoo UTC datetime.
         if from_date is None:  # pragma: no cover
             from_date = fields.Datetime.now()
-        # get the from_datetime, in case from_date is a `date`.
-        # datetime objects stored in odoo are naive UTC,
-        # while windows are partner local.
         tz = self.delivery_window_tz
+        # Build the concrete pytz timezone object used for future local dates.
+        timezone = pytz.timezone(tz)
+        # Normalize the input into an Odoo-style naive UTC datetime.
         from_datetime = fields.Datetime.to_datetime(from_date)
+        # Convert the same point, or date, into the partner delivery timezone.
         from_datetime_tz_aware = self._to_partner_delivery_datetime(from_date, tz)
-        # If the delivery is anytime, simply return the from_datetime
+        # ``anytime`` means there is no delivery window adjustment to apply.
         if self.delivery_time_preference == "anytime":
+            # Return the normalized UTC datetime unchanged.
             return from_datetime
-        # If it's workdays, we need to check if the from_datetime is a weekday
-        # or adjust accordingly
+        # ``workdays`` only constrains the partner local weekday.
         elif self.delivery_time_preference == "workdays":
+            # Use the partner local weekday, where Monday is 0 and Sunday is 6.
             weekday = from_datetime_tz_aware.weekday()
+            # Monday through Friday are already valid delivery days.
             if weekday <= 4:
+                # Keep the exact original UTC datetime.
                 return from_datetime
+            # Weekend dates are moved to next Monday, preserving the UTC time.
             return from_datetime + timedelta(days=7 - weekday)
-        # If we're using time windows, we search for the next available slot
-        # We use the tz-aware datetime, as windows are expressed in the partner's tz
+        # ``time_windows`` constrains both the partner local weekday and time.
         elif self.delivery_time_preference == "time_windows":
+            # Search today plus the next seven days, enough to cover weekly windows.
             for days_to_add in range(7 + 1):
-                next_date = (
-                    start_of(
-                        from_datetime_tz_aware + timedelta(days=days_to_add), "day"
+                # For day zero, keep the precise partner local input datetime.
+                next_date = from_datetime_tz_aware
+                # For future days, start from local midnight of that candidate day.
+                if days_to_add:
+                    # Compute the candidate date in the partner local calendar.
+                    candidate_date = from_datetime_tz_aware.date() + timedelta(
+                        days=days_to_add
                     )
-                    if days_to_add
-                    else from_datetime_tz_aware
-                )
+                    # Keep midnight timezone aware; naive midnight would be UTC-like.
+                    next_date = timezone.localize(
+                        datetime.combine(candidate_date, datetime.min.time())
+                    )
+                # Try every configured delivery window on this partner.
                 for window in self.delivery_time_window_ids:
-                    # Check if the window is available for this day
+                    # Convert the window weekdays from ``time.weekday`` names to ints.
                     weekdays = set(
                         map(int, window.time_window_weekday_ids.mapped("name"))
                     )
+                    # Skip windows that do not apply to this candidate weekday.
                     if next_date.weekday() not in weekdays:
                         continue
+                    # Get the local time at which this window starts.
                     start_time = window.get_time_window_start_time()
+                    # Get the local time at which this window ends.
                     end_time = window.get_time_window_end_time()
-                    # If we're adding days (evaluating today), and we're providing time,
-                    # we must ensure it's within the window's time range, or at least
-                    # the day range hasn't passed yet
+                    # Day zero needs special handling because it has a real input time.
                     if not days_to_add:
+                        # Date only values only need the day to match the window.
                         if not isinstance(from_date, datetime):
                             return from_datetime
+                        # Datetime values inside the window are already valid.
                         elif start_time <= from_datetime_tz_aware.time() <= end_time:
                             return from_datetime
+                        # If the candidate time is after this window, try later windows.
                         elif from_datetime_tz_aware.time() > end_time:
                             continue
-                    # Otherwise, since we're looking at days ahead, simply pick the
-                    # window's start time
+                    # For future days, or before today's window, choose the start time.
                     next_datetime = next_date.replace(
                         hour=start_time.hour,
                         minute=start_time.minute,
                         second=start_time.second,
                         microsecond=start_time.microsecond,
                     )
+                    # Convert partner local window start back to Odoo naive UTC.
                     return next_datetime.astimezone(pytz.utc).replace(tzinfo=None)
+        # Any other preference is invalid data.
         else:  # pragma: no cover
             raise ValueError(
                 self.env._(
@@ -94,4 +135,5 @@ class ResPartner(models.Model):
                     self.delivery_time_preference,
                 )
             )
+        # No matching window was found across the searched week.
         raise UserError(self.env._("No available delivery date found"))

--- a/sale_stock_partner_delivery_window/tests/test_partner_delivery_window.py
+++ b/sale_stock_partner_delivery_window/tests/test_partner_delivery_window.py
@@ -410,7 +410,7 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
         )
 
     def test_next_available_delivery_date_returns_window_start_in_utc(self):
-        """Test the next available window start is returned."""
+        """Test the next available window start is returned as UTC."""
         self._set_friday_zurich_window()
 
         next_date = self.customer_time_window._next_available_delivery_date(
@@ -419,7 +419,7 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
 
         self.assertEqual(
             fields.Datetime.to_string(next_date),
-            "2026-05-29 10:00:00",
+            "2026-05-29 08:00:00",
         )
 
     def test_next_available_delivery_date_uses_company_tz_fallback(self):
@@ -434,7 +434,7 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
 
         self.assertEqual(
             fields.Datetime.to_string(next_date),
-            "2026-05-29 10:00:00",
+            "2026-05-29 08:00:00",
         )
 
     def test_onchange_commitment_date_no_warning_inside_partner_window(self):
@@ -448,7 +448,7 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
         self.assertFalse(warning)
 
     def test_onchange_commitment_date_warning_displays_correct_next_time(self):
-        """Test warning displays the next available date."""
+        """Test warning displays the next available date in the env timezone."""
         self._set_friday_zurich_window()
         order = self._create_order(self.customer_time_window)
 
@@ -457,6 +457,6 @@ class TestSalePartnerDeliveryWindow(PartnerDeliveryWindowCommon):
 
         self.assertTrue(warning)
         self.assertIn(
-            "05/29/2026 10:00:00 AM",
+            "05/29/2026 08:00:00 AM",
             warning["warning"]["message"],
         )


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:

When computing the next available sale order delivery date for partners with fixed delivery time windows, future candidate days can lose the partner timezone information before being converted back to Odoo’s naive UTC datetime format.

Example discovered with:
- Partner timezone: `Europe/Zurich`
- Delivery window: Wednesday `09:00-17:00`
- Requested delivery date: Thursday `2026-06-11 11:00:00` UTC

The module correctly detects that Thursday is outside the Wednesday-only delivery window, but the computed next Wednesday window start must be Wednesday `09:00` Zurich local time, stored as `2026-06-17 07:00:00` UTC in June.

**Current behavior before PR:**

The future candidate date is built with `start_of(...)`, which does not preserve the partner-local timezone-aware datetime. As a result, the module can treat the local window start as if it were already UTC.

For the Zurich case above, the next available date could be computed as:

```text
local Wednesday 09:00 -> 2026-06-17 09:00:00 UTC
```

This is two hours late during summer time.

**Desired behavior after PR is merged:**

Future candidate days are built as partner-local timezone-aware midnights before applying the delivery window start time. The final value is then converted back to Odoo’s naive UTC format.

For the Zurich case above, the next available date is correctly computed as:

```text
local Wednesday 09:00 Europe/Zurich -> 2026-06-17 07:00:00 UTC
```

This keeps partner delivery windows evaluated in the partner timezone while preserving Odoo UTC handling.