### PR TITLE
[19.0][FIX] stock_move_line_expiration_date_required

### DIFF
--- a/stock_move_line_expiration_date_required/models/stock_move.py
+++ b/stock_move_line_expiration_date_required/models/stock_move.py
@@ -3,7 +3,7 @@
 
 import datetime
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockMove(models.Model):
@@ -19,6 +19,34 @@ class StockMove(models.Model):
             record.all_expiry_dates_set = not record.use_expiration_date or all(
                 record.move_line_ids.filtered("quantity").mapped("expiration_date")
             )
+
+    @api.model
+    def action_generate_lot_line_vals(
+        self, context_data, mode, first_lot, count, lot_text
+    ):
+        """Override to not default an `expiration_date` on the generated lines."""
+        vals_list = super().action_generate_lot_line_vals(
+            context_data, mode, first_lot, count, lot_text
+        )
+        product = self.env["product.product"].browse(
+            context_data.get("default_product_id")
+        )
+        if not product.use_expiration_date or product.expiration_time > 0:
+            return vals_list
+        if mode == "generate":
+            # In generate mode all expiration_dates are defaulting, since
+            # no expiration_time, these will be wrongly set dates. Setting
+            # them to False.
+            for vals in vals_list:
+                vals["expiration_date"] = False
+            return vals_list
+        # In import mode, users can import expiration dates.
+        # Lines with no expiration_date get their date defaulted, so we need
+        # to set to False only the lines for which no date was given during import.
+        for vals, lot in zip(vals_list, self.split_lots(lot_text), strict=False):
+            if not lot.get("expiration_date"):
+                vals["expiration_date"] = False
+        return vals_list
 
     def _generate_serial_move_line_commands(
         self, field_data, location_dest_id=False, origin_move_line=None

--- a/stock_move_line_expiration_date_required/models/stock_move.py
+++ b/stock_move_line_expiration_date_required/models/stock_move.py
@@ -20,10 +20,14 @@ class StockMove(models.Model):
                 record.move_line_ids.filtered("quantity").mapped("expiration_date")
             )
 
-    def _generate_serial_move_line_commands(self, lot_names, origin_move_line=None):
+    def _generate_serial_move_line_commands(
+        self, field_data, location_dest_id=False, origin_move_line=None
+    ):
         """Override to add a default `expiration_date` into the move lines values."""
         move_lines_commands = super()._generate_serial_move_line_commands(
-            lot_names, origin_move_line=origin_move_line
+            field_data,
+            location_dest_id=location_dest_id,
+            origin_move_line=origin_move_line,
         )
         if not self.product_id.use_expiration_date:
             return move_lines_commands

--- a/stock_move_line_expiration_date_required/tests/test_expiration_date_required.py
+++ b/stock_move_line_expiration_date_required/tests/test_expiration_date_required.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Moduon Team S.L. <info@moduon.team>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/LGPL).
 
+from datetime import datetime, timedelta
+
 from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests import Form, common
@@ -44,6 +46,28 @@ class TestExpirationDateRequired(common.TransactionCase):
             line_form.product_id = cls.product
             line_form.product_uom_qty = 10
         cls.picking = picking_form.save()
+
+    def _action_generate_lot_line_vals(
+        self, mode, first_lot=None, count=0, lot_text=""
+    ):
+        """Generate the move line values like the Generate/Import dialog does."""
+        move = self.picking.move_ids
+        return self.env["stock.move"].action_generate_lot_line_vals(
+            {
+                "default_company_id": self.env.company.id,
+                "default_picking_id": self.picking.id,
+                "default_picking_type_id": self.picking_type_in.id,
+                "default_location_id": move.location_id.id,
+                "default_location_dest_id": move.location_dest_id.id,
+                "default_product_id": self.product.id,
+                "default_tracking": self.product.tracking,
+                "default_quantity": move.product_uom_qty,
+            },
+            mode,
+            first_lot,
+            count,
+            lot_text,
+        )
 
     def test_expiration_date_required_and_not_auto_calculated(self):
         """Test that the expiration date is required for the stock move line
@@ -234,3 +258,46 @@ class TestExpirationDateRequired(common.TransactionCase):
             self.product.display_name,
         ):
             self.picking.with_context(skip_sanity_check=False)._sanity_check()
+
+    def test_generate_lots_expiration_date_not_auto_calculated(self):
+        """Test that generating lots doesn't auto-calculate the expiration date
+        if the product has no expiration time"""
+        # 10 units in lots of 5 -> 2 lines
+        vals_list = self._action_generate_lot_line_vals(
+            "generate", first_lot="TLE-G1", count=5
+        )
+        self.assertEqual(len(vals_list), 2)
+        for vals in vals_list:
+            self.assertFalse(vals.get("expiration_date"))
+
+    def test_generate_lots_expiration_date_auto_calculated(self):
+        """Test that generating lots keeps the auto-calculated expiration date
+        if the expiration time is set in the product"""
+        self.product.expiration_time = 10
+        expected_dtt = self.picking.scheduled_date + timedelta(days=10)
+        vals_list = self._action_generate_lot_line_vals(
+            "generate", first_lot="TLE-G2", count=5
+        )
+        self.assertEqual(len(vals_list), 2)
+        for vals in vals_list:
+            self.assertEqual(vals.get("expiration_date"), expected_dtt)
+
+    def test_import_lots_keeps_given_expiration_dates(self):
+        """Test that expiration dates imported along with the lot names are
+        kept, and the missing ones are not auto-calculated"""
+        given_dtt = datetime(2030, 12, 31)
+        vals_list = self._action_generate_lot_line_vals(
+            "import", lot_text=f"TLE-I1;6;{given_dtt.date()}\nTLE-I2;4"
+        )
+        self.assertEqual(len(vals_list), 2)
+        self.assertEqual(vals_list[0].get("expiration_date"), given_dtt)
+        self.assertFalse(vals_list[1].get("expiration_date"))
+
+    def test_import_lots_keeps_date_matching_the_default(self):
+        """Test that an imported date is kept even when it's the same date that
+        would have been defaulted"""
+        self.picking.scheduled_date = datetime(2030, 6, 1)
+        vals_list = self._action_generate_lot_line_vals(
+            "import", lot_text="TLE-I3;5;2030-06-01"
+        )
+        self.assertEqual(vals_list[0].get("expiration_date"), datetime(2030, 6, 1))


### PR DESCRIPTION
Two fixes:

- [FIX] stock_move_line_expiration_date_required: adapt _generate_serial_move_line_commands signature

Core takes (field_data, location_dest_id=False, origin_move_line=None) and
callers do pass location_dest_id by keyword. The override still carried the
16.0 signature, so any such call raises a TypeError once this module is installed.

- [FIX]  stock_move_line_expiration_date_required: empty date on generated lots

Since https://github.com/odoo/odoo/commit/4f339301179c product_expiry defaults
on the lines built by the 'Generate/Import Lots or Serials' dialog. For a product
that uses expiration dates with no expiration time configured, that date is
the receipt date itself, which is precisely what this module exists to avoid.