### PR TITLE
[18.0][FIX] stock_move_backdating: fix KeyError on lot-valuated products

### DIFF
--- a/stock_move_backdating/models/stock_move.py
+++ b/stock_move_backdating/models/stock_move.py
@@ -37,6 +37,8 @@ class StockMove(models.Model):
                     date_backdating,
                     round=False,
                 )
+            if self.product_id.lot_valuated:
+                return dict.fromkeys(self.lot_ids, converted_price)
             return {self.env["stock.lot"]: converted_price}
         return price_unit
 


### PR DESCRIPTION
## Bug

Validating a backdated stock picking for
a lot-valuated product raised: KeyError: stock.lot()

at `stock_account` in `product_price_update_before_done()`.

## Root cause

`StockMove._get_price_unit()` in this module overrides the price
for moves that have `date_backdating` set and are linked to a
purchase order line. It always returns the price keyed by an empty
`stock.lot` recordset:

    return {self.env["stock.lot"]: converted_price}

Core's `product_price_update_before_done()` builds its per-lot
quantity dict from the actual lot on each move line, then looks up
`move_cost[lot]`. For lot-valuated products, core's own
`_get_price_unit()` keys the dict by `self.lot_ids` (the real
lot(s)) rather than an empty lot. This module's override did not
follow that convention, so for lot-valuated products the lookup
key never matched, causing the KeyError.

## Fix

Key the returned price by `self.lot_ids` when
`product_id.lot_valuated` is set, matching the pattern already used
in `stock_account`.

## Test

Validate a backdated receipt (with `date_backdating` set on the
move line) linked to a purchase order, for a product with
lot/serial tracking and lot-based valuation enabled. Confirm the
picking validates without error and the lot's standard price is
updated correctly.