### PR TITLE
[FIX] stock_move_source_relocate: reserve after the source is relocated

### DIFF
--- a/stock_move_source_relocate/models/stock_move.py
+++ b/stock_move_source_relocate/models/stock_move.py
@@ -37,6 +37,12 @@ class StockMove(models.Model):
                 relocated_moves |= relocated
         if relocated_moves:
             relocated_moves._after_apply_source_relocate_rule()
+            # The source location changed
+            # => Reservation must be tried again on it.
+            relocated_moves.exists().with_context(
+                # Skip the relocation rules to avoid recursing.
+                exclude_apply_source_relocate=True
+            )._action_assign()
 
     def _apply_source_relocate_rule(self, relocation):
         """Perform the source location relocation.

--- a/stock_move_source_relocate/tests/test_source_relocate.py
+++ b/stock_move_source_relocate/tests/test_source_relocate.py
@@ -137,6 +137,30 @@ class TestSourceRelocate(SourceRelocateCommon):
             ],
         )
 
+    def test_relocate_reserve_in_new_location(self):
+        # the rule applies on the parent location, so the relocation location
+        # is not searched by the first reservation attempt made on Shelf 1
+        self._create_relocate_rule(
+            self.loc_shelf, self.loc_replenish, self.wh.pick_type_id
+        )
+        self._update_qty_in_location(self.loc_replenish, self.product, 10)
+        move = self._create_single_move(
+            self.product,
+            self.wh.pick_type_id,
+            custom_vals={"location_id": self.loc_shelf_1.id},
+        )
+        self.assertRecordValues(
+            move,
+            [
+                {
+                    "state": "assigned",
+                    "product_qty": 10.0,
+                    "quantity": 10.0,
+                    "location_id": self.loc_replenish.id,
+                }
+            ],
+        )
+
     def test_relocate_domain(self):
         self._create_relocate_rule(
             self.wh.lot_stock_id,


### PR DESCRIPTION
PR #2291 removed the `_action_confirm` call that used to re-run the reservation on the relocated moves.
=> Relocated moves stay unreserved.

Fix: Re-run _action_assign on the relocated moves instead. Ignore the relocation rules to avoid infinite recursion.

Add test to reproduce the bug and confirm its resolution