### PR TITLE
[18.0] [FIX] product_cost_price_avco_sync: replace deprecated quantity_done

### DIFF
--- a/product_cost_price_avco_sync/models/stock_valuation_layer.py
+++ b/product_cost_price_avco_sync/models/stock_valuation_layer.py
@@ -83,7 +83,7 @@ class StockValuationLayer(models.Model):
         if (
             float_compare(
                 abs(new_svl_qty),
-                move.quantity_done,
+                move.quantity,
                 precision_digits=high_decimal_precision,
             )
             != 0
@@ -95,7 +95,7 @@ class StockValuationLayer(models.Model):
                         "stock valuation layer quantity"
                     )
                 )
-            move.quantity_done = abs(new_svl_qty)
+            move.quantity = abs(new_svl_qty)
         # Reasign qty variables
         qty = new_svl_qty
         svl_dic["quantity"] = new_svl_qty


### PR DESCRIPTION
In Odoo 17, stock.move.quantity_done was removed and replaced by stock.move.quantity.

This module read and wrote the deprecated field in _process_avco_svl_inventory, causing AttributeError on Odoo 17+. The existing tests never exercised this code path because it requires both an inventory move SVL and keep_avco_inventory=True in context.

Reference: OCA OpenUpgrade 17.0 upgrade_analysis.txt for stock module.

@BinhexTeam T23802