### PR TITLE
[18.0][FWD][IMP] stock_picking_group_by_partner_by_carrier: Control the original_group_id propagation

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/__manifest__.py
+++ b/stock_picking_group_by_partner_by_carrier/__manifest__.py
@@ -18,6 +18,7 @@
     "data": [
         "views/res_partner.xml",
         "views/stock_picking_type.xml",
+        "views/stock_rule.xml",
         "views/stock_warehouse.xml",
         "report/report_delivery_slip.xml",
         "wizards/stock_picking_merge_wiz.xml",

--- a/stock_picking_group_by_partner_by_carrier/__manifest__.py
+++ b/stock_picking_group_by_partner_by_carrier/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Picking: group by partner and carrier",
     "Summary": "Group sales deliveries moves in 1 picking per partner and carrier",
-    "version": "18.0.1.3.1",
+    "version": "18.0.2.0.0",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "category": "Warehouse",

--- a/stock_picking_group_by_partner_by_carrier/migrations/18.0.2.0.0/post-migrate.py
+++ b/stock_picking_group_by_partner_by_carrier/migrations/18.0.2.0.0/post-migrate.py
@@ -1,0 +1,100 @@
+# Copyright 2024 ACSONE SA/NV (https://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    # Get the list of picking types to group.
+    picking_types = env["stock.picking.type"].search(
+        [("group_pickings", "=", True), ("code", "=", "outgoing")]
+    )
+    if not picking_types:
+        return
+
+    # Declare procurement group linked to more than one sale order as
+    # merged for procurement groups linked to stock pickings of type outgoing
+    SQL = """
+        UPDATE
+            procurement_group
+        SET
+            is_merged = TRUE
+        WHERE
+            id IN (
+                SELECT
+                    procurement_group_id
+                FROM
+                    procurement_group_sale_order_rel
+                    JOIN stock_picking ON stock_picking.group_id = procurement_group_id
+                WHERE
+                    stock_picking.state NOT IN ('cancel', 'done')
+                    AND stock_picking.picking_type_id in %s
+                GROUP BY
+                    procurement_group_id
+                HAVING
+                    COUNT(DISTINCT sale_order_id) > 1
+            )
+    """
+    env.cr.execute(SQL, (tuple(picking_types.ids),))
+    _logger.info("Declared %d procurement groups as merged", env.cr.rowcount)
+
+    # Get all procurement group linked to only one sale order for stock pickings
+    # of type outgoing with state not done or cancel and not set as merged.
+    SQL = """
+    SELECT
+        id
+    FROM stock_picking
+    WHERE
+        state NOT IN ('cancel', 'done')
+        AND picking_type_id in %s
+        AND group_id IN (
+            SELECT
+                procurement_group_id
+            FROM
+                procurement_group_sale_order_rel
+                JOIN stock_picking ON stock_picking.group_id = procurement_group_id
+                JOIN procurement_group ON procurement_group.id = procurement_group_id
+            WHERE
+                stock_picking.state NOT IN ('cancel', 'done')
+                AND stock_picking.picking_type_id in %s
+                AND (
+                    not procurement_group.is_merged
+                    or procurement_group.is_merged IS NULL
+                )
+            GROUP BY
+                procurement_group_id
+            HAVING
+                COUNT(DISTINCT sale_order_id) = 1
+        )
+    """
+    env.cr.execute(SQL, (tuple(picking_types.ids), tuple(picking_types.ids)))
+    ids = [row[0] for row in env.cr.fetchall()]
+    # generate a merged procurement group for each group of stock pickings
+    pickings = env["stock.picking"].browse(ids)
+    total = len(pickings)
+    cpt = 0
+    for picking in pickings:
+        cpt += 1
+        base_group = picking.group_id
+        moves = picking.move_ids.filtered(
+            lambda move: move.state not in ("done", "cancel")
+        )
+        _logger.info(
+            "Generating a merged procurement group for stock picking %s (%d of %d)",
+            picking.name,
+            cpt,
+            total,
+        )
+        assert len(moves.group_id) == 1
+        group_pickings = moves.group_id.picking_ids.filtered(
+            lambda picking: not (picking.printed or picking.state == "done")
+        )
+        moves = group_pickings.move_ids
+        new_group = base_group.copy(
+            picking._prepare_merge_procurement_group_values(moves.original_group_id)
+        )
+        moves.group_id = new_group

--- a/stock_picking_group_by_partner_by_carrier/models/procurement_group.py
+++ b/stock_picking_group_by_partner_by_carrier/models/procurement_group.py
@@ -10,3 +10,4 @@ class ProcurementGroup(models.Model):
         inverse_name="group_id",
         readonly=True,
     )
