### PR TITLE
[18.0][FIX] stock_owner_restriction: Owner restriction on chained moves

### DIFF
--- a/stock_owner_restriction/__manifest__.py
+++ b/stock_owner_restriction/__manifest__.py
@@ -11,7 +11,17 @@
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
-    "data": ["views/stock_picking_type_views.xml", "views/stock_picking_views.xml"],
+    "data": [
+        "views/stock_move_line_views.xml",
+        "views/stock_move_views.xml",
+        "views/stock_picking_type_views.xml",
+        "views/stock_picking_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "stock_owner_restriction/static/src/fields/stock_move_line_x2_many_field.esm.js",
+        ],
+    },
     "depends": ["stock"],
     "post_init_hook": "set_default_owner_restriction",
     "uninstall_hook": "uninstall_hook",

--- a/stock_owner_restriction/models/__init__.py
+++ b/stock_owner_restriction/models/__init__.py
@@ -1,6 +1,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import product
 from . import stock_move
+from . import stock_move_line
 from . import stock_quant
 from . import stock_picking
 from . import stock_picking_type

--- a/stock_owner_restriction/models/stock_move.py
+++ b/stock_owner_restriction/models/stock_move.py
@@ -3,11 +3,26 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from collections import defaultdict
 
-from odoo import models
+from odoo import api, fields, models
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
+
+    owner_restriction = fields.Selection(related="picking_type_id.owner_restriction")
+    restricted_owner_id = fields.Many2one(
+        comodel_name="res.partner",
+        compute="_compute_restricted_owner_id",
+    )
+
+    @api.depends(
+        "move_dest_ids.picking_id.owner_id",
+        "picking_id.owner_id",
+        "picking_id.partner_id",
+    )
+    def _compute_restricted_owner_id(self):
+        for move in self:
+            move.restricted_owner_id = move._get_owner_for_assign()[:1]
 
     def _get_moves_to_assign_with_standard_behavior(self):
         """This method is expected to be extended as necessary. e.g. you may not want to
@@ -62,7 +77,7 @@ class StockMove(models.Model):
                 )._action_assign(force_qty=force_qty)
         return res
 
-    def _update_reserved_quantity(
+    def _update_reserved_quantity_vals(
         self,
         need,
         location_id,
@@ -71,10 +86,12 @@ class StockMove(models.Model):
         owner_id=None,
         strict=True,
     ):
+        # Overridden instead of _update_reserved_quantity because the chained
+        # moves path in _action_assign calls this method directly.
         restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)
         if not owner_id and restricted_owner_id is not None:
             owner_id = restricted_owner_id
-        return super()._update_reserved_quantity(
+        return super()._update_reserved_quantity_vals(
             need,
             location_id,
             lot_id=lot_id,

--- a/stock_owner_restriction/models/stock_move_line.py
+++ b/stock_owner_restriction/models/stock_move_line.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Carlos Dauden - Tecnativa
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    owner_restriction = fields.Selection(related="picking_type_id.owner_restriction")
+    restricted_owner_id = fields.Many2one(
+        comodel_name="res.partner",
+        compute="_compute_restricted_owner_id",
+    )
+
+    @api.depends(
+        "move_id.restricted_owner_id",
+        "picking_id.owner_id",
+        "picking_id.partner_id",
+    )
+    def _compute_restricted_owner_id(self):
+        for line in self:
+            line.restricted_owner_id = (
+                line.move_id.restricted_owner_id
+                if line.move_id
+                else line.picking_id.owner_id or line.picking_id.partner_id
+            )

--- a/stock_owner_restriction/models/stock_quant.py
+++ b/stock_owner_restriction/models/stock_quant.py
@@ -55,6 +55,11 @@ class StockQuant(models.Model):
     ):
         restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)
         if restricted_owner_id is not None:
+            # The context value can be a res.partner recordset (set by
+            # stock.move._action_assign) or an id; domains do not accept
+            # recordset values.
+            if isinstance(restricted_owner_id, models.BaseModel):
+                restricted_owner_id = restricted_owner_id.id
             domain = expression.AND([domain, [("owner_id", "=", restricted_owner_id)]])
         return super()._read_group(
             domain,

--- a/stock_owner_restriction/static/src/fields/stock_move_line_x2_many_field.esm.js
+++ b/stock_owner_restriction/static/src/fields/stock_move_line_x2_many_field.esm.js
@@ -1,0 +1,41 @@
+/** @odoo-module **/
+import {Domain} from "@web/core/domain";
+import {SMLX2ManyField} from "@stock/fields/stock_move_line_x2_many_field";
+import {patch} from "@web/core/utils/patch";
+
+patch(SMLX2ManyField.prototype, {
+    setup() {
+        super.setup();
+        const selectCreate = this.selectCreate;
+        this.selectCreate = (params) => {
+            const restrictionDomain = this._getOwnerRestrictionDomain();
+            if (restrictionDomain.length) {
+                params.domain = Domain.and([
+                    params.domain || [],
+                    restrictionDomain,
+                ]).toList();
+            }
+            return selectCreate(params);
+        };
+    },
+    /**
+     * Restrict the quants offered by the "Add line" dialog according to the
+     * picking type owner restriction, mirroring the reservation rules.
+     *
+     * @returns {Array} domain leaves to append, empty when unrestricted
+     */
+    _getOwnerRestrictionDomain() {
+        const data = this.props.record.data;
+        const ownerId = data.restricted_owner_id ? data.restricted_owner_id[0] : false;
+        switch (data.owner_restriction) {
+            case "unassigned_owner":
+                return [["owner_id", "=", false]];
+            case "picking_partner":
+                return [["owner_id", "=", ownerId]];
+            case "partner_or_unassigned":
+                return ["|", ["owner_id", "=", false], ["owner_id", "=", ownerId]];
+            default:
+                return [];
+        }
+    },
+});

--- a/stock_owner_restriction/tests/test_stock_owner_restriction.py
+++ b/stock_owner_restriction/tests/test_stock_owner_restriction.py
@@ -150,6 +150,92 @@ class TestStockOwnerRestriction(TransactionCase):
         self.assertEqual(self.picking_out.move_ids.quantity, 500.00)
         self.assertEqual(len(self.picking_out.move_line_ids), 1)
 
+    def test_move_line_restricted_owner_fields(self):
+        """The manual quant selector domain feeds on these helper fields."""
+        self.picking_type_out.owner_restriction = "picking_partner"
+        self.picking_out.partner_id = self.owner
+        self.move_model.create(
+            {
+                "name": self.product.display_name,
+                "product_id": self.product.id,
+                "picking_id": self.picking_out.id,
+                "product_uom_qty": 100.00,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.picking_type_out.default_location_src_id.id,
+                "location_dest_id": self.customer_location.id,
+            }
+        )
+        self.picking_out.action_confirm()
+        self.picking_out.action_assign()
+        move = self.picking_out.move_ids
+        self.assertEqual(move.owner_restriction, "picking_partner")
+        self.assertEqual(move.restricted_owner_id, self.owner)
+        line = self.picking_out.move_line_ids
+        self.assertEqual(line.owner_restriction, "picking_partner")
+        self.assertEqual(line.restricted_owner_id, self.owner)
+
+    def test_chained_moves_picking_partner(self):
+        """Chained moves reserve under owner restriction without breaking.
+
+        A pick brings owner stock to Output and the chained delivery must
+        reserve it for the same partner. In 18.0 _action_assign prefetches a
+        quants cache through stock.quant._read_group for chained moves, so
+        this flow used to crash when the restriction context held a recordset.
+        """
+        picking_type_internal = self.env.ref("stock.picking_type_internal")
+        output_location = self.env.ref("stock.stock_location_output")
+        picking_type_internal.owner_restriction = "picking_partner"
+        self.picking_type_out.owner_restriction = "picking_partner"
+        pick = self.picking_model.create(
+            {
+                "partner_id": self.owner.id,
+                "picking_type_id": picking_type_internal.id,
+                "location_id": self.picking_type_out.default_location_src_id.id,
+                "location_dest_id": output_location.id,
+            }
+        )
+        pick_move = self.move_model.create(
+            {
+                "name": self.product.display_name,
+                "product_id": self.product.id,
+                "picking_id": pick.id,
+                "product_uom_qty": 100.00,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.picking_type_out.default_location_src_id.id,
+                "location_dest_id": output_location.id,
+            }
+        )
+        ship = self.picking_model.create(
+            {
+                "partner_id": self.owner.id,
+                "picking_type_id": self.picking_type_out.id,
+                "location_id": output_location.id,
+                "location_dest_id": self.customer_location.id,
+            }
+        )
+        ship_move = self.move_model.create(
+            {
+                "name": self.product.display_name,
+                "product_id": self.product.id,
+                "picking_id": ship.id,
+                "product_uom_qty": 100.00,
+                "product_uom": self.product.uom_id.id,
+                "location_id": output_location.id,
+                "location_dest_id": self.customer_location.id,
+                "move_orig_ids": [(4, pick_move.id)],
+                "procure_method": "make_to_order",
+            }
+        )
+        (pick | ship).action_confirm()
+        pick.action_assign()
+        self.assertEqual(pick_move.quantity, 100.00)
+        self.assertEqual(pick.move_line_ids.owner_id, self.owner)
+        pick.move_line_ids.picked = True
+        pick.button_validate()
+        ship.action_assign()
+        self.assertEqual(ship_move.quantity, 100.00)
+        self.assertEqual(ship.move_line_ids.owner_id, self.owner)
+
     def test_search_qty(self):
         products = self.env["product.product"].search(
             [("id", "=", self.product.id), ("qty_available", ">", 500.00)]

--- a/stock_owner_restriction/views/stock_move_line_views.xml
+++ b/stock_owner_restriction/views/stock_move_line_views.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Carlos Dauden - Tecnativa
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_stock_move_line_detailed_operation_tree" model="ir.ui.view">
+        <field name="name">stock.move.line.operations.list - owner restriction</field>
+        <field name="model">stock.move.line</field>
+        <field
+            name="inherit_id"
+            ref="stock.view_stock_move_line_detailed_operation_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="quant_id" position="before">
+                <field name="owner_restriction" column_invisible="True" />
+                <field name="restricted_owner_id" column_invisible="True" />
+            </field>
+            <field name="quant_id" position="attributes">
+                <attribute
+                    name="domain"
+                >[('product_id', '=', product_id), ('location_id', 'child_of', picking_location_id)] + ([('owner_id', '=', False)] if owner_restriction == 'unassigned_owner' else [('owner_id', '=', restricted_owner_id)] if owner_restriction == 'picking_partner' else ['|', ('owner_id', '=', False), ('owner_id', '=', restricted_owner_id)] if owner_restriction == 'partner_or_unassigned' else [])</attribute>
+            </field>
+        </field>
+    </record>
+    <record id="view_stock_move_line_operation_tree" model="ir.ui.view">
+        <field name="name">stock.move.line.operations.list - owner restriction</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
+        <field name="arch" type="xml">
+            <field name="quant_id" position="before">
+                <field name="owner_restriction" column_invisible="True" />
+                <field name="restricted_owner_id" column_invisible="True" />
+            </field>
+            <field name="quant_id" position="attributes">
+                <attribute
+                    name="domain"
+                >[('product_id', '=', product_id), ('location_id', 'child_of', parent.location_id)] + ([('owner_id', '=', False)] if owner_restriction == 'unassigned_owner' else [('owner_id', '=', restricted_owner_id)] if owner_restriction == 'picking_partner' else ['|', ('owner_id', '=', False), ('owner_id', '=', restricted_owner_id)] if owner_restriction == 'partner_or_unassigned' else [])</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/stock_owner_restriction/views/stock_move_views.xml
+++ b/stock_owner_restriction/views/stock_move_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Carlos Dauden - Tecnativa
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_stock_move_operations" model="ir.ui.view">
+        <field name="name">stock.move.operations.form - owner restriction</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_stock_move_operations" />
+        <field name="arch" type="xml">
+            <field name="move_line_ids" position="before">
+                <field name="owner_restriction" invisible="1" />
+                <field name="restricted_owner_id" invisible="1" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Odoo 18.0 _action_assign prefetches a quants cache for chained moves through stock.quant._read_group and reserves them by calling _update_reserved_quantity_vals directly:

- The _read_group override injected the raw context value (a res.partner recordset set by stock.move._action_assign) into the domain, which core now rejects (AssertionError: Invalid value res.partner(...) in domain term), so assigning any chained move under picking_partner or partner_or_unassigned restriction crashed.
- The _update_reserved_quantity override was dead code on the chained moves path; move it to _update_reserved_quantity_vals, which covers both the regular and the chained reservation paths.

[FIX] stock_owner_restriction: restrict manual quant selection

The Pick From selector (quant_id, detailed operations) let the user pick a quant regardless of the picking type owner restriction, and _copy_quant_info then carried that owner to the move line, reserving another partner's stock. Extend the selector domain in both detailed operation views according to the restriction, backed by two helper fields on stock.move.line.

The sml_x2_many widget builds its own quant domain in onAdd (product and location only), so the Add line dialog of the detailed operations offered quants from any owner regardless of the restriction. Patch the widget to append the owner clause, fed by the same helper fields now also exposed on stock.move.

@Tecnativa TT63741

ping @sergio-teruel @carlos-lopez-tecnativa @CarlosRoca13 