### PR TITLE
[FIX] stock_restrict_lot: handle additional fields in the availabilit…

### DIFF
--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -57,7 +57,8 @@ class StockMove(models.Model):
         if self.restrict_lot_id:
             new_available_move_lines = {}
             for key, value in available_move_lines.items():
-                _location_id, lot_id, _package_id, _owner_id = key
+                # unpack defensively to avoid ValueError.
+                _location_id, lot_id, *_other_groupby_keys = key
                 if lot_id == self.restrict_lot_id:
                     new_available_move_lines[key] = value
             return new_available_move_lines


### PR DESCRIPTION
…y groupby key

The lot restriction logic in _get_available_move_lines unpacked the availability key as a fixed (location, lot, package, owner) tuple. If Odoo core or a custom module adds a field to this groupby key, the unpacking raises a ValueError ("too many values to unpack") during reservation.

Since only the lot is required here and it is consistently the second element of the key, the value is now extracted directly and any remaining fields are ignored. This keeps the filter functional if the key structure changes.