### PR TITLE
stock_move_manage_priority: user rights display

### DIFF
--- a/stock_move_manage_priority/security/groups.xml
+++ b/stock_move_manage_priority/security/groups.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo noupdate="0">
+<odoo noupdate="1">
     <record id="group_stock_move_priority_manager" model="res.groups">
-        <field name="name">stock move priority manager</field>
-        <field name="category_id" ref="base.module_category_inventory_inventory" />
-        <field
-            name="users"
-            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
-        />
+        <field name="name">Inventory: Change stock move priority</field>
+        <field name="category_id" ref="base.module_category_usability" />
     </record>
     <record id="stock.group_stock_manager" model="res.groups">
         <field


### PR DESCRIPTION
Manage as "Extra Right" to not break the Inventory app user rights hierarchy

cc @lmignon @rousseldenis

Similar to:
* https://github.com/OCA/stock-logistics-workflow/pull/2447
* https://github.com/OCA/stock-logistics-orderpoint/pull/99