+    is_merged = fields.Boolean()

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -76,16 +76,20 @@ class StockMove(models.Model):
                 subtype_xmlid="mail.mt_note",
             )
 
-    def _search_picking_for_assignation_domain(self):
-        domain = super()._search_picking_for_assignation_domain()
-        if (
+    def _is_grouping_disabled(self):
+        self.ensure_one()
+        return (
             not self.picking_type_id.group_pickings
             or self.partner_id.disable_picking_grouping
             or (
                 not self.picking_type_id.group_pickings_one
                 and self.group_id.move_type == "one"
             )
-        ):
+        )
+
+    def _search_picking_for_assignation_domain(self):
+        domain = super()._search_picking_for_assignation_domain()
+        if self._is_grouping_disabled():
             return domain
 
         # remove group

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -114,10 +114,10 @@ class StockMove(models.Model):
             domain += [
                 ("carrier_id", "=", self.group_id.carrier_id.id),
             ]
-        if self.env.context.get("picking_no_copy_if_can_group"):
+        if excluded_picking := self.env.context.get("_assign_picking_excluded"):
             # we are in the context of the creation of a backorder:
             # don't consider the current move's picking
-            domain.append(("id", "!=", self.picking_id.id))
+            domain.append(("id", "!=", excluded_picking.id))
         return domain
 
     def _domain_search_picking_handle_move_type(self):

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -43,12 +43,6 @@ class StockMove(models.Model):
         # merged.
         return super()._prepare_merge_moves_distinct_fields() + ["original_group_id"]
 
