### PR TITLE
stock_move_line_lock_qty_done: user rights display

### DIFF
--- a/stock_move_line_lock_qty_done/security/res_groups.xml
+++ b/stock_move_line_lock_qty_done/security/res_groups.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2023 ACSONE SA/NV
+     Copyright 2026 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
-<odoo>
+<odoo noupdate="1">
 
-    <record id="group_stock_move_can_edit_done_qty" model="res.groups">
-        <field name="name">Can edit done quantity for done stock moves</field>
-        <field name="category_id" ref="base.module_category_inventory_inventory" />
+    <record model="res.groups" id="group_stock_move_can_edit_done_qty">
+        <field name="name">Inventory: Edit done quantity of done stock moves</field>
+        <field name="category_id" ref="base.module_category_usability" />
     </record>
+
 </odoo>


### PR DESCRIPTION
Manage as "Extra Right" to not break the Inventory app user rights hierarchy

cc @lmignon @sbejaoui @rousseldenis 

<img width="1719" height="253" alt="image" src="https://github.com/user-attachments/assets/3b6ca30b-8235-4d7c-a035-ada0d1ba5cfd" />
