### PR TITLE
[16.0][IMP] stock_picking_group_by_partner_by_carrier: avoid fetching all

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -191,10 +191,16 @@ class StockPicking(models.Model):
         if new_moves.original_group_id - old_moves.original_group_id:
             # A move with a new procurement group has been added. Adapt
             # the procurement group
-            closed_pickings = self.move_ids.group_id.picking_ids.filtered(
-                lambda picking: picking.printed or picking.state == "done"
+            has_closed_picking = self.env["stock.picking"].search_count(
+                [
+                    ("group_id", "in", self.move_ids.group_id.ids),
+                    "|",
+                    ("printed", "=", True),
+                    ("state", "=", "done"),
+                ],
+                limit=1,
             )
-            if closed_pickings:
+            if has_closed_picking:
                 # Do no longer modify a printed or done transfer: they
                 # are started and their group is now fixed. So create a
                 # new procurement group


### PR DESCRIPTION
group pickings to check closed state

_merge_procurement_groups() loaded every picking of the procurement group through the ORM (up to a hundred for the busiest "merged" groups, in a stock_picking table with several million rows) just to filter on printed/state in Python afterwards and detect if one is closed.... Replace this with an indexed search_count limited to 1 result, which only performs an existence check: the cost stays roughly constant regardless of the group size, instead of growing with how long-lived a customer's group is.