### PR TITLE
[FIX] stock_restrict_lot: avoid MissingError in _check_lot_consistent_with_restriction

### DIFF
--- a/stock_restrict_lot/models/stock_move.py
+++ b/stock_restrict_lot/models/stock_move.py
@@ -121,7 +121,11 @@ class StockMove(models.Model):
         Check that the lot set on move lines
         is the same as the restricted lot set on the move
         """
-        for move in self:
+        # ``_action_done`` may unlink some of the moves it processed (e.g. when a
+        # product is converted to a kit, the original move is replaced by its
+        # component moves), so ``self`` can still reference deleted records here.
+        # Iterate only over the ones that still exist to avoid a MissingError.
+        for move in self.exists():
             if not (move.restrict_lot_id and move.move_line_ids):
                 continue
             move_line_lot = move.mapped("move_line_ids.lot_id")


### PR DESCRIPTION
## Problem

When `_action_done` converts a product into a kit, the original move is unlinked and replaced by its component moves. The `self` recordset that flows through `_action_done` still references those deleted moves when `_check_lot_consistent_with_restriction` iterates over it, raising a `MissingError`.

## Reproduction

This is reproduced by the standard MRP test:

```
mrp_account.tests.test_mrp_account.TestMrpAccount.test_delivery_validate_after_product_converted_to_kit
```

The test delivers a product that gets converted to a kit, then validates the delivery. With `stock_restrict_lot` installed, the post-`_action_done` consistency check iterates over already-unlinked moves and fails with `MissingError`.

## Fix

Iterate only over the moves that still exist (`self.exists()`) in `_check_lot_consistent_with_restriction`, skipping the records unlinked during `_action_done`.