### PR TITLE
[16.0][FIX] stock_move_propagate_first_move: ensure first move is well propagated during splits

### DIFF
--- a/stock_move_propagate_first_move/models/stock_move.py
+++ b/stock_move_propagate_first_move/models/stock_move.py
@@ -38,27 +38,51 @@ class StockMove(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         # Extract the tracking flag before calling super so it doesn't break standard create
-        split_first_move_ids = {}
+        split_first_move_id_by_move_index = {}
         for i, vals in enumerate(vals_list):
             if "_split_first_move_id" in vals:
-                split_first_move_ids[i] = vals.pop("_split_first_move_id")
+                split_first_move_id_by_move_index[i] = vals.pop("_split_first_move_id")
 
         moves = super().create(vals_list)
 
-        # Update the upstream moves to point to the newly created backorder
-        for i, move in enumerate(moves):
-            split_first_move_id = split_first_move_ids.get(i)
-            if not split_first_move_id:
-                continue
-            # Find all moves that were tied to the split first_move
-            # and have not yet been completed or cancelled.
-            moves_to_update = self.env["stock.move"].search(
-                [
-                    ("first_move_id", "=", split_first_move_id),
-                    ("state", "not in", ("done", "cancel")),
-                ]
-            )
-            if moves_to_update:
-                moves_to_update.write({"first_move_id": move.id})
+        self._propagate_first_move_after_create(
+            split_first_move_id_by_move_index, moves
+        )
 
         return moves
+
+    def _propagate_first_move_after_create(
+        self, split_first_move_id_by_move_index, moves
+    ):
+        """Propagate the new first_move_id to upstream moves created from a split."""
+        if not split_first_move_id_by_move_index:
+            return
+
+        split_first_move_ids = [
+            fm_id for fm_id in split_first_move_id_by_move_index.values() if fm_id
+        ]
+
+        # Find all ongoing moves tied to any of the split first_moves
+        groups = self.env["stock.move"].read_group(
+            domain=[
+                ("first_move_id", "in", split_first_move_ids),
+                ("state", "not in", ("done", "cancel")),
+            ],
+            fields=[
+                "first_move_id",
+                "move_ids:array_agg(id)",
+            ],
+            groupby=["first_move_id"],
+        )
+        grouped_moves_to_update = {
+            group["first_move_id"][0]: self.env["stock.move"].browse(group["move_ids"])
+            for group in groups
+        }
+
+        # Replace old first move with new one for each group
+        for i, move in enumerate(moves):
+            split_first_move_id = split_first_move_id_by_move_index.get(i)
+            if split_first_move_id and split_first_move_id in grouped_moves_to_update:
+                grouped_moves_to_update[split_first_move_id].write(
+                    {"first_move_id": move.id}
+                )

--- a/stock_move_propagate_first_move/models/stock_move.py
+++ b/stock_move_propagate_first_move/models/stock_move.py
@@ -5,7 +5,6 @@ from odoo import api, fields, models
 
 
 class StockMove(models.Model):
-
     _inherit = "stock.move"
 
     first_move_id = fields.Many2one(
@@ -22,10 +21,44 @@ class StockMove(models.Model):
         help="Picking type of the original move which generated this one.",
     )
 
+    def _is_inside_a_chain(self) -> bool:
+        return bool(self.move_dest_ids or self.move_orig_ids)
+
+    def _split(self, qty, restrict_partner_id=False):
+        res = super()._split(qty, restrict_partner_id)
+        self_first_move_from_chain = (
+            not self.first_move_id and self._is_inside_a_chain()
+        )
+        if self_first_move_from_chain:
+            for vals in res:
+                vals["_split_first_move_id"] = self.id
+
+        return res
+
     @api.model_create_multi
     def create(self, vals_list):
-        records = super().create(vals_list)
-        for rec in records:
-            if not rec.first_move_id:
-                rec.first_move_id = rec
-        return records
+        # Extract the tracking flag before calling super so it doesn't break standard create
+        split_first_move_ids = {}
+        for i, vals in enumerate(vals_list):
+            if "_split_first_move_id" in vals:
+                split_first_move_ids[i] = vals.pop("_split_first_move_id")
+
+        moves = super().create(vals_list)
+
+        # Update the upstream moves to point to the newly created backorder
+        for i, move in enumerate(moves):
+            split_first_move_id = split_first_move_ids.get(i)
+            if not split_first_move_id:
+                continue
+            # Find all moves that were tied to the split first_move
+            # and have not yet been completed or cancelled.
+            moves_to_update = self.env["stock.move"].search(
+                [
+                    ("first_move_id", "=", split_first_move_id),
+                    ("state", "not in", ("done", "cancel")),
+                ]
+            )
+            if moves_to_update:
+                moves_to_update.write({"first_move_id": move.id})
+
+        return moves

--- a/stock_move_propagate_first_move/tests/__init__.py
+++ b/stock_move_propagate_first_move/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_stock_move_picking_type_origin_pull
 from . import test_stock_move_picking_type_origin_push
 from . import test_stock_move_picking_type_origin_pull_push
+from . import test_stock_move_propagate_first_move

--- a/stock_move_propagate_first_move/tests/test_stock_move_picking_type_origin_pull.py
+++ b/stock_move_propagate_first_move/tests/test_stock_move_picking_type_origin_pull.py
@@ -51,13 +51,13 @@ class TestStockMovePickingTypeOriginPull(TestStockMovePickingTypeOrigin):
         move_pick = self.stock_model.search([("group_id", "=", pg_inter.id)])
         move_ship = self.stock_model.search([("group_id", "=", pg_out.id)])
 
-        self.assertEqual(move_pick.first_picking_type_id, self.picking_type_out)
-        self.assertEqual(move_pick.first_move_id, move_ship)
         self.assertEqual(move_pick.picking_type_id, self.picking_type_inter)
+        self.assertEqual(move_pick.first_move_id, move_ship)
+        self.assertEqual(move_pick.first_picking_type_id, self.picking_type_out)
 
-        self.assertEqual(move_ship.first_move_id, move_ship)
-        self.assertEqual(move_ship.first_picking_type_id, self.picking_type_out)
         self.assertEqual(move_ship.picking_type_id, self.picking_type_out)
+        self.assertFalse(move_ship.first_move_id)
+        self.assertFalse(move_ship.first_picking_type_id)
 
     def test_pull_three_steps(self):
         self.env["stock.quant"]._update_available_quantity(
@@ -133,14 +133,14 @@ class TestStockMovePickingTypeOriginPull(TestStockMovePickingTypeOrigin):
         move_pick_1 = self.stock_model.search([("group_id", "=", pg_inter_1.id)])
         move_pick_2 = self.stock_model.search([("group_id", "=", pg_inter_2.id)])
 
-        self.assertEqual(move_pick_1.first_picking_type_id, self.picking_type_out)
         self.assertEqual(move_pick_1.picking_type_id, self.picking_type_inter)
         self.assertEqual(move_pick_1.first_move_id, move_ship)
+        self.assertEqual(move_pick_1.first_picking_type_id, self.picking_type_out)
 
-        self.assertEqual(move_pick_2.first_picking_type_id, self.picking_type_out)
         self.assertEqual(move_pick_2.picking_type_id, self.picking_type_inter)
         self.assertEqual(move_pick_2.first_move_id, move_ship)
+        self.assertEqual(move_pick_2.first_picking_type_id, self.picking_type_out)
 
-        self.assertEqual(move_ship.first_move_id, move_ship)
-        self.assertEqual(move_ship.first_picking_type_id, self.picking_type_out)
         self.assertEqual(move_ship.picking_type_id, self.picking_type_out)
+        self.assertFalse(move_ship.first_move_id)
+        self.assertFalse(move_ship.first_picking_type_id)

--- a/stock_move_propagate_first_move/tests/test_stock_move_picking_type_origin_pull_push.py
+++ b/stock_move_propagate_first_move/tests/test_stock_move_picking_type_origin_pull_push.py
@@ -31,11 +31,15 @@ class TestStockMovePickingTypeOriginPull(TestStockMovePickingTypeOrigin):
         picking.action_confirm()
         moves = self.env["stock.move"].search([("product_id", "=", self.product.id)])
         self.assertEqual(len(moves), 3)
-        self.assertEqual(moves[0].first_picking_type_id, self.picking_type_in)
+
         self.assertEqual(moves[0].picking_type_id, self.picking_type_in)
-        self.assertEqual(moves[1].first_picking_type_id, self.picking_type_in)
+        self.assertFalse(moves[0].first_move_id)
+        self.assertFalse(moves[0].first_picking_type_id)
+
         self.assertEqual(moves[1].picking_type_id, self.picking_type_inter)
-        self.assertEqual(moves[2].first_picking_type_id, self.picking_type_in)
-        self.assertEqual(moves[2].picking_type_id, self.picking_type_inter)
         self.assertEqual(moves[1].first_move_id, moves[0])
+        self.assertEqual(moves[1].first_picking_type_id, self.picking_type_in)
+
+        self.assertEqual(moves[2].picking_type_id, self.picking_type_inter)
         self.assertEqual(moves[2].first_move_id, moves[0])
+        self.assertEqual(moves[2].first_picking_type_id, self.picking_type_in)

--- a/stock_move_propagate_first_move/tests/test_stock_move_picking_type_origin_push.py
+++ b/stock_move_propagate_first_move/tests/test_stock_move_picking_type_origin_push.py
@@ -67,11 +67,15 @@ class TestStockMovePickingTypeOriginPush(TestStockMovePickingTypeOrigin):
         )
         moves = self.stock_model.search([("group_id", "=", pg_in.id)])
         self.assertEqual(len(moves), 3)
-        self.assertEqual(moves[0].first_picking_type_id, self.picking_type_in)
+
         self.assertEqual(moves[0].picking_type_id, self.picking_type_in)
+        self.assertFalse(moves[0].first_move_id)
+        self.assertFalse(moves[0].first_picking_type_id)
+
         self.assertEqual(moves[1].first_picking_type_id, self.picking_type_in)
-        self.assertEqual(moves[1].picking_type_id, self.picking_type_inter)
-        self.assertEqual(moves[2].first_picking_type_id, self.picking_type_in)
-        self.assertEqual(moves[2].picking_type_id, self.picking_type_inter)
         self.assertEqual(moves[1].first_move_id, moves[0])
+        self.assertEqual(moves[1].picking_type_id, self.picking_type_inter)
+
+        self.assertEqual(moves[2].first_picking_type_id, self.picking_type_in)
         self.assertEqual(moves[2].first_move_id, moves[0])
+        self.assertEqual(moves[2].picking_type_id, self.picking_type_inter)

--- a/stock_move_propagate_first_move/tests/test_stock_move_propagate_first_move.py
+++ b/stock_move_propagate_first_move/tests/test_stock_move_propagate_first_move.py
@@ -1,0 +1,85 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo import Command
+
+from .common import TestStockMovePickingTypeOrigin
+
+
+class TestStockMovePropagateFirstMove(TestStockMovePickingTypeOrigin):
+    def test_first_move_id_not_copied_during_non_chanied_move_split(self):
+        picking = self.env["stock.picking"].create(
+            {
+                "location_id": self.loc_supplier.id,
+                "location_dest_id": self.loc_in_1.id,
+                "picking_type_id": self.picking_type_in.id,
+                "move_ids": [
+                    Command.create(
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 5,
+                            "product_uom": self.product.uom_id.id,
+                            "location_id": self.loc_supplier.id,
+                            "location_dest_id": self.loc_in_1.id,
+                        }
+                    )
+                ],
+            }
+        )
+        picking.action_confirm()
+
+        picking.move_line_ids.qty_done = 2
+        picking._action_done()
+
+        backorder = picking.backorder_ids
+        self.assertTrue(backorder, "No backorder picking was created")
+
+        original_move = picking.move_ids
+        backorder_move = backorder.move_ids
+        self.assertFalse(original_move.first_move_id)
+        self.assertFalse(backorder_move.first_move_id)
+
+    def test_first_move_id_well_copied_during_chained_moves_split(self):
+        self.warehouse.delivery_steps = "pick_ship"
+        pg_out = self.env["procurement.group"].create({"name": "PG Out"})
+
+        self.env["procurement.group"].run(
+            [
+                pg_out.Procurement(
+                    self.product,
+                    2.0,
+                    self.product.uom_id,
+                    self.loc_customer,
+                    "delivery product A",
+                    "delivery product A",
+                    self.warehouse.company_id,
+                    {"warehouse_id": self.warehouse, "group_id": pg_out},
+                )
+            ]
+        )
+
+        moves = self.stock_model.search([("group_id", "=", pg_out.id)])
+        ship_move = moves.filtered(lambda m: m.picking_type_id == self.picking_type_out)
+        pick_move = moves - ship_move
+
+        pick = pick_move.picking_id
+        ship = ship_move.picking_id
+
+        # create a backorder on pick
+        pick.move_ids.quantity_done = 1
+        pick._action_done()
+        pick_backorder = pick.backorder_ids
+        pick_move_bo = pick_backorder.move_ids
+
+        self.assertEqual(pick_move_bo.first_move_id, ship_move)
+
+        # create a backorder on ship
+        ship.move_ids.quantity_done = 1
+        ship._action_done()
+        ship_backorder = ship.backorder_ids
+        ship_move_bo = ship_backorder.move_ids
+
+        self.assertFalse(ship_move_bo.first_move_id)
+        self.assertEqual(pick_move_bo.first_move_id, ship_move_bo)


### PR DESCRIPTION
- Change `first_move_id` definition in case you are the first move of a chain: before=yourself, now=False (this allows to split and thus copy fields without side effects when the move is not inside a picking)
- When splitting the first move, ensure the moves that were linked to it are then linked to the newly created split move (to ensure the link is preserved during chained moves split)