### PR TITLE
[16.0][FIX] stock_move_line_change_lot: don't break mrp

### DIFF
--- a/stock_move_line_change_lot/models/stock_move_line.py
+++ b/stock_move_line_change_lot/models/stock_move_line.py
@@ -95,7 +95,9 @@ class StockMoveLine(models.Model):
         already_processed = self.browse()
         to_reassign_moves = self.env["stock.move"]
         moves_by_previous_lot = defaultdict(self.env["stock.move"].browse)
-        lot = self.env["stock.lot"].browse(vals["lot_id"])
+        lot = self.env["stock.lot"].browse(
+            self._fields["lot_id"].convert_to_write(vals["lot_id"], self)
+        )
         for move_line in self:
             if move_line.move_id._should_bypass_reservation(move_line.location_id):
                 continue

--- a/stock_move_line_change_lot/tests/test_change_lot.py
+++ b/stock_move_line_change_lot/tests/test_change_lot.py
@@ -390,3 +390,17 @@ class ChangeLotCase(TransactionCase):
         self.assert_quant_reserved_qty(
             line, lambda: line.reserved_qty, package=new_package
         )
+
+    def test_write_recordset(self):
+        """
+        Test that writing a recordset on stock.move.line#lot_id works
+        """
+        lot = self._create_lot(self.product_a)
+        self._update_qty_in_location(self.shelf1, self.product_a, 10, lot=lot)
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.action_assign()
+        line = picking.move_line_ids
+        line.write({"lot_id": lot})
+        self.assert_quant_reserved_qty(line, lambda: 10, lot=lot)
+        line.write({"lot_id": self.env["stock.lot"]})
+        self.assert_quant_reserved_qty(line, lambda: 0, lot=lot)


### PR DESCRIPTION
when mrp [posts](https://github.com/odoo/odoo/blob/16.0/addons/mrp/models/mrp_production.py#L1587) an inventory, a [recordset](https://github.com/odoo/odoo/blob/16.0/addons/mrp/models/mrp_production.py#L2350) is written on stock.move.line#lot_id, which while uncommon, is [supported](https://github.com/odoo/odoo/blob/16.0/odoo/fields.py#L3046) by the ORM.

browse however doesn't support this, so we need to convert this to a type it understands