### PR TITLE
[19.0][FIX] stock_landed_costs_purchase_auto: Add _test_skip_check_lc_journal_id to the context

### DIFF
--- a/stock_landed_costs_purchase_auto/models/purchase_order.py
+++ b/stock_landed_costs_purchase_auto/models/purchase_order.py
@@ -33,7 +33,8 @@ class PurchaseOrder(models.Model):
         # We need to use sudo() because only Inventory > Administrator have
         # permissions on stock.landed.cost
         self.ensure_one()
-        if not self.company_id.lc_journal_id:
+        StockLandedCost = self.env["stock.landed.cost"].with_company(self.company_id)
+        if not StockLandedCost._default_account_journal_id():
             raise UserError(
                 self.env._(
                     "Cannot create a landed cost for purchase order %(order)s: "

--- a/stock_landed_costs_purchase_auto/tests/common.py
+++ b/stock_landed_costs_purchase_auto/tests/common.py
@@ -22,14 +22,6 @@ class TestPurchaseOrderBase(BaseCommon):
             }
         )
         cls.partner = cls.env["res.partner"].create({"name": "Mr Odoo"})
-        cls.company.lc_journal_id = cls.env["account.journal"].create(
-            {
-                "name": "Test LC",
-                "type": "general",
-                "code": "MISC-LC",
-                "company_id": cls.company.id,
-            }
-        )
         cls.purchase_user = new_test_user(
             cls.env,
             login="test_purchase_user",


### PR DESCRIPTION
Use default landed cost account journal

Related with #2388 

@pedrobaeza ping
@Tecnativa 