-    def _keep_original_group(self):
-        """Keep the original group on the move when creating a joint group."""
-        for move in self:
-            if move.group_id and not move.original_group_id:
-                move.original_group_id = move.group_id
-
     def _assign_picking(self):
         result = super(
             StockMove, self.with_context(picking_no_overwrite_partner_origin=1)

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -43,6 +43,12 @@ class StockMove(models.Model):
         # merged.
         return super()._prepare_merge_moves_distinct_fields() + ["original_group_id"]
 
+    def _keep_original_group(self):
+        """Keep the original group on the move when creating a joint group."""
+        for move in self:
+            if move.group_id and not move.original_group_id:
+                move.original_group_id = move.group_id
+
     def _assign_picking(self):
         result = super(
             StockMove, self.with_context(picking_no_overwrite_partner_origin=1)

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -6,6 +6,8 @@ from itertools import groupby
 
 from odoo import _, api, fields, models
 from odoo.fields import first
+from odoo.exceptions import UserError
+from odoo.fields import Command
 
 
 class StockPicking(models.Model):
@@ -126,7 +128,7 @@ class StockPicking(models.Model):
                 "Merged procurement for partners: %(partners_name)s",
                 partners_name=", ".join(partners.mapped("display_name")),
             )
-        return {"sale_ids": [(6, 0, sales.ids)], "name": name}
+        return {"sale_ids": [Command.set(sales.ids)], "name": name, "is_merged": True}
 
     def _merge_procurement_groups(self):
         self.ensure_one()
@@ -137,11 +139,10 @@ class StockPicking(models.Model):
 
         moves = self.move_ids
         base_group = self.group_id
-        # If we have moves of different procurement groups, it means moves
-        # have been merged in the same picking. In this case a new
-        # procurement group is required
-        if len(moves.original_group_id) > 1 and base_group in moves.original_group_id:
-            # Create a new procurement group
+        # When grouping is allowed, we create a "merged" procurement group
+        # that will be used to group the moves every time a new move is
+        # added to the picking from a different procurement group.
+        if not base_group.is_merged:
             new_group = base_group.copy(
                 self._prepare_merge_procurement_group_values(moves.original_group_id)
             )

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -5,7 +5,6 @@
 from itertools import groupby
 
 from odoo import _, api, fields, models
-from odoo.fields import first
 from odoo.exceptions import UserError
 from odoo.fields import Command
 
@@ -89,36 +88,72 @@ class StockPicking(models.Model):
 
     def _create_backorder(self, backorder_moves=None):
         backorders = self.browse()
-        for picking in self:
-            if not picking._is_grouping_disabled():
-                picking = picking.with_context(picking_no_copy_if_can_group=1)
-            picking_backorder_moves = None
-            if backorder_moves:
-                picking_backorder_moves = backorder_moves.filtered(
-                    lambda x, picking=picking: x.picking_id == picking
-                )
-            backorder = super(StockPicking, picking)._create_backorder(
-                backorder_moves=picking_backorder_moves
+        bo_to_assign = self.browse()
+        if picking_no_grouping := self.filtered(lambda p: p._is_grouping_disabled()):
+            backorders += super(StockPicking, picking_no_grouping)._create_backorder(
+                backorder_moves=backorder_moves
             )
-            if backorder and not picking._is_grouping_disabled():
-                if backorder.group_id != picking.group_id:
-                    # the backorder is an existing picking where the remaining
-                    # moves have been moved to. We need to update the origin
-                    backorder._update_merged_origin()
+        if picking_grouping := self - picking_no_grouping:
+            moves = picking_grouping.move_ids
+            for old_picking in moves.picking_id:
+                if backorder_moves:
+                    moves_to_backorder = backorder_moves.filtered(
+                        lambda m, old_picking=old_picking: m.picking_id == old_picking
+                    )
                 else:
+                    moves_to_backorder = old_picking._get_moves_to_backorder()
+                if not moves_to_backorder:
+                    continue
+                moves_to_backorder._recompute_state()
+                moves_to_backorder.filtered("picked").picked = False
+                moves_to_backorder.with_context(
+                    _assign_picking_excluded=old_picking
+                )._assign_picking()
+                for new_picking, moves in moves_to_backorder.grouped(
+                    "picking_id"
+                ).items():
+                    if old_picking == new_picking:
+                        raise UserError(
+                            self.env._(
+                                "Backorder moves cannot be assigned to the same picking"
+                            )
+                        )
+                    backorders |= new_picking
+
                     # Create a new procurement group to remove the link from moves
                     # done in the original group and therefore avoid that a sale order
                     # linked to the picking and entirely delivered is no more linked
                     # to the backorder.
-                    base_group = backorder.group_id
-                    moves = backorder.move_ids
-                    new_group = base_group.copy(
-                        self._prepare_merge_procurement_group_values(
-                            moves.original_group_id
+                    if any(
+                        ogroup not in new_picking.move_ids.original_group_id
+                        for ogroup in old_picking.move_ids.original_group_id
+                    ):
+                        moves.group_id = new_picking.group_id.copy(
+                            self._prepare_merge_procurement_group_values(
+                                moves.original_group_id
+                            )
+                        )
+
+                    move_lines = moves.move_line_ids.filtered(
+                        lambda ml, new_picking=new_picking: ml.picking_id != new_picking
+                    )
+                    if move_lines:
+                        moves.move_line_ids.package_level_id.picking_id = new_picking
+                        moves.move_line_ids.picking_id = new_picking
+
+                    if not new_picking.backorder_id:
+                        new_picking.backorder_id = old_picking
+                    old_picking.message_post(
+                        body=_(
+                            "The backorder %s has been created.",
+                            new_picking._get_html_link(),
                         )
                     )
-                    moves.group_id = new_group
-            backorders |= backorder
+
+                    if new_picking.picking_type_id.reservation_method == "at_confirm":
+                        bo_to_assign |= new_picking
+        if bo_to_assign:
+            bo_to_assign.action_assign()
         return backorders
 
     def _prepare_merged_origin(self):
@@ -191,18 +226,6 @@ class StockPicking(models.Model):
             return True
         new_moves.group_id = base_group
         return False
-
-    def copy(self, defaults=None):
-        if self.env.context.get("picking_no_copy_if_can_group") and self.move_ids:
-            # we are in the process of the creation of a backorder. If we can
-            # find a suitable picking, then use it instead of copying the one
-            # we are creating a backorder from
-            picking = first(self.move_ids)._search_picking_for_assignation()
-            if picking:
-                return picking
-        return super(
-            StockPicking, self.with_context(picking_no_copy_if_can_group=0)
-        ).copy(defaults)
 
     def _is_grouping_disabled(self):
         self.ensure_one()

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -134,15 +134,10 @@ class StockPicking(models.Model):
             return False
         if not self.picking_type_id.group_pickings:
             return False
-        group_pickings = self.move_ids.group_id.picking_ids.filtered(
-            # Do no longer modify a printed or done transfer: they are
-            # started and their group is now fixed. It prevents keeping
-            # old, done sales orders in new groups forever
-            lambda picking: not (picking.printed or picking.state == "done")
-        )
-        moves = group_pickings.move_ids
-        base_group = self.group_id
 
+        moves = self.move_ids
+        moves._keep_original_group()
+        base_group = self.group_id
         # If we have moves of different procurement groups, it means moves
         # have been merged in the same picking. In this case a new
         # procurement group is required
@@ -151,7 +146,7 @@ class StockPicking(models.Model):
             new_group = base_group.copy(
                 self._prepare_merge_procurement_group_values(moves.original_group_id)
             )
-            group_pickings.move_ids.group_id = new_group
+            moves.group_id = new_group
             return True
 
         new_moves = moves.filtered(lambda move: move.group_id != base_group)
@@ -171,7 +166,7 @@ class StockPicking(models.Model):
                         moves.original_group_id
                     )
                 )
-                group_pickings.move_ids.group_id = new_group
+                self.move_ids.group_id = new_group
                 return True
 
             base_group.write(

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -184,8 +184,6 @@ class StockPicking(models.Model):
         self.ensure_one()
         if self._is_grouping_disabled():
             return False
-        if not self.picking_type_id.group_pickings:
-            return False
 
         moves = self.move_ids
         base_group = self.group_id
@@ -232,6 +230,10 @@ class StockPicking(models.Model):
         return (
             not self.picking_type_id.group_pickings
             or self.partner_id.disable_picking_grouping
+            or (
+                not self.picking_type_id.group_pickings_one
+                and self.group_id.move_type == "one"
+            )
         )
 
     def _group_moves_by_order(self, moves):

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -101,8 +101,23 @@ class StockPicking(models.Model):
                 backorder_moves=picking_backorder_moves
             )
             if backorder and not picking._is_grouping_disabled():
-                backorder._merge_procurement_groups()
-                backorder._update_merged_origin()
+                if backorder.group_id != picking.group_id:
+                    # the backorder is an existing picking where the remaining
+                    # moves have been moved to. We need to update the origin
+                    backorder._update_merged_origin()
+                else:
+                    # Create a new procurement group to remove the link from moves
+                    # done in the original group and therefore avoid that a sale order
+                    # linked to the picking and entirely delivered is no more linked
+                    # to the backorder.
+                    base_group = backorder.group_id
+                    moves = backorder.move_ids
+                    new_group = base_group.copy(
+                        self._prepare_merge_procurement_group_values(
+                            moves.original_group_id
+                        )
+                    )
+                    moves.group_id = new_group
             backorders |= backorder
         return backorders
 

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -136,7 +136,6 @@ class StockPicking(models.Model):
             return False
 
         moves = self.move_ids
-        moves._keep_original_group()
         base_group = self.group_id
         # If we have moves of different procurement groups, it means moves
         # have been merged in the same picking. In this case a new

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
 # Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import freezegun
 
 from odoo.fields import first
 from odoo.tests import Form, TransactionCase
@@ -313,73 +312,6 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         self.assertEqual(len(ships), 1)
         self.assertEqual(len(picks), 1)
         self.assertFalse(so1.picking_ids - so2.picking_ids)
-
-    def test_delivery_multi_step_group_out_pick_op_merged(self):
-        """the warehouse uses pick + ship (with grouping enabled on ship but
-        and pick)
-        We don't propagate the original group on pick.
-
-        Moves for the same product are merged into the pick
-        """
-        self.warehouse.delivery_steps = "pick_ship"
-        rule = self.env["procurement.group"]._get_rule(
-            self.product,
-            self.warehouse.pick_type_id.default_location_dest_id,
-            {"warehouse_id": self.warehouse},
-        )
-        rule.propagate_carrier = False
-        rule.propagate_original_group = False
-        self.warehouse.pick_type_id.group_pickings = True
-        so1 = self._get_new_sale_order(carrier=self.carrier1)
-        so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
-        with freezegun.freeze_time("2019-01-01"):
-            # we need to ensure that the computed date_deadline on the
-            # stock.move is the same for the 2 SO since it is used to
-            # group the moves. In some deployment, the date_deadline is
-            # removed from the list of fields used to group the moves.
-            # to ensure that when planning the pickings to do (for example
-            # in conjunction with the stock_available_to_promise_release
-            # module), the date_deadline will not prevent the moves to be
-            # grouped since we expect that the planned work must be done
-            # at the same time.
-            so1.action_confirm()
-            so2.action_confirm()
-        ships = (so1.picking_ids | so2.picking_ids).filtered(
-            lambda p: p.picking_type_code == "outgoing"
-        )
-        self.assertEqual(len(ships), 1)
-        picks = (so1.picking_ids | so2.picking_ids).filtered(
-            lambda p: p.picking_type_code == "internal"
-        )
-        self.assertTrue(ships.move_ids.mapped("original_group_id"))
-        self.assertFalse(picks.move_ids.mapped("original_group_id"))
-        self.assertEqual(len(picks), 1)
-        self.assertEqual(len(picks.move_ids), 1)
-        self.assertEqual(len(ships.move_ids), 2)
-        self.assertEqual(picks.move_ids.move_dest_ids, ships.move_ids)
-        for move in ships.move_ids:
-            self.assertEqual(move.move_orig_ids, picks.move_ids)
-
-        # We reset the sold quantity to 0 to trigger the creation of a negative
-        # procurement that will at the end cancel the moves related to the SO.
-        so1.order_line.filtered(
-            lambda l: l.product_id == self.product
-        ).product_uom_qty = 0
-        ship_move_so1 = ships.move_ids.filtered(
-            lambda m: m.sale_line_id.order_id == so1
-        )
-        ship_move_so2 = ships.move_ids.filtered(
-            lambda m: m.sale_line_id.order_id == so2
-        )
-        self.assertEqual(ship_move_so1.state, "cancel")
-        self.assertEqual(ship_move_so2.state, "waiting")
-        self.assertEqual(picks.move_ids.state, "confirmed")
-        self.assertEqual(picks.move_ids.product_qty, 11)
-        so2.order_line.filtered(
-            lambda l: l.product_id == self.product
-        ).product_uom_qty = 0
-        self.assertEqual(ships.state, "cancel")
-        self.assertEqual(picks.state, "cancel")
 
     def test_delivery_multi_step_cancel_so1(self):
         """the warehouse uses pick + ship. Cancel SO1

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
 # Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import freezegun
+
 from odoo.fields import first
 from odoo.tests import Form, TransactionCase
 
@@ -23,10 +25,13 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         -> the pickings are merged"""
         so1 = self._get_new_sale_order()
         so2 = self._get_new_sale_order(amount=11)
+        so3 = self._get_new_sale_order(amount=12)
         so1.action_confirm()
         so2.action_confirm()
+        so3.action_confirm()
         self.assertTrue(so1.picking_ids)
-        self.assertEqual(so1.picking_ids, so2.picking_ids)
+        self.assertEqual(so1.picking_ids, so2.picking_ids, so3.picking_ids)
+        self.assertEqual(1, len(so1.picking_ids.move_ids.group_id))
 
     def test_sale_stock_merge_same_carrier(self):
         """2 sale orders for the same partner, with same carrier
@@ -308,6 +313,73 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         self.assertEqual(len(ships), 1)
         self.assertEqual(len(picks), 1)
         self.assertFalse(so1.picking_ids - so2.picking_ids)
+
+    def test_delivery_multi_step_group_out_pick_op_merged(self):
+        """the warehouse uses pick + ship (with grouping enabled on ship but
+        and pick)
+        We don't propagate the original group on pick.
+
+        Moves for the same product are merged into the pick
+        """
+        self.warehouse.delivery_steps = "pick_ship"
+        rule = self.env["procurement.group"]._get_rule(
+            self.product,
+            self.warehouse.pick_type_id.default_location_dest_id,
+            {"warehouse_id": self.warehouse},
+        )
+        rule.propagate_carrier = False
+        rule.propagate_original_group = False
+        self.warehouse.pick_type_id.group_pickings = True
+        so1 = self._get_new_sale_order(carrier=self.carrier1)
+        so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
+        with freezegun.freeze_time("2019-01-01"):
+            # we need to ensure that the computed date_deadline on the
+            # stock.move is the same for the 2 SO since it is used to
+            # group the moves. In some deployment, the date_deadline is
+            # removed from the list of fields used to group the moves.
+            # to ensure that when planning the pickings to do (for example
+            # in conjunction with the stock_available_to_promise_release
+            # module), the date_deadline will not prevent the moves to be
+            # grouped since we expect that the planned work must be done
+            # at the same time.
+            so1.action_confirm()
+            so2.action_confirm()
+        ships = (so1.picking_ids | so2.picking_ids).filtered(
+            lambda p: p.picking_type_code == "outgoing"
+        )
+        self.assertEqual(len(ships), 1)
+        picks = (so1.picking_ids | so2.picking_ids).filtered(
+            lambda p: p.picking_type_code == "internal"
+        )
+        self.assertTrue(ships.move_ids.mapped("original_group_id"))
+        self.assertFalse(picks.move_ids.mapped("original_group_id"))
+        self.assertEqual(len(picks), 1)
+        self.assertEqual(len(picks.move_ids), 1)
+        self.assertEqual(len(ships.move_ids), 2)
+        self.assertEqual(picks.move_ids.move_dest_ids, ships.move_ids)
+        for move in ships.move_ids:
+            self.assertEqual(move.move_orig_ids, picks.move_ids)
+
+        # We reset the sold quantity to 0 to trigger the creation of a negative
+        # procurement that will at the end cancel the moves related to the SO.
+        so1.order_line.filtered(
+            lambda l: l.product_id == self.product
+        ).product_uom_qty = 0
+        ship_move_so1 = ships.move_ids.filtered(
+            lambda m: m.sale_line_id.order_id == so1
+        )
+        ship_move_so2 = ships.move_ids.filtered(
+            lambda m: m.sale_line_id.order_id == so2
+        )
+        self.assertEqual(ship_move_so1.state, "cancel")
+        self.assertEqual(ship_move_so2.state, "waiting")
+        self.assertEqual(picks.move_ids.state, "confirmed")
+        self.assertEqual(picks.move_ids.product_qty, 11)
+        so2.order_line.filtered(
+            lambda l: l.product_id == self.product
+        ).product_uom_qty = 0
+        self.assertEqual(ships.state, "cancel")
+        self.assertEqual(picks.state, "cancel")
 
     def test_delivery_multi_step_cancel_so1(self):
         """the warehouse uses pick + ship. Cancel SO1

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
@@ -226,13 +226,10 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        self.assertEqual(len(so1.picking_ids), 3)
-        self.assertEqual(len(so2.picking_ids), 3)
-        self.assertEqual(so1.picking_ids, so2.picking_ids)
+        self.assertEqual(len(so1.picking_ids), 2)
+        self.assertEqual(len(so2.picking_ids), 2)
         # ship should be shared between so1 and so2
-        ships = (so1.picking_ids | so2.picking_ids).filtered(
-            lambda p: p.picking_type_code == "outgoing"
-        )
+        ships = so1.picking_ids & so2.picking_ids
         self.assertEqual(len(ships), 1)
         self.assertEqual(ships.picking_type_id, self.warehouse.out_type_id)
         # but not picks
@@ -240,29 +237,40 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         # be regrouped but this is currently not supported by this module. You
         # need the stock_available_to_promise_release module to have this
         # feature
-        picks = so1.picking_ids - ships
+        picks = so1.picking_ids - ships | so2.picking_ids - ships
         self.assertEqual(len(picks), 2)
         self.assertEqual(picks.picking_type_id, self.warehouse.pick_type_id)
-        # the group is the same on the move lines and picking
-        self.assertEqual(len(so1.picking_ids.group_id), 1)
-        self.assertEqual(so1.picking_ids.group_id, so1.picking_ids.move_ids.group_id)
+
+        # the group is the same on the move lines in every picks and on the ships
+        for pick in picks | ships:
+            self.assertEqual(pick.group_id, pick.move_ids.group_id)
+
         # Add a line to so1
         self.assertEqual(len(ships.move_ids), 2)
         sale_form = Form(so1)
         self._set_line(sale_form, 4)
         sale_form.save()
         self.assertEqual(len(ships.move_ids), 3)
-        # the group is the same on the move lines and picking
-        self.assertEqual(len(so1.picking_ids.group_id), 1)
-        self.assertEqual(so1.picking_ids.group_id, so1.picking_ids.move_ids.group_id)
+        # the group is the same on the move lines in every picks and on the ships
+        ships = so1.picking_ids & so2.picking_ids
+        self.assertEqual(len(ships), 1)
+        picks = so1.picking_ids - ships | so2.picking_ids - ships
+        self.assertEqual(len(picks), 2)
+        for pick in picks | ships:
+            self.assertEqual(pick.group_id, pick.move_ids.group_id)
+
         # Add a line to so2
         self.assertEqual(len(ships.move_ids), 3)
         self._set_line(sale_form, 4)
         sale_form.save()
         self.assertEqual(len(ships.move_ids), 4)
-        # the group is the same on the move lines and picking
-        self.assertEqual(len(so2.picking_ids.group_id), 1)
-        self.assertEqual(so1.picking_ids.group_id, so2.picking_ids.move_ids.group_id)
+        # the group is the same on the move lines in every picks and on the ships
+        ships = so1.picking_ids & so2.picking_ids
+        self.assertEqual(len(ships), 1)
+        picks = so1.picking_ids - ships | so2.picking_ids - ships
+        self.assertEqual(len(picks), 2)
+        for pick in picks | ships:
+            self.assertEqual(pick.group_id, pick.move_ids.group_id)
 
     def test_delivery_multi_step_group_pick(self):
         """the warehouse uses pick + ship (with grouping enabled on pick)

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping_pull_rules.py
@@ -611,3 +611,36 @@ class TestGroupByPullRules(TestGroupByBase, TransactionCase):
         self.assertEqual(picking.state, "done")
         self.assertTrue(picking.backorder_ids)
         self.assertNotEqual(picking, picking.backorder_ids)
+
+    def test_create_backorder_new_procurement_group(self):
+        """Ensure a new procurement group is created when a backorder is created
+        and that the backorder will reference only pickings from remaining moves.
+        """
+        so1 = self._get_new_sale_order()
+        so2 = self._get_new_sale_order(amount=11)
+        so3 = self._get_new_sale_order(amount=12)
+        so1.action_confirm()
+        so2.action_confirm()
+        so3.action_confirm()
+
+        picking = so1.picking_ids | so2.picking_ids | so3.picking_ids
+        line = so1.order_line.filtered(lambda line: not line.is_delivery)
+
+        self._update_qty_in_location(
+            picking.location_id,
+            line.product_id,
+            line.product_uom_qty,
+        )
+
+        self.assertEqual(len(picking), 1)
+        picking.action_assign()
+
+        # partially process the picking for line from so1
+        move = picking.move_ids.filtered(lambda m: m.sale_line_id.order_id == so1)
+        move.move_line_ids.picked = True
+        picking._action_done()
+        backorder = picking.backorder_ids
+        self.assertTrue(backorder)
+        self.assertEqual(len(backorder), 1)
+        self.assertNotEqual(picking.group_id, backorder.group_id)
+        self.assertEqual(backorder.sale_ids, so2 | so3)

--- a/stock_picking_group_by_partner_by_carrier/views/stock_rule.xml
+++ b/stock_picking_group_by_partner_by_carrier/views/stock_rule.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_stock_rule_form" model="ir.ui.view">
+        <field name="name">stock.rule.form</field>
+        <field name="model">stock.rule</field>
+        <field name="inherit_id" ref="stock.view_stock_rule_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='propagate_cancel']" position="after">
+                <field name="propagate_original_group" groups="base.group_no_one" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Port of:
* https://github.com/OCA/stock-logistics-workflow/pull/1751

cc @lmignon @TDu 