### PR TITLE
[18.0][FIX] stock_picking_group_by_partner_by_carrier: Center column content

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -116,7 +116,7 @@
                                         t-esc="remaining['concept']"
                                     />
                                 </td>
-                                <td class="text-end text-nowrap">
+                                <td class="text-center text-nowrap">
                                     <t t-if="not remaining['is_header']">
                                         <span
                                             t-esc="remaining['qty']"


### PR DESCRIPTION
Odoo centers the content of the columns.
We should match this behavior